### PR TITLE
Use port 6443 for init to bring inline with bootstrap/join

### DIFF
--- a/microovn/cmd/microovn/init.go
+++ b/microovn/cmd/microovn/init.go
@@ -64,7 +64,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		address = util.CanonicalNetworkAddress(address, 7000)
+		address = util.CanonicalNetworkAddress(address, 6443)
 
 		wantsBootstrap, err := cli.AskBool("Would you like to create a new MicroOVN cluster? (yes/no) [default=no]: ", "no")
 		if err != nil {


### PR DESCRIPTION
Both microceph and microovn use port 7000 for the init workflow.