### PR TITLE
[branch-22.03] snap: Fix doc build.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -280,7 +280,11 @@ parts:
     plugin: nil
     source: docs/
     build-packages:
-      - python3.10-venv
+      - libpython3-dev
+      - libxml2-dev
+      - libxslt1-dev
+      - make
+      - python3-venv
     override-build: |
       set -ex
       make install


### PR DESCRIPTION
On non-x86/arm64 architectures the doc build currently fails due to prebuilt python wheels not being available.

Add the missing build dependencies.

Use the `python3-venv` metapackage instead of specifying the specific version.

Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>
(cherry picked from commit 26677141e2dc3ac8cd9d1876cdb025b0ac016d21)

Conflicts:
	snap/snapcraft.yaml