### PR TITLE
tests/upgrade: Allow DBs to settle before post-upgrade test.

### DIFF
--- a/tests/test_helper/bats/upgrade.bats
+++ b/tests/test_helper/bats/upgrade.bats
@@ -19,6 +19,17 @@ setup() {
 @test "Verify that currently released snap can be upgraded" {
     echo "# Upgrading MicroOVN from revision $MICROOVN_SNAP_REV" >&3
     install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+
+    for container in $TEST_CONTAINERS; do
+        local container_services
+        container_services=$(microovn_get_cluster_services "$container")
+        if [[ "$container_services" != *"central"* ]]; then
+            continue
+        fi
+        microovn_wait_ovndb_state "$container" nb connected 15
+        microovn_wait_ovndb_state "$container" sb connected 15
+    done
+
     perform_manual_upgrade_steps $TEST_CONTAINERS
     local cluster_test_filename="${ABS_TOP_TEST_DIRNAME=}test_helper/bats/post_upgrade_cluster.bats"
     local tls_test_filename="${ABS_TOP_TEST_DIRNAME=}test_helper/bats/post_upgrade_tls.bats"

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -232,6 +232,25 @@ function microovn_ovndb_server_id() {
     echo "${full_sid:0:4}"
 }
 
+# microovn_wait_ovndb_state CONTAINER NBSB STATE TIMEOUT
+#
+# From the point of view of CONTAINER, wait until the 'nb' or 'sb' database as
+# represented by NBSB reaches STATE, waiting a maximum of TIMEOUT seconds.
+function microovn_wait_ovndb_state() {
+    local container=$1; shift
+    local nbsb=$1; shift
+    local state=$1; shift
+    local timeout=$1; shift
+
+    local schema_name
+    schema_name=$(_ovn_schema_name "$nbsb")
+
+    lxc_exec "$container" \
+        "timeout ${timeout} microovn.ovsdb-client wait \
+         unix:/var/snap/microovn/common/run/ovn/ovn${nbsb}_db.sock \
+         ${schema_name} ${state}"
+}
+
 # microovn_get_cluster_services CONTAINER
 #
 # Print MicroOVN services for CONTAINER from the point of view of CONTAINER.


### PR DESCRIPTION
The upgrade test currently performs an upgrade of all nodes in quick succession, and then immediately runs tests.  This leads to spurious errors because the database clusters may or may not have settled on a new leader after all nodes being restarted.

Use `ovsdb-client` to check that each member of database cluster is connected prior to continuning with the test.