### PR TITLE
snap/hooks: Prevent snap install when OVS detected

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# The ovs-dpctl tool calls directly into OVS dpif library functions, which for
+# the system datapath means making calls to the kernel over a netlink socket.
+#
+# If there is an already running ovs-vswitchd process that has initialized this
+# data path, it will be listed.
+ovs-dpctl dump-dps 2>&1 | grep ovs-system > /dev/null
+rc=$?
+if [ $rc -eq 0 ]; then
+        cat << EOF >&2
+An already running copy of Open vSwitch detected in current namespace.
+
+The microovn snap provides Open vSwitch.
+
+Running multiple instances of Open vSwitch in the same namespace is not
+supported.
+EOF
+	exit 1
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,12 @@ description: |-
 
 confinement: strict
 
+hooks:
+  install:
+    plugs:
+      - network
+      - network-control
+
 apps:
   # Service
   daemon:
@@ -90,6 +96,7 @@ apps:
     command: commands/ovs-dpctl
     plugs:
       - network
+      - network-control
   ovs-ofctl:
     command: commands/ovs-ofctl
     plugs:


### PR DESCRIPTION
Running multiple instances of Open vSwitch in the same namespace is not supported.  Abort snap install if Open vSwitch detected to be already running on the system to avoid data plane outage.