### PR TITLE
snap: Add ovn-api & ovn-chassis content interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,21 @@ description: |-
 
 confinement: strict
 
+slots:
+  ovn-api:
+    interface: content
+    source:
+      read:
+        - "$SNAP_COMMON/data/pki/client-cert.pem"
+        - "$SNAP_COMMON/data/pki/client-privkey.pem"
+        - "$SNAP_COMMON/data/pki/cacert.pem"
+        - "$SNAP_COMMON/data/ovn.env"
+  ovn-chassis:
+    interface: content
+    source:
+      write:
+        - "$SNAP_COMMON/run/switch"
+
 hooks:
   install:
     plugs:


### PR DESCRIPTION
Adds a `content` type snap interface so projects like LXD and MicroCloud can hook into MicroOVN and access the underlying OVN.

This will allow snapd to automatically share `/var/snap/microovn/common/data` and `/var/snap/microovn/common/run` with LXD, or any other snap that expects the `ovn-conf` interface from the same publisher.

https://snapcraft.io/docs/content-interface