### PR TITLE
[branch-22.03] Doc: Update TLS upgrade steps to restat northd

### DIFF
--- a/docs/how-to/tls.rst
+++ b/docs/how-to/tls.rst
@@ -139,7 +139,10 @@ plaintext to TLS:
 
 2. run ``microovn certificates regenerate-ca`` on one of the cluster members
 
-3. run ``sudo snap restart microovn.daemon`` on **all** cluster members
+3. run ``sudo snap restart microovn.daemon`` on **all** cluster members. Allow
+   commands to complete before proceeding to the next step.
+
+4. run ``sudo snap restart microovn.ovn-northd`` on **all** cluster members
 
 Once this is done, OVN API services throughout the cluster will start listening
 on TLS-secured ports. However, the process is not complete yet because OVN


### PR DESCRIPTION
In previous MicroOVN versions, restarting `microovn.daemon` would trigger restart of `northd` service as well. This is no longer the case, so the step must be performed manually.

Signed-off-by: Martin Kalcok <martin.kalcok@canonical.com>
(cherry picked from commit 536ee242394bd093a94a0d8ecf72f789a28cf534)