### PR TITLE
Ensure that joining member finishes its  `ovn.Join` execution before rest of the cluster is notified.

### DIFF
--- a/microovn/cmd/microovnd/main.go
+++ b/microovn/cmd/microovnd/main.go
@@ -67,7 +67,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 	h := &config.Hooks{}
 	h.OnBootstrap = ovn.Bootstrap
-	h.OnJoin = ovn.Join
+	h.PreJoin = ovn.Join
 	h.OnNewMember = ovn.Refresh
 	h.PostRemove = ovn.Refresh
 

--- a/microovn/go.mod
+++ b/microovn/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/microovn/microovn
 go 1.18
 
 require (
-	github.com/canonical/microcluster v0.0.0-20230501200316-dd78e864d2f1
+	github.com/canonical/microcluster v0.0.0-20230506033402-0ed3a9e8df4d
 	github.com/lxc/lxd v0.0.0-20230501200206-976cd2bfee6a
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.7.0

--- a/microovn/go.sum
+++ b/microovn/go.sum
@@ -52,8 +52,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/canonical/go-dqlite v1.11.9 h1:aO7GG3QohddXsT+C7yEetdRHhhPUWNBKavz+/JabB90=
 github.com/canonical/go-dqlite v1.11.9/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/microcluster v0.0.0-20230501200316-dd78e864d2f1 h1:EvGu81OjcQ/tdCvhYvNRsklI3d0di1LLt3jzYBV+9pk=
-github.com/canonical/microcluster v0.0.0-20230501200316-dd78e864d2f1/go.mod h1:xeiiMtb4NP1M13coTK7CO7u2yWsjdng0h+1+GdAg3X8=
+github.com/canonical/microcluster v0.0.0-20230506033402-0ed3a9e8df4d h1:8vmDKDLHXqc39yLVMRvJsm1zLpYyg017mfeMAmR3t84=
+github.com/canonical/microcluster v0.0.0-20230506033402-0ed3a9e8df4d/go.mod h1:xeiiMtb4NP1M13coTK7CO7u2yWsjdng0h+1+GdAg3X8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
New feature in `microcluster` splits `OnJoin` hook into `PreJoin` and `PostJoin`. `PreJoin` hook is guaranteed to execute before rest of the cluster members execute their `OnNewMember` hooks.

This fixes a bug in which existing cluster members execute `ovn.Refresh` before the new member registers its services to the dqlite database.