### PR TITLE
[branch-22.03] Add CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @canonical/ovn-team


### PR DESCRIPTION
This is a security measure required for using our managed self-hosted actions runners.

GitHub documentation about code owners [0].

0: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>
(cherry picked from commit a5c6f1c934978c9128e06a2dbcb581e669039df2)