### PR TITLE
tests/test_helper/lxd: Load openvswitch kernel module through LXD config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,6 @@ jobs:
           snap list
           sudo apt update
           sudo apt -y install bats
-          sudo modprobe openvswitch
 
       - name: Build snaps
         run: make microovn.snap

--- a/tests/lxd-instance-config.yaml
+++ b/tests/lxd-instance-config.yaml
@@ -1,5 +1,6 @@
 ---
 config:
+  linux.kernel_modules: openvswitch
   cloud-init.user-data: |
     #cloud-config
     package_upgrade: true

--- a/tests/test_helper/lxd.bash
+++ b/tests/test_helper/lxd.bash
@@ -5,7 +5,7 @@ function launch_containers() {
     for container in $containers; do
         echo "# Launching $container" >&3
         lxc launch -q "ubuntu:$image_name" "$container" < \
-            "$BATS_TEST_DIRNAME/cloud-init.yaml"
+            "$BATS_TEST_DIRNAME/lxd-instance-config.yaml"
     done
 }
 


### PR DESCRIPTION
To improve developer ergonomics, we ensure the `openvswitch` kernel module is loaded by making use of the
`linux.kernel_modules` LXD instance configuration option.

Doing it this way gives one less step for anyone wanting to run the test suite on their own system.

This makes it obvious that the `tests/cloud-init.yaml` file is badly named, so rename it.