### PR TITLE
Split `microovn.central` service.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check-lint: check-tabs
 
 check-system: $(MICROOVN_SNAP)
 	echo "Running functional tests";					\
-	$(CURDIR)/.bats/bats-core/bin/bats tests/upgrade.bats
+	$(CURDIR)/.bats/bats-core/bin/bats tests/
 
 $(MICROOVN_SNAP):
 	echo "Building the snap";						\

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -37,3 +37,7 @@ io
 OpenStack
 failover
 README
+sb
+nb
+tls
+rst

--- a/docs/how-to/tls.rst
+++ b/docs/how-to/tls.rst
@@ -112,6 +112,8 @@ member.
    member. Any failure will result in subsequent communication errors for that
    service within the cluster.
 
+.. _certificates_lifecycle:
+
 Certificate lifecycle
 ---------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,3 +26,4 @@ way and suitable for production environment.
 
    how-to/index
    tutorial/index
+   reference/index

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,11 @@
+=========
+Reference
+=========
+
+MicroOVN reference material is specific to the MicroOVN project. It
+does not cover upstream OVN/OVS topics.
+
+.. toctree::
+   :maxdepth: 1
+
+   services

--- a/docs/reference/services.rst
+++ b/docs/reference/services.rst
@@ -1,0 +1,71 @@
+=================
+MicroOVN services
+=================
+
+This page presents a list of all MicroOVN services. Their descriptions are
+for reference only - the user is not expected to interact directly with these
+services.
+
+The status of all services is displayed by running:
+
+.. code-block:: none
+
+   snap services microovn
+
+``microovn.central``
+--------------------
+
+.. warning::
+
+   The ``microovn.central`` service is deprecated and will be removed in a
+   future release.
+
+This is a transitional service. Starting this service will start and enable
+multiple services:
+
+* ``microovn.ovn-ovsdb-server-nb``
+* ``microovn.ovn-ovsdb-server-sb``
+* ``microovn.ovn-northd``
+
+However this service is not capable of stopping these child services so its
+usage is strongly discouraged. Users should use individual services instead.
+
+``microovn.chassis``
+--------------------
+
+This service maps directly to the ``ovn-controller`` daemon.
+
+``microovn.daemon``
+-------------------
+
+The main MicroOVN service/process that manages all the other processes. It also
+handles communication with other MicroOVN cluster members and provides an API
+for the ``microovn`` client command.
+
+``microovn.ovn-ovsdb-server-nb``
+--------------------------------
+
+This service maps directly to the ``OVN Northbound`` database/service.
+
+``microovn.ovn-northd``
+-----------------------
+
+This service maps directly to the ``ovn-northd`` daemon.
+
+``microovn.ovn-ovsdb-server-sb``
+--------------------------------
+
+This service maps directly to the ``OVN Southbound`` database/service.
+
+``microovn.refresh-expiring-certs``
+-----------------------------------
+
+This service is a recurring process that runs once a day between ``02:00`` and
+``02:30``. It triggers TLS certification reissue for certificates that are
+nearing the expiration. For more information see the
+:ref:`certificates lifecycle <certificates_lifecycle>`.
+
+``microovn.switch``
+-------------------
+
+This services maps directly to the ``ovs-vswitchd`` daemon.

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -93,9 +93,19 @@ func Bootstrap(s *state.State) error {
 	}
 
 	// Enable OVN central.
-	err = snapStart("central", true)
+	err = snapStart("ovn-ovsdb-server-nb", true)
 	if err != nil {
-		return fmt.Errorf("Failed to start OVN central: %w", err)
+		return fmt.Errorf("Failed to start OVN NB: %w", err)
+	}
+
+	err = snapStart("ovn-ovsdb-server-sb", true)
+	if err != nil {
+		return fmt.Errorf("Failed to start OVN SB: %w", err)
+	}
+
+	err = snapStart("ovn-northd", true)
+	if err != nil {
+		return fmt.Errorf("Failed to start OVN northd: %w", err)
 	}
 
 	// Generate certificate for OVN chassis (controller)

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -68,9 +68,9 @@ func Bootstrap(s *state.State) error {
 	// all OVS-based programs ability to specify active or passive (listen)
 	// connection types.
 	err = GenerateNewServiceCertificate(s, "client", CertificateTypeServer)
-        if err != nil {
-                return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
-        }
+	if err != nil {
+		return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
+	}
 
 	// Enable OVS switch.
 	err = snapStart("switch", true)

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -76,9 +76,9 @@ func Join(s *state.State) error {
 	// all OVS-based programs ability to specify active or passive (listen)
 	// connection types.
 	err = GenerateNewServiceCertificate(s, "client", CertificateTypeServer)
-        if err != nil {
-                return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
-        }
+	if err != nil {
+		return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
+	}
 
 	// Copy shared CA certificate from shared database to file on disk
 	err = DumpCA(s)

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -108,9 +108,19 @@ func Join(s *state.State) error {
 			return fmt.Errorf("failed to generate TLS certificate for ovn-northd service")
 		}
 
-		err = snapStart("central", true)
+		err = snapStart("ovn-ovsdb-server-nb", true)
 		if err != nil {
-			return fmt.Errorf("Failed to start OVN central: %w", err)
+			return fmt.Errorf("Failed to start OVN NB: %w", err)
+		}
+
+		err = snapStart("ovn-ovsdb-server-sb", true)
+		if err != nil {
+			return fmt.Errorf("Failed to start OVN SB: %w", err)
+		}
+
+		err = snapStart("ovn-northd", true)
+		if err != nil {
+			return fmt.Errorf("Failed to start OVN northd: %w", err)
 		}
 	}
 

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -71,9 +71,19 @@ func Leave(s *state.State) error {
 		logger.Warnf("Failed to get SB database specification: %s", err)
 	}
 
-	err = snapStop("central", true)
+	err = snapStop("ovn-northd", true)
 	if err != nil {
-		logger.Warnf("Failed to stop Central service: %s", err)
+		logger.Warnf("Failed to stop OVN northd service: %s", err)
+	}
+
+	err = snapStop("ovn-ovsdb-server-nb", true)
+	if err != nil {
+		logger.Warnf("Failed to stop OVN NB service: %s", err)
+	}
+
+	err = snapStop("ovn-ovsdb-server-sb", true)
+	if err != nil {
+		logger.Warnf("Failed to stop OVN SB service: %s", err)
 	}
 
 	logger.Info("Cleaning up runtime and data directories.")

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -50,11 +50,11 @@ func refresh(s *state.State) error {
 		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
 	}
 
-	// Enable OVN central (if needed).
+	// Restart OVN Northd service to account for NB/SB cluster changes.
 	if hasCentral {
-		err = snapRestart("central")
+		err = snapRestart("ovn-northd")
 		if err != nil {
-			return fmt.Errorf("Failed to start OVN central: %w", err)
+			return fmt.Errorf("Failed to restart OVN northd: %w", err)
 		}
 	}
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,27 @@ apps:
     command: commands/central.start
     daemon: simple
     install-mode: disable
+
+  ovn-ovsdb-server-nb:
+    command: commands/ovn-ovsdb-server-nb.start
+    daemon: simple
+    install-mode: disable
+    plugs:
+      - network
+      - network-bind
+
+  ovn-ovsdb-server-sb:
+    command: commands/ovn-ovsdb-server-sb.start
+    daemon: simple
+    install-mode: disable
+    plugs:
+      - network
+      - network-bind
+
+  ovn-northd:
+    command: commands/ovn-northd.start
+    daemon: simple
+    install-mode: disable
     plugs:
       - network
       - network-bind

--- a/snapcraft/commands/central.start
+++ b/snapcraft/commands/central.start
@@ -1,58 +1,15 @@
 #!/bin/sh
-set -eux
 
-# Load the environment
-. "${SNAP_COMMON}/data/ovn.env"
+echo "This is a transitional service that can be used to start 'ovn-ovsdb-server-nb',
+'ovn-ovsdb-server-sb' and 'ovn-northd' services at the same time. However its usage is
+discouraged as it will be removed in future releases."
 
-# Setup directories
-export OVN_DBDIR="${SNAP_COMMON}/data/central/db"
-export OVN_LOGDIR="${SNAP_COMMON}/logs"
-export OVN_RUNDIR="${SNAP_COMMON}/run/ovn"
-export OVN_PKGDATADIR="${SNAP}/share/ovn"
-export OVN_SYSCONFDIR="${SNAP}/etc"
-export OVN_PKIDIR="${SNAP_COMMON}/data/pki"
-
-# Prepare the arguments
-# By specifying "--db-*-create-insecure-remote=no" we prevent creation of
-# hardcoded bindings and we can use database to configure remotes later.
-OVN_ARGS="--db-nb-addr="${OVN_LOCAL_IP}" \
---db-nb-create-insecure-remote=no \
---db-sb-addr="${OVN_LOCAL_IP}" \
---db-sb-create-insecure-remote=no \
---db-nb-cluster-local-addr="${OVN_LOCAL_IP}" \
---db-sb-cluster-local-addr="${OVN_LOCAL_IP}" \
---ovn-northd-nb-db="${OVN_NB_CONNECT}" \
---ovn-northd-sb-db="${OVN_SB_CONNECT}" \
---db-nb-cluster-local-proto=ssl \
---db-nb-cluster-remote-proto=ssl \
---db-sb-cluster-local-proto=ssl \
---db-sb-cluster-remote-proto=ssl \
---ovn-northd-ssl-key="${OVN_PKIDIR}"/ovn-northd-privkey.pem \
---ovn-northd-ssl-cert="${OVN_PKIDIR}"/ovn-northd-cert.pem \
---ovn-northd-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem \
---ovn-nb-db-ssl-key="${OVN_PKIDIR}"/ovnnb-privkey.pem \
---ovn-nb-db-ssl-cert="${OVN_PKIDIR}"/ovnnb-cert.pem \
---ovn-nb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem \
---ovn-sb-db-ssl-key="${OVN_PKIDIR}"/ovnsb-privkey.pem \
---ovn-sb-db-ssl-cert="${OVN_PKIDIR}"/ovnsb-cert.pem \
---ovn-sb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"
-
-if [ "${OVN_INITIAL_NB}" != "${OVN_LOCAL_IP}" ]; then
-    OVN_ARGS="${OVN_ARGS} --db-nb-cluster-remote-addr="${OVN_INITIAL_NB}""
-fi
-
-if [ "${OVN_INITIAL_SB}" != "${OVN_LOCAL_IP}" ]; then
-    OVN_ARGS="${OVN_ARGS} --db-sb-cluster-remote-addr="${OVN_INITIAL_SB}""
-fi
-
-# Start NorthBound OVN DB
-"${SNAP}/share/ovn/scripts/ovn-ctl" run_nb_ovsdb ${OVN_ARGS} &
-
-# Start SouthBound OVN DB
-"${SNAP}/share/ovn/scripts/ovn-ctl" run_sb_ovsdb ${OVN_ARGS} &
-
-# Start NorthBOund daemon
-"${SNAP}/share/ovn/scripts/ovn-ctl" start_northd ${OVN_ARGS} \
-    --ovn-manage-ovsdb=no --no-monitor
-
-sleep infinity
+while true; do
+    if snapctl start --enable microovn.ovn-ovsdb-server-nb \
+                              microovn.ovn-ovsdb-server-sb \
+                              microovn.ovn-northd; then
+        snapctl stop --disable microovn.central
+        exit 0
+    fi
+    sleep 1
+done

--- a/snapcraft/commands/central.start
+++ b/snapcraft/commands/central.start
@@ -12,15 +12,6 @@ export OVN_PKGDATADIR="${SNAP}/share/ovn"
 export OVN_SYSCONFDIR="${SNAP}/etc"
 export OVN_PKIDIR="${SNAP_COMMON}/data/pki"
 
-# Disable some commands
-mkdir -p "${OVN_RUNDIR}/bin/"
-for i in install plymouth sudo systemctl; do
-    [ -e "${OVN_RUNDIR}/bin/${i}" ] && continue
-
-    ln -s "/bin/true" "${OVN_RUNDIR}/bin/${i}"
-done
-export PATH="${OVN_RUNDIR}/bin/:${PATH}"
-
 # Prepare the arguments
 # By specifying "--db-*-create-insecure-remote=no" we prevent creation of
 # hardcoded bindings and we can use database to configure remotes later.

--- a/snapcraft/commands/chassis.start
+++ b/snapcraft/commands/chassis.start
@@ -13,15 +13,6 @@ export OVN_PKGDATADIR="${SNAP}/share/ovn"
 export OVN_SYSCONFDIR="${SNAP}/etc"
 export OVN_PKIDIR="${SNAP_COMMON}/data/pki"
 
-# Disable some commands
-mkdir -p "${OVN_RUNDIR}/bin/"
-for i in install plymouth sudo systemctl; do
-    [ -e "${OVN_RUNDIR}/bin/${i}" ] && continue
-
-    ln -s "/bin/true" "${OVN_RUNDIR}/bin/${i}"
-done
-export PATH="${OVN_RUNDIR}/bin/:${PATH}"
-
 # Prepare the arguments
 OVN_ARGS="--db-nb-addr="${OVN_LOCAL_IP}" \
 --db-sb-addr="${OVN_LOCAL_IP}" \

--- a/snapcraft/commands/ovn-northd.start
+++ b/snapcraft/commands/ovn-northd.start
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eux
+
+. "${SNAP}/ovn-central.env"
+
+# Prepare the arguments
+OVN_ARGS="--ovn-northd-nb-db="${OVN_NB_CONNECT}" \
+--ovn-northd-sb-db="${OVN_SB_CONNECT}" \
+--ovn-northd-ssl-key="${OVN_PKIDIR}"/ovn-northd-privkey.pem \
+--ovn-northd-ssl-cert="${OVN_PKIDIR}"/ovn-northd-cert.pem \
+--ovn-northd-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"
+
+# Start Northd daemon
+"${SNAP}/share/ovn/scripts/ovn-ctl" start_northd ${OVN_ARGS} \
+    --ovn-manage-ovsdb=no --no-monitor
+
+# Keep running while northd process lives
+tail --pid "$(cat "$SNAP_COMMON"/run/ovn/ovn-northd.pid)" -f /dev/null

--- a/snapcraft/commands/ovn-ovsdb-server-nb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-nb.start
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eux
+
+. "${SNAP}/ovn-central.env"
+
+# Prepare the arguments
+# By specifying "--db-nb-create-insecure-remote=no" we prevent creation of
+# hardcoded bindings and we can use database to configure remotes later.
+OVN_ARGS="--db-nb-addr="${OVN_LOCAL_IP}" \
+--db-nb-create-insecure-remote=no \
+--db-nb-cluster-local-addr="${OVN_LOCAL_IP}" \
+--db-nb-cluster-local-proto=ssl \
+--db-nb-cluster-remote-proto=ssl \
+--ovn-nb-db-ssl-key="${OVN_PKIDIR}"/ovnnb-privkey.pem \
+--ovn-nb-db-ssl-cert="${OVN_PKIDIR}"/ovnnb-cert.pem \
+--ovn-nb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"
+
+if [ "${OVN_INITIAL_NB}" != "${OVN_LOCAL_IP}" ]; then
+    OVN_ARGS="${OVN_ARGS} --db-nb-cluster-remote-addr="${OVN_INITIAL_NB}""
+fi
+
+# Start NorthBound OVN DB
+"${SNAP}/share/ovn/scripts/ovn-ctl" run_nb_ovsdb ${OVN_ARGS}

--- a/snapcraft/commands/ovn-ovsdb-server-sb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-sb.start
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eux
+
+. "${SNAP}/ovn-central.env"
+
+# Prepare the arguments
+# By specifying "--db-sb-create-insecure-remote=no" we prevent creation of
+# hardcoded bindings and we can use database to configure remotes later.
+OVN_ARGS="--db-sb-addr="${OVN_LOCAL_IP}" \
+--db-sb-create-insecure-remote=no \
+--db-sb-cluster-local-addr="${OVN_LOCAL_IP}" \
+--db-sb-cluster-local-proto=ssl \
+--db-sb-cluster-remote-proto=ssl \
+--ovn-sb-db-ssl-key="${OVN_PKIDIR}"/ovnsb-privkey.pem \
+--ovn-sb-db-ssl-cert="${OVN_PKIDIR}"/ovnsb-cert.pem \
+--ovn-sb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"
+
+if [ "${OVN_INITIAL_SB}" != "${OVN_LOCAL_IP}" ]; then
+    OVN_ARGS="${OVN_ARGS} --db-sb-cluster-remote-addr="${OVN_INITIAL_SB}""
+fi
+
+# Start SouthBound OVN DB
+"${SNAP}/share/ovn/scripts/ovn-ctl" run_sb_ovsdb ${OVN_ARGS}

--- a/snapcraft/commands/switch.start
+++ b/snapcraft/commands/switch.start
@@ -10,15 +10,6 @@ export OVS_PKGDATADIR="${SNAP}/share/openvswitch"
 export OVS_BINDIR="${SNAP}/bin"
 export OVS_SBINDIR="${SNAP}/bin"
 
-# Disable some commands
-mkdir -p "${OVS_RUNDIR}/bin/"
-for i in install plymouth systemctl; do
-    [ -e "${OVS_RUNDIR}/bin/${i}" ] && continue
-
-    ln -s "/bin/true" "${OVS_RUNDIR}/bin/${i}"
-done
-export PATH="${OVS_RUNDIR}/bin/:${PATH}"
-
 # Start vswitchd
 "${SNAP}/share/openvswitch/scripts/ovs-ctl" start --system-id="$(hostname)"
 sleep infinity

--- a/snapcraft/ovn-central.env
+++ b/snapcraft/ovn-central.env
@@ -1,0 +1,12 @@
+# Set of environment variables used by OVN Central services
+
+# Load runtime OVN environment variables
+. "${SNAP_COMMON}/data/ovn.env"
+
+# Setup directories
+export OVN_DBDIR="${SNAP_COMMON}/data/central/db"
+export OVN_LOGDIR="${SNAP_COMMON}/logs"
+export OVN_RUNDIR="${SNAP_COMMON}/run/ovn"
+export OVN_PKGDATADIR="${SNAP}/share/ovn"
+export OVN_SYSCONFDIR="${SNAP}/etc"
+export OVN_PKIDIR="${SNAP_COMMON}/data/pki"

--- a/snapcraft/ovn.env
+++ b/snapcraft/ovn.env
@@ -1,6 +1,6 @@
 # Set of environment variables for OVN commands
 
-# Load dynamic environment variables
+# Load runtime environment variables
 . "${SNAP_COMMON}/data/ovn.env"
 
 export OVN_PKI_DIR="${SNAP_COMMON}/data/pki"

--- a/tests/test_helper/bats/cluster.bats
+++ b/tests/test_helper/bats/cluster.bats
@@ -33,7 +33,9 @@ setup() {
     local chassis_services="snap.microovn.chassis \
                             snap.microovn.daemon \
                             snap.microovn.switch"
-    local central_services="snap.microovn.central \
+    local central_services="snap.microovn.ovn-ovsdb-server-nb \
+                            snap.microovn.ovn-ovsdb-server-sb \
+                            snap.microovn.ovn-northd \
                             $chassis_services"
 
     for container in $TEST_CONTAINERS; do

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -18,14 +18,28 @@ function install_microovn() {
         echo "# Installing MicroOVN in container $container" >&3
         lxc_exec "$container" "snap install /tmp/microovn.snap --dangerous"
         echo "# Connecting plugs in container $container" >&3
-        lxc_exec "$container" "for plug in firewall-control \
-                                           hardware-observe \
-                                           hugepages-control \
-                                           network-control \
-                                           openvswitch-support \
-                                           process-control \
-                                           system-trace; do \
-                                   sudo snap connect microovn:\$plug;done"
+        # Give it few retries as snap can't connect plugs while services
+        # are still starting
+        local i
+        for (( i = 0; i < 10; i++ )); do
+            if lxc_exec "$container" "for plug in firewall-control \
+                                                  hardware-observe \
+                                                  hugepages-control \
+                                                  network-control \
+                                                  openvswitch-support \
+                                                  process-control \
+                                                  system-trace; do \
+                                          sudo snap connect microovn:\$plug;done"; then
+                break
+            fi
+
+            if [ "$i" -eq 9 ]; then
+                echo "Failed to connect MicroOVN plugs."
+                return 1
+            fi
+
+            sleep 1
+        done
     done
 }
 

--- a/tests/test_helper/tls.bash
+++ b/tests/test_helper/tls.bash
@@ -64,7 +64,7 @@ function _verify_cert_files() {
         assert [ -n "$cert_pubkey" ]
         assert [ -n "$key_pubkey" ]
         ## Ensure that public key hashes match
-        assert_equal "$(sha256sum "$cert_pubkey")" "$(sha256sum "$key_pubkey")"
+        assert_equal "$(echo "$cert_pubkey" | sha256sum)" "$(echo "$key_pubkey" | sha256sum)"
 
         # Check that certificates match CA
         lxc_exec "$container" "openssl verify -CAfile $CA_CERT_PATH $cert"

--- a/tests/test_helper/upgrade_procedures.bash
+++ b/tests/test_helper/upgrade_procedures.bash
@@ -42,11 +42,15 @@ function rejoin_cluster_with_tls() {
 
     lxc_exec "$target_container" "microovn.ovn-appctl -t $ctl_path cluster/leave $db_name"
     wait_ovsdb_cluster_container_leave "$target_server_id" "$ctl_path" "$db_name" 30 "$monitor_containers"
-    lxc_exec "$target_container" "snap stop microovn.central"
+    lxc_exec "$target_container" "snap stop microovn.ovn-northd"
+    lxc_exec "$target_container" "snap stop microovn.ovn-ovsdb-server-nb"
+    lxc_exec "$target_container" "snap stop microovn.ovn-ovsdb-server-sb"
     lxc_exec "$target_container" "rm $db_path"
     lxc_exec "$target_container" "microovn.ovsdb-tool join-cluster $db_path $db_name \
                                   ssl:$local_ip:$port $target_proto:$target_ip:$port"
-    lxc_exec "$target_container" "snap restart microovn.central"
+    lxc_exec "$target_container" "snap restart microovn.ovn-ovsdb-server-nb"
+    lxc_exec "$target_container" "snap restart microovn.ovn-ovsdb-server-sb"
+    lxc_exec "$target_container" "snap restart microovn.ovn-northd"
     wait_ovsdb_cluster_changes_applied "$target_container" "$ctl_path" "$db_name" 30
 }
 


### PR DESCRIPTION
Previously `microovn.central` started all three central services (ovn-nb, ovn-sb and northd). Now these daemons are split into their own services for more fine-grained controll over them.

The `microovn.central` will stay for now and act as an umbrella service that can trigger start of all three services. However the usage is discouraged as it will be removed. It's also not capable of being used as shortcut for stopping these services.

Additional consequence of splitting of the services is that we can now scale the cluster without restarting OVN NB/SB services as only the northd daemon needs restart.