### PR TITLE
Don't restart OVN NB/SB services during scaling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check-lint: check-tabs
 
 check-system: $(MICROOVN_SNAP)
 	echo "Running functional tests";					\
-	$(CURDIR)/.bats/bats-core/bin/bats tests/upgrade.bats
+	$(CURDIR)/.bats/bats-core/bin/bats tests/
 
 $(MICROOVN_SNAP):
 	echo "Building the snap";						\

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -33,12 +33,6 @@ func refresh(s *state.State) error {
 		return err
 	}
 
-	// Query existing local services.
-	hasCentral, err := localServiceActive(s, "central")
-	if err != nil {
-		return err
-	}
-
 	hasSwitch, err := localServiceActive(s, "switch")
 	if err != nil {
 		return err
@@ -48,14 +42,6 @@ func refresh(s *state.State) error {
 	err = generateEnvironment(s)
 	if err != nil {
 		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
-	}
-
-	// Enable OVN central (if needed).
-	if hasCentral {
-		err = snapRestart("central")
-		if err != nil {
-			return fmt.Errorf("Failed to start OVN central: %w", err)
-		}
 	}
 
 	// Enable OVN chassis.

--- a/tests/test_helper/tls.bash
+++ b/tests/test_helper/tls.bash
@@ -64,7 +64,7 @@ function _verify_cert_files() {
         assert [ -n "$cert_pubkey" ]
         assert [ -n "$key_pubkey" ]
         ## Ensure that public key hashes match
-        assert_equal "$(sha256sum "$cert_pubkey")" "$(sha256sum "$key_pubkey")"
+        assert_equal "$(echo "$cert_pubkey" | sha256sum)" "$(echo "$key_pubkey" | sha256sum)"
 
         # Check that certificates match CA
         lxc_exec "$container" "openssl verify -CAfile $CA_CERT_PATH $cert"


### PR DESCRIPTION
It is not necessary to restart OVN NB/SB services when a member is added or
removed as the cluster handles this change internally and seamlessly.