### PR TITLE
[branch-22.03] handle switch and chassis services on stop/refresh

### DIFF
--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# NOTE(fnordahl): tell the ovn-controller to exit without cleaning up flows nor
+# SB DB state on refresh.
+${SNAP}/commands/ovn-appctl exit --restart || true
+
 # Note (mkalcok): `microovn.switch` service, by default, stops OVS
 # vswitch daemon with `--cleanup` flag that releases datapath
 # resources like ports and bridges. This hook prevents such behavior

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Note (mkalcok): `microovn.switch` service, by default, stops OVS
+# vswitch daemon with `--cleanup` flag that releases datapath
+# resources like ports and bridges. This hook prevents such behavior
+# by stopping the daemon without `--cleanup` flag during the snap
+# refresh.
+
+${SNAP}/commands/ovs-appctl exit || true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,7 +74,7 @@ apps:
     command: commands/switch.start
     daemon: simple
     install-mode: disable
-    refresh-mode: endure
+    stop-command: commands/ovs-appctl exit --cleanup
     plugs:
       - firewall-control
       - hardware-observe

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ apps:
     command: commands/chassis.start
     daemon: simple
     install-mode: disable
+    stop-command: commands/chassis.stop
     plugs:
       - network
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,7 +74,7 @@ apps:
     command: commands/switch.start
     daemon: simple
     install-mode: disable
-    stop-command: commands/ovs-appctl exit --cleanup
+    stop-command: commands/switch.stop
     plugs:
       - firewall-control
       - hardware-observe

--- a/snapcraft/commands/chassis.stop
+++ b/snapcraft/commands/chassis.stop
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eux
+
+export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
+export OVN_RUNDIR="${SNAP_COMMON}/run/ovn"
+
+# Stop the OVN controller
+"${SNAP}/share/ovn/scripts/ovn-ctl" stop_controller

--- a/snapcraft/commands/switch.stop
+++ b/snapcraft/commands/switch.stop
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+export OVS_RUNDIR="${SNAP_COMMON}/run/switch"
+
+# Stop vswitchd
+"${SNAP}/commands/ovs-appctl" exit --cleanup
+"${SNAP}/share/openvswitch/scripts/ovs-ctl" stop

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -1,0 +1,1 @@
+test_helper/bats/lifecycle.bats

--- a/tests/test_helper/bats/lifecycle.bats
+++ b/tests/test_helper/bats/lifecycle.bats
@@ -1,0 +1,63 @@
+# This is a bash shell fragment -*- bash -*-
+
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 1)
+    export TEST_CONTAINERS
+    launch_containers jammy $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+}
+
+teardown_file() {
+    delete_containers $TEST_CONTAINERS
+}
+
+setup() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-support/load.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+
+    # Trim trailing whitespace from a variable with only single container
+    TEST_CONTAINER="$(echo -e "${TEST_CONTAINERS}" | sed -e 's/[[:space:]]*$//')"
+    export TEST_CONTAINER
+}
+
+teardown() {
+    lxc_exec "$TEST_CONTAINER" "snap remove microovn" || true
+}
+
+@test "Cleanup OVS datapaths on snap removal" {
+    # Verify that removal of MicroOVN snap cleans up DP resources
+
+    # The tests will need external `ovs-dpctl` command to check DPs after
+    # microovn removal.
+    lxc_exec "$TEST_CONTAINER" "DEBIAN_FRONTEND=noninteractive apt install -yqq openvswitch-switch"
+
+    echo "Checking datapaths on container '$TEST_CONTAINER' before MicroOVN installation."
+    run lxc_exec "$TEST_CONTAINER" "ovs-dpctl dump-dps | wc -l"
+    assert_output "0"
+
+    install_microovn "$MICROOVN_SNAP_PATH" "$TEST_CONTAINER"
+    bootstrap_cluster "$TEST_CONTAINER"
+
+    echo "Checking datapaths on container '$TEST_CONTAINER' after MicroOVN bootstrap."
+    run lxc_exec "$TEST_CONTAINER" "ovs-dpctl dump-dps | wc -l"
+    assert_output "1"
+
+    echo "Removing MicroOVN snap."
+    run lxc_exec "$TEST_CONTAINER" "snap remove microovn"
+
+    echo "Checking datapaths on container '$TEST_CONTAINER' after MicroOVN removal."
+    run lxc_exec "$TEST_CONTAINER" "ovs-dpctl dump-dps | wc -l"
+    assert_output "0"
+}

--- a/tests/test_helper/bats/upgrade.bats
+++ b/tests/test_helper/bats/upgrade.bats
@@ -18,6 +18,17 @@ setup() {
 @test "Verify that currently released snap can be upgraded" {
     echo "# Upgrading MicroOVN from revision $MICROOVN_SNAP_REV" >&3
     install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+
+    for container in $TEST_CONTAINERS; do
+        local container_services
+        container_services=$(microovn_get_cluster_services "$container")
+        if [[ "$container_services" != *"central"* ]]; then
+            continue
+        fi
+        microovn_wait_ovndb_state "$container" nb connected 15
+        microovn_wait_ovndb_state "$container" sb connected 15
+    done
+
     perform_manual_upgrade_steps $TEST_CONTAINERS
     local cluster_test_filename="${ABS_TOP_TEST_DIRNAME=}test_helper/bats/post_upgrade_cluster.bats"
     local tls_test_filename="${ABS_TOP_TEST_DIRNAME=}test_helper/bats/post_upgrade_tls.bats"

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -224,6 +224,25 @@ function microovn_ovndb_server_id() {
     echo "${full_sid:0:4}"
 }
 
+# microovn_wait_ovndb_state CONTAINER NBSB STATE TIMEOUT
+#
+# From the point of view of CONTAINER, wait until the 'nb' or 'sb' database as
+# represented by NBSB reaches STATE, waiting a maximum of TIMEOUT seconds.
+function microovn_wait_ovndb_state() {
+    local container=$1; shift
+    local nbsb=$1; shift
+    local state=$1; shift
+    local timeout=$1; shift
+
+    local schema_name
+    schema_name=$(_ovn_schema_name "$nbsb")
+
+    lxc_exec "$container" \
+        "timeout ${timeout} microovn.ovsdb-client wait \
+         unix:/var/snap/microovn/common/run/ovn/ovn${nbsb}_db.sock \
+         ${schema_name} ${state}"
+}
+
 # microovn_get_cluster_services CONTAINER
 #
 # Print MicroOVN services for CONTAINER from the point of view of CONTAINER.


### PR DESCRIPTION
The upgrade test currently performs an upgrade of all nodes in quick succession, and then immediately runs tests.  This leads to spurious errors because the database clusters may or may not have settled on a new leader after all nodes being restarted.

Use `ovsdb-client` to check that each member of database cluster is connected prior to continuning with the test.

Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>
(cherry picked from commit c6eb8d494d54bb7f92c370307f6d39274967bef6)