### PR TITLE
Use systemd journal for logging.

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -24,3 +24,5 @@ OVS
 OpenStack
 failover
 README
+systemd
+vSwitch

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,3 +1,4 @@
+appctl
 Permalink
 reST
 RST
@@ -21,8 +22,10 @@ lifecycle
 PKI
 unencrypted
 OVS
+ovs
 OpenStack
 failover
 README
 systemd
 vSwitch
+manpage

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -11,3 +11,4 @@ a basic understanding of OVN.
 
    tls
    downscaling
+   logs

--- a/docs/how-to/logs.rst
+++ b/docs/how-to/logs.rst
@@ -1,0 +1,56 @@
+==============
+Accessing logs
+==============
+
+The :ref:`MicroOVN services` provide logs as part of their normal operation.
+
+By default they are provided through the systemd journal.
+
+Below you can view an example for how to access the logs of the
+``microovn.chassis`` service:
+
+.. code-block:: none
+
+   journalctl -u microovn.chassis
+
+Below you can view an example of how to view a live log display for the same
+service:
+
+.. code-block:: none
+
+   journalctl -f -u microovn.chassis
+
+Log files
+---------
+
+Inside the ``/var/snap/microovn/common/logs`` directory you will find files for
+each individual service, however these will either be empty or not contain
+updated information, this is intentional.
+
+On fresh install the files are created, as a precaution, in the event a need
+arises for enabling `debug logging`_.  On refresh from older versions of
+MicroOVN existing files will be retained, but not updated.
+
+Debug logging
+-------------
+
+The Open vSwitch (OVS) and Open Virtual Network (OVN) daemons have a rich set
+of debug features, one of which being available by augmenting log levels for
+individual modules at run time.
+
+A list of modules can be acquired through the ``microovn.ovs-appctl`` and
+``microovn.ovn-appctl`` commands.
+
+Below you can view an example of how to enable debug logging for the Open
+vSwitch ``vswitchd`` module:
+
+.. code-block:: none
+
+   microovn.ovs-appctl vlog/set vswitchd:file:dbg
+
+Below you can view an example of how to enable debug logging for the Open
+Virtual Network ``reconnect`` module:
+
+.. code-block:: none
+
+   microovn.ovn-appctl vlog/set reconnect:file:dbg

--- a/docs/how-to/logs.rst
+++ b/docs/how-to/logs.rst
@@ -6,15 +6,13 @@ The :ref:`MicroOVN services` provide logs as part of their normal operation.
 
 By default they are provided through the systemd journal.
 
-Below you can view an example for how to access the logs of the
-``microovn.chassis`` service:
+This is how you can access the logs of the ``microovn.chassis`` service:
 
 .. code-block:: none
 
    journalctl -u microovn.chassis
 
-Below you can view an example of how to view a live log display for the same
-service:
+This is how you can view a live log display for the same service:
 
 .. code-block:: none
 
@@ -27,30 +25,34 @@ Inside the ``/var/snap/microovn/common/logs`` directory you will find files for
 each individual service, however these will either be empty or not contain
 updated information, this is intentional.
 
-On fresh install the files are created, as a precaution, in the event a need
-arises for enabling `debug logging`_.  On refresh from older versions of
-MicroOVN existing files will be retained, but not updated.
+On a fresh install the files are created, as a precaution, in the event a need
+arises for enabling `debug logging`_.  When upgrading MicroOVN, existing files
+will be retained, but not updated.
 
 Debug logging
 -------------
 
 The Open vSwitch (OVS) and Open Virtual Network (OVN) daemons have a rich set
-of debug features, one of which being available by augmenting log levels for
+of debug features, one of which is the ability to specify log levels for
 individual modules at run time.
 
 A list of modules can be acquired through the ``microovn.ovs-appctl`` and
 ``microovn.ovn-appctl`` commands.
 
-Below you can view an example of how to enable debug logging for the Open
-vSwitch ``vswitchd`` module:
+This is how to enable debug logging for the Open vSwitch ``vswitchd`` module:
 
 .. code-block:: none
 
    microovn.ovs-appctl vlog/set vswitchd:file:dbg
 
-Below you can view an example of how to enable debug logging for the Open
-Virtual Network ``reconnect`` module:
+This is how to enable debug logging for the Open Virtual Network ``reconnect``
+module:
 
 .. code-block:: none
 
    microovn.ovn-appctl vlog/set reconnect:file:dbg
+
+For more details on how to configure logging, see `ovs-appctl manpage`_.
+
+.. LINKS
+.. _ovs-appctl manpage: https://docs.openvswitch.org/en/latest/ref/ovs-appctl.8/#logging-commands

--- a/docs/reference/services.rst
+++ b/docs/reference/services.rst
@@ -1,3 +1,5 @@
+.. _MicroOVN services:
+
 =================
 MicroOVN services
 =================

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mkdir -p $SNAP_COMMON/logs
+cp $SNAP/docs/microovn/how-to/logs.txt $SNAP_COMMON/logs/README

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -283,6 +283,25 @@ parts:
       - bin/microovn
       - bin/microovnd
 
+  docs:
+    plugin: nil
+    source: docs/
+    build-packages:
+      - python3.11-venv
+    override-build: |
+      set -ex
+      make .sphinx/venv
+      make text
+      rm -rf ${CRAFT_PART_INSTALL}/docs/microovn
+      mkdir -p ${CRAFT_PART_INSTALL}/docs
+      cp -pR _build/text ${CRAFT_PART_INSTALL}/docs/microovn
+    stage:
+      # drop doc starter pack boiler plate files
+      - -docs/microovn/help-woke.*
+      - -docs/microovn/readme.txt
+      - -docs/microovn/setup.txt
+      - -docs/microovn/_*
+
   wrappers:
     plugin: dump
     source: snapcraft/

--- a/snapcraft/commands/chassis.start
+++ b/snapcraft/commands/chassis.start
@@ -36,6 +36,8 @@ fi
 
 # Start the OVN controller
 "${SNAP}/share/ovn/scripts/ovn-ctl" start_controller ${OVN_ARGS} \
-    --ovn-manage-ovsdb=no --no-monitor
+    --ovn-manage-ovsdb=no \
+    --no-monitor \
+    --ovn-controller-log="-vsyslog:info -vfile:off"
 
 sleep infinity

--- a/snapcraft/commands/ovn-northd.start
+++ b/snapcraft/commands/ovn-northd.start
@@ -12,7 +12,9 @@ OVN_ARGS="--ovn-northd-nb-db="${OVN_NB_CONNECT}" \
 
 # Start Northd daemon
 "${SNAP}/share/ovn/scripts/ovn-ctl" start_northd ${OVN_ARGS} \
-    --ovn-manage-ovsdb=no --no-monitor
+    --ovn-manage-ovsdb=no \
+    --no-monitor \
+    --ovn-northd-log="-vsyslog:info -vfile:off"
 
 # Keep running while northd process lives
 tail --pid "$(cat "$SNAP_COMMON"/run/ovn/ovn-northd.pid)" -f /dev/null

--- a/snapcraft/commands/ovn-ovsdb-server-nb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-nb.start
@@ -21,4 +21,5 @@ if [ "${OVN_INITIAL_NB}" != "${OVN_LOCAL_IP}" ]; then
 fi
 
 # Start NorthBound OVN DB
-"${SNAP}/share/ovn/scripts/ovn-ctl" run_nb_ovsdb ${OVN_ARGS}
+"${SNAP}/share/ovn/scripts/ovn-ctl" run_nb_ovsdb ${OVN_ARGS} \
+    --ovn-nb-log="-vsyslog:info -vfile:off"

--- a/snapcraft/commands/ovn-ovsdb-server-sb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-sb.start
@@ -21,4 +21,5 @@ if [ "${OVN_INITIAL_SB}" != "${OVN_LOCAL_IP}" ]; then
 fi
 
 # Start SouthBound OVN DB
-"${SNAP}/share/ovn/scripts/ovn-ctl" run_sb_ovsdb ${OVN_ARGS}
+"${SNAP}/share/ovn/scripts/ovn-ctl" run_sb_ovsdb ${OVN_ARGS} \
+    --ovn-sb-log="-vsyslog:info -vfile:off"

--- a/snapcraft/commands/switch.start
+++ b/snapcraft/commands/switch.start
@@ -11,5 +11,9 @@ export OVS_BINDIR="${SNAP}/bin"
 export OVS_SBINDIR="${SNAP}/bin"
 
 # Start vswitchd
-"${SNAP}/share/openvswitch/scripts/ovs-ctl" start --system-id="$(hostname)"
+"${SNAP}/share/openvswitch/scripts/ovs-ctl" \
+    start \
+    --system-id="$(hostname)" \
+    --ovsdb-server-options="-vsyslog:info -vfile:off" \
+    --ovs-vswitchd-options="-vsyslog:info -vfile:off"
 sleep infinity


### PR DESCRIPTION
At present the OVS and OVN services provided by MicroOVN logs to file.

This is a problem, because there is no mechanism for rotating these logfiles, and as a consequence they will grow without bounds potentially depleting all available storage.

The best practice for snaps is to log to the systemd journal [0].

Due to how the `ovs-ctl` and `ovn-ctl` scripts work, there is no way to avoid the log files from being created.  It may also be useful to have log files configured for live debugging sessions.

Add a README in $SNAP_COMMON/logs explaining that the log files are not updated by default, pointing the user to where to find the actual logs.

0: https://forum.snapcraft.io/t/best-practice-for-logging/1210

Closes-Bug: #2039582