### PR TITLE
[branch-22.03] docs/logs: Fix typo in command example.

### DIFF
--- a/docs/how-to/logs.rst
+++ b/docs/how-to/logs.rst
@@ -4,19 +4,34 @@ Accessing logs
 
 The :ref:`MicroOVN services` provide logs as part of their normal operation.
 
-By default they are provided through the systemd journal.
+By default they are provided through the systemd journal, and can be accessed
+through the use of the ``journalctl`` or ``snap logs`` commands.
 
-This is how you can access the logs of the ``microovn.chassis`` service:
-
-.. code-block:: none
-
-   journalctl -u microovn.chassis
-
-This is how you can view a live log display for the same service:
+This is how you can access the logs of the ``microovn.chassis`` service using
+the ``snap logs`` command:
 
 .. code-block:: none
 
-   journalctl -f -u microovn.chassis
+   snap logs microovn.chassis
+
+and using the ``journalctl`` command:
+
+.. code-block:: none
+
+   journalctl -u snap.microovn.chassis
+
+This is how you can view a live log display for the same service using
+the ``snap logs`` command:
+
+.. code-block:: none
+
+   snap logs -f microovn.chassis
+
+and using the ``journalctl`` command:
+
+.. code-block:: none
+
+   journalctl -f -u snap.microovn.chassis
 
 Log files
 ---------


### PR DESCRIPTION
The provided command example omits the `snap.` prefix for the ``journalctl`` command.

For the sake of completeness provide examples for using both the ``snap logs`` command, where the `snap.` prefix is not needed, and the ``journalctl`` command.

Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>
(cherry picked from commit f53940dbdc0108ab3b0ea14d3b294d7ccb519def)