### PR TITLE
tests/basic_cluster: Fix sharing of TEST_CONTAINERS

### DIFF
--- a/tests/basic_cluster.bats
+++ b/tests/basic_cluster.bats
@@ -1,4 +1,4 @@
-TEST_CONTAINERS=""
+# This is a bash shell fragment -*- bash -*-
 
 setup_file() {
     load test_helper/common.bash
@@ -7,6 +7,7 @@ setup_file() {
 
 
     TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
+    export TEST_CONTAINERS
     launch_containers jammy jq "${TEST_CONTAINERS[@]}"
     install_microovn "$MICROOVN_SNAP_PATH" "${TEST_CONTAINERS[@]}"
     bootstrap_cluster "${TEST_CONTAINERS[@]}"
@@ -21,6 +22,10 @@ setup() {
     load test_helper/lxd.bash
     load ../.bats/bats-support/load.bash
     load ../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
 }
 
 @test "Expected MicroOVN cluster count" {


### PR DESCRIPTION
The committed solution for sharing TEST_CONTAINERS between file level setup and teardown functions and the individual tests does not actually work.

This was not caught because the individual tests do their assertions within loops, they provided false positive results when the loop variable was empty.

Add assertion on contents of TEST_CONTAINERS in per-test setup function to avoid false positive results.

Export the TEST_CONTAINERS variable from the file-level setup function.  This is in line with the bats documentation and have confirmed it works fine even when running multiple test files in parallel.

Add a shell fragment comment at the top so that editors/IDEs enable bash syntax highlighting when editing the file.