### PR TITLE
Cleanup OVS resource on snap removal.

### DIFF
--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Note (mkalcok): `microovn.switch` service, by default, stops OVS
+# vswitch daemon with `--cleanup` flag that releases datapath
+# resources like ports and bridges. This hook prevents such behavior
+# by stopping the daemon without `--cleanup` flag during the snap
+# refresh.
+
+${SNAP}/commands/ovs-appctl exit || true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,7 +75,7 @@ apps:
     command: commands/switch.start
     daemon: simple
     install-mode: disable
-    refresh-mode: endure
+    stop-command: commands/ovs-appctl exit --cleanup
     plugs:
       - firewall-control
       - hardware-observe

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -1,0 +1,1 @@
+test_helper/bats/lifecycle.bats

--- a/tests/test_helper/bats/lifecycle.bats
+++ b/tests/test_helper/bats/lifecycle.bats
@@ -1,0 +1,63 @@
+# This is a bash shell fragment -*- bash -*-
+
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 1)
+    export TEST_CONTAINERS
+    launch_containers jammy $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+}
+
+teardown_file() {
+    delete_containers $TEST_CONTAINERS
+}
+
+setup() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-support/load.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+
+    # Trim trailing whitespace from a variable with only single container
+    TEST_CONTAINER="$(echo -e "${TEST_CONTAINERS}" | sed -e 's/[[:space:]]*$//')"
+    export TEST_CONTAINER
+}
+
+teardown() {
+    lxc_exec "$TEST_CONTAINER" "snap remove microovn" || true
+}
+
+@test "Cleanup OVS datapaths on snap removal" {
+    # Verify that removal of MicroOVN snap cleans up DP resources
+
+    # The tests will need external `ovs-dpctl` command to check DPs after
+    # microovn removal.
+    lxc_exec "$TEST_CONTAINER" "DEBIAN_FRONTEND=noninteractive apt install -yqq openvswitch-switch"
+
+    echo "Checking datapaths on container '$TEST_CONTAINER' before MicroOVN installation."
+    run lxc_exec "$TEST_CONTAINER" "ovs-dpctl dump-dps | wc -l"
+    assert_output "0"
+
+    install_microovn "$MICROOVN_SNAP_PATH" "$TEST_CONTAINER"
+    bootstrap_cluster "$TEST_CONTAINER"
+
+    echo "Checking datapaths on container '$TEST_CONTAINER' after MicroOVN bootstrap."
+    run lxc_exec "$TEST_CONTAINER" "ovs-dpctl dump-dps | wc -l"
+    assert_output "1"
+
+    echo "Removing MicroOVN snap."
+    run lxc_exec "$TEST_CONTAINER" "snap remove microovn"
+
+    echo "Checking datapaths on container '$TEST_CONTAINER' after MicroOVN removal."
+    run lxc_exec "$TEST_CONTAINER" "ovs-dpctl dump-dps | wc -l"
+    assert_output "0"
+}


### PR DESCRIPTION
This change modifies `microovn.switch` service to stop OVS vswitchd service with `--cleanup` flag. This ensures that when snap is removed, datapath resources like ports and bridges are cleaned up.

This new behavior is overriden in pre-refresh hook to avoid dataplane outages during the snap refresh.