### PR TITLE
switch: Use the hostname as system-id

### DIFF
--- a/snapcraft/commands/switch.start
+++ b/snapcraft/commands/switch.start
@@ -20,5 +20,5 @@ done
 export PATH="${OVS_RUNDIR}/bin/:${PATH}"
 
 # Start vswitchd
-"${SNAP}/share/openvswitch/scripts/ovs-ctl" start --system-id=random
+"${SNAP}/share/openvswitch/scripts/ovs-ctl" start --system-id="$(hostname)"
 sleep infinity


### PR DESCRIPTION
This should align it with the bootstrap behavior.

Closes #10