### PR TITLE
Review readme for TLS and Downscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ To remove a cluster member:
 
     microovn cluster remove <member_name>
 
-The value of <member_name> is taken from the **Name** column in the output
+The value of `<member_name>` is taken from the **Name** column in the output
 of the `microovn cluster list` command.
 
 Any chassis components (`ovn-controller` and `ovs-vswitchd`) running on the
 member will first be stopped and disabled (prevented from starting). For a
-member with central components present (`ovn-southd` and `ovn-northd`), the
-Northbound and Southbound databases will be gracefully removed.
+member with central components present (`microovn.central`), the Northbound and
+Southbound databases will be gracefully removed.
 
 ### Verification
 

--- a/README.md
+++ b/README.md
@@ -83,32 +83,32 @@ microovn.ovn-appctl -t /var/snap/microovn/common/run/central/ovnnb_db.ctl cluste
 
 ## Downscaling
 
-> **Warning**
->
-> Be aware of effect of downscaling on availability and resiliency of your
-> cluster, especially when you are removing members that run OVN central
-> service (OVN SB, OVN NB, OVN Northd). OVN uses
-> [Raft consensus algorithm](https://raft.github.io) for cluster management,
-> which has fault tolerance of up to `(N-1)/2` members. It means that if you
-> scale back 3 node cluster to just 2 nodes, you lose any fault resiliency.
+### Impact
 
-Removing MicroOVN cluster member is as easy as running
+Downscaling can have a serious negative impact on the availability and
+resiliency of the cluster, especially when a member is being removed that runs
+an OVN central service (OVN SB, OVN NB, OVN Northd).
 
-```shell
-microovn cluster remove <member_name>
-```
+OVN uses the [Raft consensus algorithm](https://raft.github.io) for cluster
+management, which has a fault tolerance of up to `(N-1)/2` members. This means
+that fault resiliency will be lost if a three-node cluster is reduced to two
+nodes.
+
+### Remove a cluster member
+
+To remove a cluster member:
+
+    microovn cluster remove <member_name>
 
 MicroOVN will stop and disable any chassis components running on the member
 (`ovn-controller` and `ovs-vswitchd`), before attempting to gracefully leave
 any OVN database clusters for members with central components present. You can
-watch logs on departing member for any indications of removal failures with:
+watch logs on the departing member for indications of removal failures with:
 
-```shell
-snap logs -f microovn.daemon
-```
+    snap logs -f microovn.daemon
 
-If there are any issues during the removal process, you will have to take
-manual steps to fix the OVN cluster.
+Any issues that arise during the removal process will need to be resolved
+manually.
 
 After the removal, you can also check the state of OVN services, to make sure
 that the member was properly removed.
@@ -134,40 +134,37 @@ MicroOVN will back up selected data directories into the timestamped location
 * OVS database file
 * Issued certificates and keys
 
-## TLS encryption
+## TLS
 
-MicroOVN enables SSL/TLS in OVN by default. It uses self-signed CA certificate
-generated during bootstrap process to issue certificates for all the OVN
-services that require it.
+Starting with snap revision `111`, new deployments of MicroOVN use TLS
+encryption by default. A self-signed CA certificate is used to issue
+certificates to all OVN services that require it. They provide authentication
+and encryption for OVSDB communication. The CA certificate is generated during
+cluster initialisation (`cluster bootstrap` command).
+
+In the current implementation, self-provisioned certificates are the only mode
+available. Future releases may include support for externally provided
+certificates.
 
 > **Warning**
 >
-> Certificate and private key generated for the self-provisioned CA by MicroOVN
-> are, in the current implementation, stored unencrypted in database on every
-> cluster member. This means that if attackers gain access to even one cluster
-> member, they can use the CA to issue valid certificates accepted by other
-> cluster members.
-
-In the current implementation, self-provisioned certificates are the only mode
-available, and they provide authentication and encryption for the OVSDB
-communication. For the future, we are considering support for externally
-provided certificates.
-
+> The certificate and private key generated for the self-provisioned CA are
+> currently stored unencrypted in the database on every cluster member. If an
+> attacker gains access to any cluster member, they can use the CA to issue
+> valid certificates that will be accepted by other cluster members.
 
 ### Certificates CLI
 
-MicroOVN exposes few commands for basic interaction with self-provisioned
-certificates
+MicroOVN exposes a few commands for basic interaction with TLS certificates.
 
 #### List certificates
 
-To show list of currently used certificates, run:
+To list currently used certificates:
 
-```shell
-microovn certificates list
-```
+    microovn certificates list
 
 Example output:
+
 ```
 [OVN CA]
 /var/snap/microovn/common/data/pki/cacert.pem (OK: Present)
@@ -190,77 +187,72 @@ Example output:
 ```
 
 This command does not perform any certificate validation, it only ensures that
-if a service is available on the node, the file that should contain certificate
-is in place.
+if a service is available on the node, the file that should contain a
+certificate is in place.
 
 #### Re-issue certificates
 
-To manually issue new certificate for a specific OVN service, run:
+To re-issue a certificate for an OVN service:
 
-```shell
-microovn certificates reissue <ovn_service_name>
-```
+    microovn certificates reissue <ovn_service_name>
 
-For list of all valid service names, see output of
+Valid service names can be discovered with the `--help` option:
 
-```shell
-microovn certificates reissue --help
-```
+    microovn certificates reissue --help
 
-This command has only local scope and will issue new certificate only for an
-OVN service running on the local host. Other members of the MicroOVN cluster
-are not affected by this command. Additionally, the certificate will be issued
-only if the service is enabled on the host.
+The `certificates reissue` command applies only to an OVN service running on
+the local host; this command does not affect peer cluster members.
+Additionally, the certificate will be issued only if the service is enabled on
+the host.
 
-Aside from specific OVN service name, this command also accepts argument `all`,
-which results in issuing new certificate for every OVN service that's enabled
-on the host.
+To re-issue certificates for all enabled local services, the `all`
+argument is supported:
 
-#### Regenerate PKI completely
+    microovn certificates reissue all
 
-To issue new CA certificate and new certificate for every OVN service
-in the cluster, run:
+#### Regenerate PKI for the cluster
 
-```shell
-microovn certificates regenerate-ca
-```
+To issue a new CA certificate and new certificates for every OVN service
+in the cluster:
 
-This command replaces current, shared, CA certificate and notifies all MicroOVN
-cluster members to issue new certificates for all their OVN services. Output of
-this command will contain report of successfully issued certificates on each
-cluster member. Make sure that all services successfully received new
-certificates, as the old certificates will no longer be accepted and services
-that will keep using them won't be able to communicate with the rest of the
-cluster.
+    microovn certificates regenerate-ca
 
-### Certificates' lifecycle
+The `certificates regenerate-ca` command replaces the current CA certificate
+and notifies all cluster members to re-issue certificates for all their
+services. The command's output will include evidence of successfully issued
+certificates for each cluster member.
 
-Certificates that are automatically provisioned by MicroOVN have following
+> **Warning**
+>
+> A new certificate must be issued successfully for every service on every
+> member. Any failure will result in subsequent communication errors for that
+> service within the cluster.
+
+### Certificate lifecycle
+
+Certificates that are automatically provisioned by MicroOVN have the following
 lifespans:
 
 * CA certificate: 10 years
 * OVN service certificate: 2 years
 
-MicroOVN will run daily check on the remaining validity of all certificates.
-When some of the certificates approach within 10 days of not being valid, they
-will be automatically renewed
+MicroOVN runs daily checks for certificate lifespan validity. When a
+certificate is within 10 days of expiration, it will be automatically renewed.
 
 ### Upgrade from plaintext to TLS
 
-All new MicroOVN deployments have TLS enabled by default and there's no
-supported way to revert back to the plaintext communication. However,
-MicroOVN is not capable of transitioning existing deployments, that already use
-plain text, to TLS automatically. Any deployments of a snap revision below `111`
-will keep using plaintext even after the upgrade until following manual upgrade
-steps are taken:
+Plaintext communication is used when MicroOVN is initially deployed with a snap
+revision of less than `111`, and there's no way to automatically convert to
+encrypted communication. The following manual steps are needed to upgrade old
+installations from plaintext to TLS:
 
-* Make sure that all MicroOVN snaps in your cluster are upgraded to, at least,
+* Ensure that all MicroOVN snaps in the cluster are upgraded to, at least,
 revision `111`
 * Run `microovn certificates regenerate-ca` on one of the cluster members
-* Run `snap restart microovn.daemon` on **all** cluster members
+* Run `sudo snap restart microovn.daemon` on **all** cluster members
 
-After these steps, OVN services in your cluster should start listening on ports,
-using TLS certificates.
+Once this is done, OVN services throughout the cluster will start listening on
+TLS-secured ports.
 
 ## Common issues
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,13 @@ To remove a cluster member:
 
     microovn cluster remove <member_name>
 
-MicroOVN will stop and disable any chassis components running on the member
-(`ovn-controller` and `ovs-vswitchd`), before attempting to gracefully leave
-any OVN database clusters for members with central components present.
+The value of <member_name> is taken from the **Name** column in the output
+of the `microovn cluster list` command.
+
+Any chassis components (`ovn-controller` and `ovs-vswitchd`) running on the
+member will first be stopped and disabled (prevented from starting). For a
+member with central components present (`ovn-southd` and `ovn-northd`), the
+Northbound and Southbound databases will be gracefully removed.
 
 ### Verification
 


### PR DESCRIPTION
This is a review of the TLS and Downscaling sections in the README.

In a future PR, parts of the README will be migrated to the actual documentation (`docs` directory and RST format).