### PR TITLE
[WIP] test: Add autotest framework for functional tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,21 @@
+AUTOM4TE = autom4te
+AUTOTEST = $(AUTOM4TE) --language=autotest
+BACKEND = lxd
+SHELL = bash
+
+COMMON_MACROS_AT = common-macros.at \
+		   system-backend-$(BACKEND)-macros.at \
+		   system-common-macros.at
+SYSTEM_TESTSUITE_AT = system-testsuite.at
+SYSTEM_TESTSUITE = system-testsuite
+
+$(SYSTEM_TESTSUITE): package.m4 $(SYSTEM_TESTSUITE_AT) $(COMMON_MACROS_AT)
+	$(AUTOTEST) -o $@.tmp $@.at
+	mv $@.tmp $@
+
+check-system: $(SYSTEM_TESTSUITE)
+	set $(SHELL) '$(SYSTEM_TESTSUITE)';						\
+	"$$@" $(TESTSUITEFLAGS) || (test X'$(RECHECK)' = Xyes && "$$@" --recheck)
+
+clean:
+	rm -rf $(SYSTEM_TESTSUITE) $(SYSTEM_TESTSUITE).log $(SYSTEM_TESTSUITE).dir

--- a/tests/atlocal
+++ b/tests/atlocal
@@ -1,0 +1,1 @@
+INSTANCE_PREFIX=microovn

--- a/tests/common-macros.at
+++ b/tests/common-macros.at
@@ -1,0 +1,26 @@
+dnl Make AT_SETUP automatically run the microovn_init() shell function
+dnl as the first step in every test.
+m4_rename([AT_SETUP], [MICROOVN_AT_SETUP])
+m4_define([AT_SETUP], [MICROOVN_AT_SETUP($@)
+microovn_init
+])
+
+m4_divert_push([PREPARE_TESTS])
+[
+# Set test_base to the base directory in which the test is running.
+microovn_init() {
+    test_base=`pwd`
+    trap microovn_on_exit 0
+    : > cleanup
+}
+
+microovn_on_exit () {
+    . "$test_base/cleanup"
+}
+
+on_exit () {
+    (echo "$1"; cat cleanup) > cleanup.tmp
+    mv cleanup.tmp cleanup
+}
+]
+m4_divert_pop([PREPARE_TESTS])

--- a/tests/package.m4
+++ b/tests/package.m4
@@ -1,0 +1,2 @@
+m4_define([AT_PACKAGE_STRING],    [microovn a])
+m4_define([AT_PACKAGE_BUGREPORT], [https://bugs.launchpad.net/microovn/+filebug])

--- a/tests/system-backend-lxd-macros.at
+++ b/tests/system-backend-lxd-macros.at
@@ -1,0 +1,41 @@
+# BACKEND_DEL(i1, [, i2 ... ])
+#
+# Delete LXD container(s)
+m4_define([BACKEND_DESTROY],
+    [m4_foreach([instance], [$@],
+                [lxc stop instance && lxc delete instance
+])
+    ]
+)
+
+# BACKEND_LAUNCH(i1 [, i2 ... ])
+#
+# Add new LXD container(s), if LXD container(s) exists, the old one
+# will be removed before new ones are created.
+#
+# Container name will be prefixed with test group number so that multiple tests
+# can use the same container number simultaneously without stepping on each other.
+m4_define([BACKEND_LAUNCH],
+    [m4_foreach([instance], [$@],
+                [instname=${INSTANCE_PREFIX}-${at_group}-instance
+                 BACKEND_DESTROY($instname)
+                 AT_CHECK([lxc launch -q ubuntu: $instname])
+                 on_exit "BACKEND_DESTROY($instname)"
+                ])
+    ]
+)
+
+# BACKEND_EXEC([instance], [command])
+#
+# Execute 'command' in 'instance'
+m4_define([BACKEND_EXEC],
+    [lxc exec ${INSTANCE_PREFIX}-${at_group}-$1 sh << BACKEND_EXEC_HEREDOC
+$2
+BACKEND_EXEC_HEREDOC])
+
+# BACKEND_CHECK_EXEC([instance], [command])
+#
+# Execute 'command' in 'instance'
+m4_define([BACKEND_CHECK_EXEC],
+    [ AT_CHECK([BACKEND_EXEC([$1], [$2])], m4_shift(m4_shift($@))) ]
+)

--- a/tests/system-clustering.at
+++ b/tests/system-clustering.at
@@ -1,0 +1,26 @@
+AT_BANNER([clustering])
+
+AT_SETUP([fake bootstrap single node])
+AT_KEYWORDS([clustering single])
+BACKEND_LAUNCH([m1])
+BACKEND_CHECK_EXEC([m1], [true])
+cat cleanup
+AT_CLEANUP
+
+AT_SETUP([fake bootstrap multi-node 3])
+AT_KEYWORDS([clustering multi])
+BACKEND_LAUNCH([m1], [m2], [m3])
+BACKEND_CHECK_EXEC([m1], [true])
+BACKEND_CHECK_EXEC([m2], [true])
+BACKEND_CHECK_EXEC([m3], [true])
+cat cleanup
+AT_CLEANUP
+
+AT_SETUP([fake bootstrap multi-node 4])
+AT_KEYWORDS([clustering multi])
+BACKEND_LAUNCH([m1], [m2], [m3], [m4])
+BACKEND_CHECK_EXEC([m1], [true])
+BACKEND_CHECK_EXEC([m2], [true])
+BACKEND_CHECK_EXEC([m3], [true])
+BACKEND_CHECK_EXEC([m4], [true])
+AT_CLEANUP

--- a/tests/system-common-macros.at
+++ b/tests/system-common-macros.at
@@ -1,0 +1,1 @@
+m4_include([system-backend-lxd-macros.at])

--- a/tests/system-testsuite.at
+++ b/tests/system-testsuite.at
@@ -1,0 +1,7 @@
+AT_INIT
+
+m4_ifdef([AT_COLOR_TESTS], [AT_COLOR_TESTS])
+
+m4_include([common-macros.at])
+m4_include([system-common-macros.at])
+m4_include([system-clustering.at])


### PR DESCRIPTION
One of the possible frameworks we may use for our testing is the autotest framework.

This patch put together a minimal set of macros and tests to demonstrate how it could be used with LXD as a backend for running the contained code.

While it is a bit archaic, it is very simple and self contained, it is also well understood by the pool of people interested in working on OVS and OVN.