### PR TITLE
ovn: Move to port 6443

### DIFF
--- a/microovn/cmd/microovn/cluster_bootstrap.go
+++ b/microovn/cmd/microovn/cluster_bootstrap.go
@@ -44,7 +44,7 @@ func (c *cmdClusterBootstrap) Run(cmd *cobra.Command, args []string) error {
 
 	// Get system address.
 	address := util.NetworkInterfaceAddress()
-	address = util.CanonicalNetworkAddress(address, 7443)
+	address = util.CanonicalNetworkAddress(address, 6443)
 
 	return m.NewCluster(hostname, address, time.Second*30)
 }

--- a/microovn/cmd/microovn/cluster_join.go
+++ b/microovn/cmd/microovn/cluster_join.go
@@ -44,7 +44,7 @@ func (c *cmdClusterJoin) Run(cmd *cobra.Command, args []string) error {
 
 	// Get system address.
 	address := util.NetworkInterfaceAddress()
-	address = util.CanonicalNetworkAddress(address, 7443)
+	address = util.CanonicalNetworkAddress(address, 6443)
 
 	return m.JoinCluster(hostname, address, args[0], time.Second*30)
 }


### PR DESCRIPTION
So we don't conflict with other MicroCloud services as we have:
 - MicroOVN: 6443
 - MicroCeph: 7443
 - LXD: 8443
 - MicroCloud: 9443