### PR TITLE
Cluster downscaling

### DIFF
--- a/microovn/cmd/microovnd/main.go
+++ b/microovn/cmd/microovnd/main.go
@@ -69,6 +69,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	h.OnBootstrap = ovn.Bootstrap
 	h.PreJoin = ovn.Join
 	h.OnNewMember = ovn.Refresh
+	h.PreRemove = ovn.Leave
 	h.PostRemove = ovn.Refresh
 	h.OnStart = ovn.Start
 

--- a/microovn/ovn/certificates.go
+++ b/microovn/ovn/certificates.go
@@ -180,10 +180,13 @@ func DumpCA(s *state.State) error {
 	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		CACertRecord, err = database.GetConfigItem(ctx, tx, CACertRecordName)
 		if err != nil {
-			return fmt.Errorf("failed to store CA certificate in the database: %s", err)
+			return fmt.Errorf("failed to get CA certificate from the database: %s", err)
 		}
 		return err
 	})
+	if err != nil {
+		return err
+	}
 
 	certPath := paths.PkiCaCertFile()
 	certFile, err := os.Create(certPath)

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -1,0 +1,86 @@
+package ovn
+
+import (
+	"github.com/canonical/microcluster/state"
+	"github.com/lxc/lxd/shared/logger"
+
+	"github.com/canonical/microovn/microovn/ovn/paths"
+)
+
+// Leave function gracefully departs from the OVN cluster before the member is removed from MicroOVN
+// cluster. It ensures that:
+//   - OVN chassis is stopped and removed from SB database
+//   - OVN NB cluster is cleanly departed
+//   - OVN SB cluster is cleanly departed
+//
+// Note (mkalcok): At this point, database table `services` no longer contains entries
+// for departing cluster member, so we'll try to exit/leave/stop all possible services
+// ignoring any errors from services that are not actually running.
+func Leave(s *state.State) error {
+	var err error
+	chassisName := s.Name()
+
+	// Gracefully exit OVN controller causing chassis to be automatically removed.
+	logger.Infof("Stopping OVN Controller and removing Chassis '%s' from OVN SB database.", chassisName)
+	_, err = ControllerCtl(s, "exit")
+	if err != nil {
+		logger.Warnf("Failed to gracefully stop OVN Controller: %s", err)
+	}
+
+	err = snapStop("chassis", true)
+	if err != nil {
+		logger.Warnf("Failed to stop Chassis service: %s", err)
+	}
+
+	err = snapStop("switch", true)
+	if err != nil {
+		logger.Warnf("Failed to stop Switch service: %s", err)
+	}
+
+	// Leave SB and NB clusters
+	logger.Info("Leaving OVN Northbound cluster")
+	_, err = AppCtl(s, paths.OvnNBControlSock(), "cluster/leave", "OVN_Northbound")
+	if err != nil {
+		logger.Warnf("Failed to leave OVN Northbound cluster: %s", err)
+	}
+
+	logger.Info("Leaving OVN Southbound cluster")
+	_, err = AppCtl(s, paths.OvnSBControlSock(), "cluster/leave", "OVN_Southbound")
+	if err != nil {
+		logger.Warnf("Failed to leave OVN Southbound cluster: %s", err)
+	}
+
+	// Wait for NB and SB cluster members to complete departure process
+	nbDatabase, err := newOvsdbSpec(OvsdbTypeNBLocal)
+	if err == nil {
+		err = waitForDBState(s, nbDatabase, OvsdbRemoved, defaultDBConnectWait)
+		if err != nil {
+			logger.Warnf("Failed to wait for NB cluster departure: %s", err)
+		}
+	} else {
+		logger.Warnf("Failed to get NB database specification: %s", err)
+	}
+
+	sbDatabase, err := newOvsdbSpec(OvsdbTypeSBLocal)
+	if err == nil {
+		err = waitForDBState(s, sbDatabase, OvsdbRemoved, defaultDBConnectWait)
+		if err != nil {
+			logger.Warnf("Failed to wait for SB cluster departure: %s", err)
+		}
+	} else {
+		logger.Warnf("Failed to get SB database specification: %s", err)
+	}
+
+	err = snapStop("central", true)
+	if err != nil {
+		logger.Warnf("Failed to stop Central service: %s", err)
+	}
+
+	logger.Info("Cleaning up runtime and data directories.")
+	err = cleanupPaths()
+	if err != nil {
+		logger.Warn(err.Error())
+	}
+
+	return nil
+}

--- a/microovn/ovn/paths/paths.go
+++ b/microovn/ovn/paths/paths.go
@@ -10,6 +10,11 @@ var pathRoot = os.Getenv("SNAP_COMMON")
 var runtimeDir = filepath.Join(pathRoot, "run")
 var dataDir = filepath.Join(pathRoot, "data")
 
+// Root returns $SNAP_COMMON root of MicroOVN
+func Root() string {
+	return pathRoot
+}
+
 // LogsDir returns path to the directory where OVN stores log files
 func LogsDir() string {
 	return filepath.Join(pathRoot, "logs")
@@ -58,6 +63,16 @@ func OvnNBDatabaseSock() string {
 // OvnSBDatabaseSock returns path to the local unix socket used by Southbound OVN database
 func OvnSBDatabaseSock() string {
 	return filepath.Join(CentralRuntimeDir(), "ovnsb_db.sock")
+}
+
+// OvnNBControlSock returns path to the local control socket for Northbound OVN service
+func OvnNBControlSock() string {
+	return filepath.Join(CentralRuntimeDir(), "ovnnb_db.ctl")
+}
+
+// OvnSBControlSock returns path to the local control socket for Southbound OVN service
+func OvnSBControlSock() string {
+	return filepath.Join(CentralRuntimeDir(), "ovnsb_db.ctl")
 }
 
 // OvsDatabaseSock returns path to the local unix socket used by OpenvSwitch database
@@ -120,5 +135,14 @@ func RequiredDirs() []string {
 		SwitchDataDir(),
 		LogsDir(),
 		PkiDir(),
+	}
+}
+
+// BackupDirs returns list of locations that should be backed up before MicroOVN
+// data removal.
+func BackupDirs() []string {
+	return []string{
+		dataDir,
+		LogsDir(),
 	}
 }

--- a/microovn/ovn/snap.go
+++ b/microovn/ovn/snap.go
@@ -24,6 +24,26 @@ func snapStart(service string, enable bool) error {
 	return nil
 }
 
+// snapStop stops specified snap service. Service can be optionally also disabled, ensuring
+// that it won't be automatically started on system reboot.
+func snapStop(service string, disable bool) error {
+	args := []string{
+		"stop",
+		fmt.Sprintf("microovn.%s", service),
+	}
+
+	if disable {
+		args = append(args, "--disable")
+	}
+
+	_, err := shared.RunCommand("snapctl", args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func snapRestart(service string) error {
 	args := []string{
 		"restart",


### PR DESCRIPTION
This change implements downscaling of a MicroOVN cluster and consists of two main parts.

Fix for a database schema. Currently `services` table contains foreign key referencing `internal_cluster_members`. However there's no `ON DELETE CASCADE` so attempts to remove microOVN cluster member fails with `Error: Delete "internal_cluster_members": FOREIGN KEY constraint failed`. This  change adds a database migration that fixes this issue.


Implementation for OVN cluster departure. `PreRemove` hook is added that attempts to
- Gracefully stop the OVN Controller, therefore removing related Chassis from OVN SB database
- Gracefully leave OVN NB cluster
- Gracefully leave OVN SB cluster

