### PR TITLE
fix ip address format (ipv4/ipv6) in environment

### DIFF
--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -85,8 +85,13 @@ func generateEnvironment(s *state.State) error {
 			return fmt.Errorf("Remote couldn't be found for %q", server.Member)
 		}
 
-		nbInitial = remote.Address.Addr().String()
-		sbInitial = remote.Address.Addr().String()
+		addrString := remote.Address.Addr().String()
+		if remote.Address.Addr().Is6() {
+			addrString = "[" + addrString + "]"
+		}
+
+		nbInitial = addrString
+		sbInitial = addrString
 
 		return nil
 	})


### PR DESCRIPTION
In light of the recent changes wrt to ipv6 - this will add the correct format to the missing entries in the env.