### PR TITLE
docs: Split doc instructions

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -36,3 +36,4 @@ github
 io
 OpenStack
 failover
+README

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -4,9 +4,9 @@
 Working with the documentation
 ==============================
 
-**Important:** This page is for documentation contributors. It assumes that an
-admin has set up this repository to work with Read the Docs as described in
-file ``setup.rst``.
+**Note:** This page is for documentation contributors. It assumes that an admin
+has enabled this repository to work with Read the Docs as described in file
+``setup.rst``.
 
 There are make targets defined in the ``Makefile`` that set up your local
 environment and allow you to view the documentation. You may also need to

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -7,9 +7,9 @@ Working with the documentation
 **Note:** This page is for documentation contributors. It assumes that this
 repository has been enabled for doc builds as described in file ``setup.rst``.
 
-There are make targets defined in the ``Makefile`` file that set up your local
-environment and allow you to view the documentation. You may also need to
-occasionally change the build configuration as new content is added.
+There are make targets defined in the documentation ``Makefile`` file that set
+up your local environment and allow you to view the documentation. You may also
+need to occasionally change the build configuration as new content is added.
 
 Set up your local environment
 -----------------------------

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -4,11 +4,10 @@
 Working with the documentation
 ==============================
 
-**Note:** This page is for documentation contributors. It assumes that an admin
-has enabled this repository to work with Read the Docs as described in file
-``setup.rst``.
+**Note:** This page is for documentation contributors. It assumes that this
+repository has been enabled for doc builds as described in file ``setup.rst``.
 
-There are make targets defined in the ``Makefile`` that set up your local
+There are make targets defined in the ``Makefile`` file that set up your local
 environment and allow you to view the documentation. You may also need to
 occasionally change the build configuration as new content is added.
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,58 +1,21 @@
 :orphan:
 
-Documentation starter pack
-==========================
+==============================
+Working with the documentation
+==============================
 
-See the `Sphinx and Read the Docs <https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/>`_ guide for instructions on how to get started with Sphinx documentation.
+**Important:** This page is for documentation contributors. It assumes that an
+admin has set up this repository to work with Read the Docs as described in
+file ``setup.rst``.
 
-Then go through the following sections to use this starter pack to set up your docs repository.
+There are make targets defined in the ``Makefile`` that set up your local
+environment and allow you to view the documentation. You may also need to
+occasionally change the build configuration as new content is added.
 
-Set up your documentation repository
-------------------------------------
+Set up your local environment
+-----------------------------
 
-You can either create a standalone documentation project based on this repository or include the files from this repository in a dedicated documentation folder in an existing code repository.
-
-**Note:** We're planning to provide the contents of this repository as an installable package in the future, but currently, you need to copy and update the required files manually.
-
-Standalone documentation repository
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To create a standalone documentation repository, clone this starter pack repository, `update the configuration <#configure-the-documentation>`_, and then commit all files to your own documentation repository.
-
-You don't need to move any files, and you don't need to do any special configuration on Read the Docs.
-
-Documentation in a code repository
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To add documentation to an existing code repository:
-
-#. create a directory called ``docs`` at the root of the code repository
-#. populate the above directory with the contents of the starter pack
-   repository (with the exception of the ``.git`` directory)
-#. copy the file(s) located in the ``docs/.github/workflows`` directory into
-   the code repository's ``.github/workflows`` directory
-#. in the above file(s), change the values of the ``working-directory`` and
-   ``workdir`` fields from "." to "docs"
-
-.. note::
-
-   When configuring RTD itself for your project, the setting **Path for
-   .readthedocs.yaml** (under **Advanced Settings**) will need to be given the
-   value of "docs/.readthedocs.yaml".
-
-Getting started
----------------
-
-There are make targets defined in the ``Makefile`` that do various things. To
-get started, we will:
-
-* install prerequisite software
-* view the documentation
-
-Install prerequisite software
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To install the prerequisites:
+Use the ``install`` make target to set up your local environment:
 
 .. code-block:: none
 
@@ -65,9 +28,9 @@ A complete set of pinned, known-working dependencies is included in
 ``.sphinx/pinned-requirements.txt``.
 
 View the documentation
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
-To view the documentation:
+Use the ``run`` make target to view the documentation:
 
 .. code-block:: none
 
@@ -85,62 +48,22 @@ The ``run`` target is therefore very convenient when preparing to submit a
 change to the documentation. For a more manual approach, to strictly build and
 serve content, explore the ``html`` and ``serve`` make targets, respectively.
 
-Configure the documentation
----------------------------
+Change the build configuration
+------------------------------
 
-You must modify some of the default configuration to suit your project.
+Occasionally you may want, or need, to alter the build configuration.
 
-Add your project information
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+False-positive misspellings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In ``conf.py``, check or edit the following settings in the *Project information* section:
+To add exceptions for words the spellcheck incorrectly marks as wrong, edit the
+``.wordlist.txt`` file.
 
-* ``project``
-* ``author``
-* ``copyright`` - in most cases, replace the first ``%s`` with the year the project started
-* ``release`` - only required if you're actually using release numbers
-  (beyond the scope of this guide, but you can also use Python to pull this
-  out of your code itself)
-* ``ogp_site_url`` - the URL of the documentation output (needed to generate a preview when linking from another website)
-* ``ogp_site_name`` - the title you want to use for the documentation in previews on other websites (by default, this is set to the project name)
-* ``ogp_image`` - an image that will be used in the preview on other websites
-* ``html_favicon`` - the favicon for the documentation (circle of friends by default)
+Unwanted link checks
+~~~~~~~~~~~~~~~~~~~~
 
-In the ``html_context`` variable, update the following settings:
+To prevent links from being validated, edit the ``linkcheck_ignore`` variable
+in the ``conf.py`` file. Example reasons for doing this include:
 
-* ``discourse_prefix`` - the URL to the Discourse instance your project uses (needed to add links to posts using the ``:discourse:`` metadata at the top of a file)
-* ``github_url`` - the link to your GitHub repository (needed to create the Edit link in the footer and the feedback button)
-* ``github_version`` - the branch that contains this version of the documentation
-* ``github_folder`` - the folder that contains the documentation files
-
-Save ``conf.py``.
-
-Configure the spelling check
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If your documentation uses US English instead of UK English, change this in the
-``.sphinx/spellingcheck.yaml`` file.
-
-To add exceptions for words the spelling check marks as wrong even though they are correct, edit the ``.wordlist.txt`` file.
-
-Configure the link check
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you have links in the documentation that you don't want to be checked (for
-example, because they are local links or give random errors even though they
-work), you can add them to the ``linkcheck_ignore`` variable in the ``conf.py``
-file.
-
-Activate/deactivate feedback button
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A feedback button is included by default, which appears at the top of each page
-in the documentation. It redirects users to your GitHub issues page, and
-populates an issue for them with details of the page they were on when they
-clicked the button.
-
-If your project does not use GitHub issues, set the ``github_issues`` variable
-in the ``conf.py`` file to an empty value to disable both the feedback button
-and the issue link in the footer.
-If you want to deactivate only the feedback button, but keep the link in the
-footer, remove the ``github_issue_links.js`` script from the ``conf.py`` file.
+* the links are local
+* the validation of the links causes errors for no good reason

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -99,16 +99,16 @@ footer, remove the ``github_issue_links.js`` script from the ``conf.py`` file.
 Next steps
 ----------
 
-Now that your repository is enabled for RTD you should:
+Now that your repository is enabled for doc builds you should:
 
 * rename this present file (``readme.rst``) to ``setup.rst``
 * rename file ``working-with-the-docs.rst`` to ``readme.rst``
 
 The new ``readme.rst`` file shows contributors how to work with the
 documentation. For a standalone documentation scenario, it will be the
-repository's main README file. For an integrated scenario, it will remain in
-the ``docs`` directory where it can be linked to from your project's main
-README file.
+repository's main README file. For the integrated scenario (i.e. documentation
+in a code repository), it will remain in the ``docs`` directory where it can be
+linked to from your project's main README file.
 
 .. LINKS
 .. _Sphinx and Read the Docs: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -99,13 +99,16 @@ footer, remove the ``github_issue_links.js`` script from the ``conf.py`` file.
 Next steps
 ----------
 
-Once your repository is set up:
+Now that your repository is enabled for RTD you should:
 
 * rename this present file (``readme.rst``) to ``setup.rst``
 * rename file ``working-with-the-docs.rst`` to ``readme.rst``
 
 The new ``readme.rst`` file shows contributors how to work with the
-documentation.
+documentation. For a standalone documentation scenario, it will be the
+repository's main README file. For an integrated scenario, it will remain in
+the ``docs`` directory where it can be linked to from your project's main
+README file.
 
 .. LINKS
 .. _Sphinx and Read the Docs: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,0 +1,111 @@
+:orphan:
+
+==========================
+Documentation starter pack
+==========================
+
+See the `Sphinx and Read the Docs`_ guide for instructions on how to get
+started with Sphinx documentation. Then go through the following sections to
+use this starter pack to set up your docs repository.
+
+Set up your documentation repository
+------------------------------------
+
+You can either create a standalone documentation project based on this
+repository or include the files from this repository in a dedicated
+documentation folder in an existing code repository.
+
+**Note:** We're planning to provide the contents of this repository as an
+installable package in the future, but currently, you need to copy and update
+the required files manually.
+
+Standalone documentation repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To create a standalone documentation repository, clone this starter pack
+repository, `update the configuration <#configure-the-documentation>`_, and
+then commit all files to your own documentation repository.
+
+You don't need to move any files, and you don't need to do any special
+configuration on Read the Docs.
+
+Documentation in a code repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To add documentation to an existing code repository:
+
+#. create a directory called ``docs`` at the root of the code repository
+#. populate the above directory with the contents of the starter pack
+   repository (with the exception of the ``.git`` directory)
+#. copy the file(s) located in the ``docs/.github/workflows`` directory into
+   the code repository's ``.github/workflows`` directory
+#. in the above file(s), change the values of the ``working-directory`` and
+   ``workdir`` fields from "." to "docs"
+
+.. note::
+
+   When configuring RTD itself for your project, the setting **Path for
+   .readthedocs.yaml** (under **Advanced Settings**) will need to be given the
+   value of "docs/.readthedocs.yaml".
+
+Add your project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In ``conf.py``, check or edit the following settings in the **Project
+information** section:
+
+* ``project``
+* ``author``
+* ``copyright`` - in most cases, replace the first ``%s`` with the year the
+  project started
+* ``release`` - only required if you're actually using release numbers (beyond
+  the scope of this guide, but you can also use Python to pull this out of your
+  code itself)
+* ``ogp_site_url`` - the URL of the documentation output (needed to generate a
+  preview when linking from another website)
+* ``ogp_site_name`` - the title you want to use for the documentation in
+  previews on other websites (by default, this is set to the project name)
+* ``ogp_image`` - an image that will be used in the preview on other websites
+* ``html_favicon`` - the favicon for the documentation (circle of friends by
+  default)
+
+In the file's ``html_context`` variable, update the following settings:
+
+* ``discourse_prefix`` - the URL to the Discourse instance your project uses
+  (needed to add links to posts using the ``:discourse:`` metadata at the top
+  of a file)
+* ``github_url`` - the link to your GitHub repository (needed to create the
+  Edit link in the footer and the feedback button)
+* ``github_version`` - the branch that contains this version of the
+  documentation
+* ``github_folder`` - the folder that contains the documentation files
+
+Save your changes.
+
+Activate/deactivate feedback button
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A feedback button is included by default, which appears at the top of each page
+in the documentation. It redirects users to your GitHub issues page, and
+populates an issue for them with details of the page they were on when they
+clicked the button.
+
+If your project does not use GitHub issues, set the ``github_issues`` variable
+in the ``conf.py`` file to an empty value to disable both the feedback button
+and the issue link in the footer.
+If you want to deactivate only the feedback button, but keep the link in the
+footer, remove the ``github_issue_links.js`` script from the ``conf.py`` file.
+
+Next steps
+----------
+
+Once your repository is set up:
+
+* rename this present file (``readme.rst``) to ``setup.rst``
+* rename file ``working-with-the-docs.rst`` to ``readme.rst``
+
+The new ``readme.rst`` file shows contributors how to work with the
+documentation.
+
+.. LINKS
+.. _Sphinx and Read the Docs: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com


### PR DESCRIPTION
Separate the instructions for enabling doc builds (setup.rst) from instructions that doc contributors need (docs/readme.rst). Now we will have:

```
README.md
docs
├── readme.rst
├── setup.rst
```

When users are directed to the `docs` directory from the main README.md they will see how to interact with the documentation, avoiding the bewilderment of configuring the repo for doc builds.

This will be implemented upstream (canonical/sphinx-docs-starter-pack/issues/96) to make this easier for future travellers.