### PR TITLE
Fix doc build

### DIFF
--- a/docs/doc-cheat-sheet.rst
+++ b/docs/doc-cheat-sheet.rst
@@ -183,13 +183,15 @@ Images
 Reuse
 -----
 
-.. |reuse_key| replace:: This is **included** text.
+.. code-block:: none
 
-|reuse_key|
+   .. |reuse_key| replace:: This is **included** text.
 
-.. include:: index.rst
-   :start-after: include_start
-   :end-before: include_end
+   |reuse_key|
+
+   .. include:: index.rst
+      :start-after: include_start
+      :end-before: include_end
 
 Tabs
 ----

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Documentation starter pack
 ==========================
 


### PR DESCRIPTION
The doc build was failing due to a documentation resource file (`doc-cheat-sheet`) that was actively referring to the doc `readme.rst` file. The latter was hollowed out in a previous PR, causing the cheat sheet to complain. The latter will be redone (in its own repository) to make it passive.

The `readme.rst` file was also orphaned in order to remove a doc build warning. 