### PR TITLE
Set default NB/SB election timer to 16s

### DIFF
--- a/snapcraft/commands/ovn-ovsdb-server-nb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-nb.start
@@ -11,6 +11,7 @@ OVN_ARGS="--db-nb-addr="${OVN_LOCAL_IP}" \
 --db-nb-cluster-local-addr="${OVN_LOCAL_IP}" \
 --db-nb-cluster-local-proto=ssl \
 --db-nb-cluster-remote-proto=ssl \
+--db-nb-election-timer="${ELECTION_TIMER}" \
 --ovn-nb-db-ssl-key="${OVN_PKIDIR}"/ovnnb-privkey.pem \
 --ovn-nb-db-ssl-cert="${OVN_PKIDIR}"/ovnnb-cert.pem \
 --ovn-nb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"

--- a/snapcraft/commands/ovn-ovsdb-server-sb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-sb.start
@@ -11,6 +11,7 @@ OVN_ARGS="--db-sb-addr="${OVN_LOCAL_IP}" \
 --db-sb-cluster-local-addr="${OVN_LOCAL_IP}" \
 --db-sb-cluster-local-proto=ssl \
 --db-sb-cluster-remote-proto=ssl \
+--db-sb-election-timer="${ELECTION_TIMER}" \
 --ovn-sb-db-ssl-key="${OVN_PKIDIR}"/ovnsb-privkey.pem \
 --ovn-sb-db-ssl-cert="${OVN_PKIDIR}"/ovnsb-cert.pem \
 --ovn-sb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"

--- a/snapcraft/ovn-central.env
+++ b/snapcraft/ovn-central.env
@@ -10,3 +10,6 @@ export OVN_RUNDIR="${SNAP_COMMON}/run/ovn"
 export OVN_PKGDATADIR="${SNAP}/share/ovn"
 export OVN_SYSCONFDIR="${SNAP}/etc"
 export OVN_PKIDIR="${SNAP_COMMON}/data/pki"
+
+# Set more lenient election timer for NB/SB clusters (16s)
+export ELECTION_TIMER=16000


### PR DESCRIPTION
Note: This change will affect only new deployments.