### PR TITLE
microovn/ovn/environment: Use dqlite cluster record to find peers

### DIFF
--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -111,7 +111,7 @@ func Bootstrap(s *state.State) error {
 	}
 
 	// Configure OVS to use OVN.
-	sbConnect, err := connectString(s, 6642)
+	sbConnect, _, err := environmentString(s, 6642)
 	if err != nil {
 		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
 	}

--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -97,8 +97,8 @@ func connectString(s *state.State, port int) (string, error) {
 	addresses := make([]string, 0, len(servers))
 	protocol := networkProtocol(s)
 	for _, server := range servers {
-		peer := clusterMap[server.Member]
-		addr, _, err := net.SplitHostPort(peer.Address)
+		member := clusterMap[server.Member]
+		memberAddr, err := netip.ParseAddrPort(member.Address)
 		if err != nil {
 			return "", err
 		}
@@ -107,7 +107,7 @@ func connectString(s *state.State, port int) (string, error) {
 			addresses,
 			fmt.Sprintf("%s:%s",
 				protocol,
-				net.JoinHostPort(addr, strconv.Itoa(port)),
+				net.JoinHostPort(memberAddr.Addr().String(), strconv.Itoa(port)),
 			),
 		)
 	}

--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -67,7 +67,8 @@ func localServiceActive(s *state.State, serviceName string) (bool, error) {
 	return serviceActive, err
 }
 
-func connectString(s *state.State, port int) (string, error) {
+// Builds environment variable strings for OVN.
+func environmentString(s *state.State, port int) (string, string, error) {
 	var err error
 	var servers []database.Service
 	var clusterMap map[string]cluster.InternalClusterMember
@@ -101,7 +102,7 @@ func connectString(s *state.State, port int) (string, error) {
 		member := clusterMap[server.Member]
 		memberAddr, err := netip.ParseAddrPort(member.Address)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 
 		if i == 0 {
@@ -120,17 +121,17 @@ func connectString(s *state.State, port int) (string, error) {
 		)
 	}
 
-	return strings.Join(addresses, ","), nil
+	return strings.Join(addresses, ","), initialString, nil
 }
 
 func generateEnvironment(s *state.State) error {
 	// Get the servers.
-	nbConnect, nbInitial, err := connectString(s, 6641)
+	nbConnect, nbInitial, err := environmentString(s, 6641)
 	if err != nil {
 		return err
 	}
 
-	sbConnect, sbInitial, err := connectString(s, 6642)
+	sbConnect, sbInitial, err := environmentString(s, 6642)
 	if err != nil {
 		return err
 	}

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -125,7 +125,7 @@ func Join(s *state.State) error {
 	}
 
 	// Enable OVN chassis.
-	sbConnect, err := connectString(s, 6642)
+	sbConnect, _, err := environmentString(s, 6642)
 	if err != nil {
 		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
 	}

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -66,7 +66,7 @@ func refresh(s *state.State) error {
 		}
 
 		// Reconfigure OVS to use OVN.
-		sbConnect, err := connectString(s, 6642)
+		sbConnect, _, err := environmentString(s, 6642)
 		if err != nil {
 			return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
 		}

--- a/microovn/ovn/start.go
+++ b/microovn/ovn/start.go
@@ -39,7 +39,7 @@ func Start(s *state.State) error {
 		}
 	}
 	// Reconfigure OVS to use OVN.
-	sbConnect, err := connectString(s, 6642)
+	sbConnect, _, err := environmentString(s, 6642)
 	if err != nil {
 		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
 	}


### PR DESCRIPTION
Rather than using `state.Remotes` which is the local record of nodes and is updated on each heartbeat, use `cluster.InternalClusterMember` to get the most up-to-date record of peers.

The `services` table is already related to the `internal_cluster_members` table so this will ensure every peer is picked up for every service. 