### PR TITLE
snap: Add ``ovn-trace`` command

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -77,6 +77,10 @@ apps:
     command: commands/ovn-sbctl
     plugs:
       - network
+  ovn-trace:
+    command: commands/ovn-trace
+    plugs:
+      - network
 
   ovs-appctl:
     command: commands/ovs-appctl
@@ -159,6 +163,7 @@ parts:
      - bin/ovn-nbctl
      - bin/ovn-northd
      - bin/ovn-sbctl
+     - bin/ovn-trace
      - etc/ovn
      - share/ovn
     override-build: |

--- a/snapcraft/commands/ovn-sb
+++ b/snapcraft/commands/ovn-sb
@@ -1,0 +1,5 @@
+# Load the environment
+. "${SNAP}/ovn.env"
+
+CERT="${OVN_PKI_DIR}/ovnsb-cert.pem"
+KEY="${OVN_PKI_DIR}/ovnsb-privkey.pem"

--- a/snapcraft/commands/ovn-sbctl
+++ b/snapcraft/commands/ovn-sbctl
@@ -1,8 +1,5 @@
 #!/bin/sh
 # Load the environment
-. "${SNAP}/ovn.env"
-
-CERT="${OVN_PKI_DIR}/ovnsb-cert.pem"
-KEY="${OVN_PKI_DIR}/ovnsb-privkey.pem"
+. ${SNAP}/commands/ovn-sb
 
 exec ovn-sbctl -c "$CERT" -p "$KEY" -C "$CA_CERT" "${@}"

--- a/snapcraft/commands/ovn-trace
+++ b/snapcraft/commands/ovn-trace
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Load the environment
+. ${SNAP}/commands/ovn-sb
+
+exec ovn-trace -c "$CERT" -p "$KEY" -C "$CA_CERT" "${@}"


### PR DESCRIPTION
The ``ovn-trace`` command is useful for end users of the snap for debugging configuration issues and/or CMS/OVN bugs.