### PR TITLE
Expose `ovsdb-tool` and `ovsdb-client`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,6 +105,12 @@ apps:
     command: commands/ovs-vsctl
     plugs:
       - network
+  ovsdb-tool:
+    command: bin/ovsdb-tool
+  ovsdb-client:
+    command: bin/ovsdb-client
+    plugs:
+      - network
 
   refresh-expiring-certs:
     command: commands/refresh-expiring-certs


### PR DESCRIPTION
Make these two low level commands available to MicroOVN snap users.

I opted to expose these commands directly rather than through wrapper as they don't utilize any env variables that could be exposed.