### PR TITLE
snap: Fix doc build.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -288,7 +288,11 @@ parts:
     plugin: nil
     source: docs/
     build-packages:
-      - python3.11-venv
+      - libpython3-dev
+      - libxml2-dev
+      - libxslt1-dev
+      - make
+      - python3-venv
     override-build: |
       set -ex
       make .sphinx/venv


### PR DESCRIPTION
On non-x86/arm64 architectures the doc build currently fails due to prebuilt python wheels not being available.

Add the missing build dependencies.

Use the `python3-venv` metapackage instead of specifying the specific version.