### PR TITLE
microovn/ovn: support OVS `ovn-encap-ip` configuration from external initConfig

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -45,3 +45,6 @@ bugfixes
 backport
 devel
 YY
+hostname
+Geneve
+Virtualization

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -13,3 +13,4 @@ a basic understanding of OVN.
    downscaling
    logs
    major-upgrades
+   ovn-underlay

--- a/docs/how-to/ovn-underlay.rst
+++ b/docs/how-to/ovn-underlay.rst
@@ -1,0 +1,65 @@
+===================================
+Create  custom OVN underlay network
+===================================
+
+The underlay network is the physical network infrastructure that provides connectivity between the nodes in an OVN deployment and is responsible for carrying encapsulated traffic between OVN components through Geneve (`Generic Network Virtualization Encapsulation`) tunnels.
+This allows the virtual network traffic to be transported over the physical underlay network.
+Now, by default, MicroOVN uses the hostname of a cluster member as a Geneve endpoint to set up the underlay network, but it is also possible to use custom Geneve endpoints for the cluster members.
+
+
+Set up the underlay network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To tell MicroOVN to use the underlay network, you need to provide the IP address of the underlay network interface on each node.
+Let us assume that we want to create a three-node OVN cluster and that each node has a dedicated interface ``eth1`` with an IP address. Let says that ``10.0.1.{2,3,4}`` are the respective addresses on the ``eth1`` interface on each node.
+You can set the underlay network IP address in the :command:`init` :
+
+.. code-block:: none
+
+   microovn init
+
+Example of the interaction:
+
+.. code-block:: none
+
+   root@micro1:~# microovn init
+   Please choose the address MicroOVN will be listening on [default=10.242.68.93]:
+   Would you like to create a new MicroOVN cluster? (yes/no) [default=no]: yes
+   Please choose a name for this system [default=micro1]:
+   Would you like to define a custom encapsulation IP address for this member? (yes/no) [default=no]: yes
+   Please enter the custom encapsulation IP address for this member: 10.0.1.2
+   Would you like to add additional servers to the cluster? (yes/no) [default=no]: yes
+   What's the name of the new MicroOVN server? (empty to exit): micro2
+   eyJzZWNyZXQiOiJmOWU1OWU0N2Q1M2E0ZjJlYTYzNWYwMzIzYTE5ZTgyMjEyMzA3ZmJmY2U5OTRiOTk3NzQ4ZTAyM2VmOGEyN2MyIiwiZmluZ2VycHJpbnQiOiJlZGY0MzEzY2ZkOWFiMTdmYWIwZTZkMmE3MWZiNGZlM2U5M2RjZTBjNzNhYTQ4NWI3ZTk2Zjk2YzBhZmZlOWU2Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuMjQyLjY4LjkzOjY0NDMiXX0=
+   What's the name of the new MicroOVN server? (empty to exit): micro3
+   eyJzZWNyZXQiOiI5MWYzODUyZTA4ZjQyOWQxNGE2Y2JiZWI0NGNmODkyMjRjNzUzZjU1NjYzYTY3MjE5ZjZkMmVhOGM0MTdhM2YxIiwiZmluZ2VycHJpbnQiOiJlZGY0MzEzY2ZkOWFiMTdmYWIwZTZkMmE3MWZiNGZlM2U5M2RjZTBjNzNhYTQ4NWI3ZTk2Zjk2YzBhZmZlOWU2Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuMjQyLjY4LjkzOjY0NDMiXX0=
+   What's the name of the new MicroOVN server? (empty to exit):
+
+   root@micro2:~# microovn init
+   Please choose the address MicroOVN will be listening on [default=10.242.68.13]:
+   Would you like to create a new MicroOVN cluster? (yes/no) [default=no]: no
+   Please enter your join token: eyJzZWNyZXQiOiJmOWU1OWU0N2Q1M2E0ZjJlYTYzNWYwMzIzYTE5ZTgyMjEyMzA3ZmJmY2U5OTRiOTk3NzQ4ZTAyM2VmOGEyN2MyIiwiZmluZ2VycHJpbnQiOiJlZGY0MzEzY2ZkOWFiMTdmYWIwZTZkMmE3MWZiNGZlM2U5M2RjZTBjNzNhYTQ4NWI3ZTk2Zjk2YzBhZmZlOWU2Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuMjQyLjY4LjkzOjY0NDMiXX0=
+   Would you like to define a custom encapsulation IP address for this member? (yes/no) [default=no]: yes
+   Please enter the custom encapsulation IP address for this member: 10.0.1.3
+
+   root@micro3:~# microovn init
+   Please choose the address MicroOVN will be listening on [default=10.242.68.170]:
+   Would you like to create a new MicroOVN cluster? (yes/no) [default=no]:
+   Please enter your join token: eyJzZWNyZXQiOiI5MWYzODUyZTA4ZjQyOWQxNGE2Y2JiZWI0NGNmODkyMjRjNzUzZjU1NjYzYTY3MjE5ZjZkMmVhOGM0MTdhM2YxIiwiZmluZ2VycHJpbnQiOiJlZGY0MzEzY2ZkOWFiMTdmYWIwZTZkMmE3MWZiNGZlM2U5M2RjZTBjNzNhYTQ4NWI3ZTk2Zjk2YzBhZmZlOWU2Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuMjQyLjY4LjkzOjY0NDMiXX0=
+   Would you like to define a custom encapsulation IP address for this member? (yes/no) [default=no]: yes
+   Please enter the custom encapsulation IP address for this member: 10.0.1.4
+
+Now, the MicroOVN cluster is configured to use the underlay network with the IP addresses ``10.0.1.{2,3,4}`` on each node as tunnel endpoint for the encapsulated traffic.
+To verify that the underlay network is correctly configured, you can check the IP of OVN Geneve tunnel endpoint on each node:
+
+.. code-block:: none
+
+   root@micro1:~# microovn.ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
+   "10.0.1.2"
+
+   root@micro2:~# microovn.ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
+   "10.0.1.3"
+
+   root@micro3:~# microovn.ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
+   "10.0.1.4"
+

--- a/tests/init_cluster_custom_encap.bats
+++ b/tests/init_cluster_custom_encap.bats
@@ -1,0 +1,48 @@
+# This is a bash shell fragment -*- bash -*-
+
+load "test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+setup() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS and EAST_WEST_ADDRS are populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+}
+
+@test "Check that custom IP encapsulation works" {
+    local container_services
+    EAST_WEST_ADDRS=()
+    while IFS= read -r line; do
+        EAST_WEST_ADDRS+=("$line")
+    done < "$BATS_TMPDIR/east_west_addrs.txt"
+
+    for pair in "${EAST_WEST_ADDRS[@]}"; do
+        IFS='@' read -r container ip_east_west <<< "$pair"
+
+        container_services=$(microovn_get_cluster_services "$container")
+        if [[ "$container_services" != *"chassis"* ]]; then
+            echo "Skip $container, no chassis services" >&3
+            continue
+        fi
+
+        run lxc_exec \
+            "$container" \
+            "microovn.ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip"
+        assert_output -p $ip_east_west
+    done
+
+    local test_filename=tests/init_cluster
+    test_filename+=$(test_is_ipv6_test && echo _ipv6 || true)
+    test_filename+=.bats
+
+    # Run the cluster test with the custom IP encapsulation
+    run bats -F junit $test_filename
+
+    echo "# $output" >&3
+    echo "#" >&3
+}

--- a/tests/init_cluster_custom_encap_ipv6.bats
+++ b/tests/init_cluster_custom_encap_ipv6.bats
@@ -1,0 +1,1 @@
+init_cluster_custom_encap.bats

--- a/tests/scaleup_cluster.bats
+++ b/tests/scaleup_cluster.bats
@@ -39,13 +39,13 @@ teardown() {
                   $container \
                   "$(test_is_ipv6_test && echo inet6 || echo inet)")
         if [ $i -eq 1 ]; then
-            microovn_init_create_cluster "$container" "$addr"
+            microovn_init_create_cluster "$container" "$addr" ""
         else
             local token
             token=$(microovn_cluster_get_join_token \
                         "${containers[0]}" \
                         "$container")
-            microovn_init_join_cluster "$container" "$addr" "$token"
+            microovn_init_join_cluster "$container" "$addr" "$token" ""
         fi
         starttimes_ovn_controller[$container]=$(\
             microovn_wait_for_service_starttime $container ovn-controller)

--- a/tests/test_helper/lxd.bash
+++ b/tests/test_helper/lxd.bash
@@ -8,6 +8,90 @@ function launch_containers() {
     done
 }
 
+function create_lxd_network() {
+    local bridge_name=$1; shift
+
+    lxc network create "$bridge_name" ipv6.address=auto > /dev/null 2>&1
+
+    local ipv4_subnet
+    local ipv6_subnet
+
+    ipv4_subnet=$(lxc network get "$bridge_name" ipv4.address)
+    ipv6_subnet=$(lxc network get "$bridge_name" ipv6.address)
+
+    echo "$ipv4_subnet|$ipv6_subnet"
+}
+
+function delete_lxd_network() {
+    local network_name=$1; shift
+
+    lxc network delete "$network_name"
+}
+
+function connect_containers_to_network_ipv4() {
+    local containers=$1; shift
+    local network_name=$1; shift
+    local ipv4_subnet=$1; shift
+
+    local base_ip
+    local ip_counter
+
+    base_ip=$(echo $ipv4_subnet | cut -d '/' -f 1)  # Base IP of the subnet
+    ip_counter=2  # Start assigning from the second IP in the subnet
+
+    output=""
+    for container in $containers; do
+        # Add a NIC to the container and attach it to the network
+        lxc config device add "${container}" eth1 nic nictype=bridged parent="${network_name}" > /dev/null 2>&1
+
+        # Calculate the next IP address
+        local ip="${base_ip%.*}.$ip_counter"
+        ((ip_counter++))
+
+        # Get the first interface that is down
+        # and configure it with an IPv4 address that
+        # is part of the ipv4_subnet
+        down_virtIface=$(lxc_exec "${container}" "ip link show | grep 'state DOWN' | awk -F': ' '{print $2}' | head -n 1")
+        down_iface="${down_virtIface%@*}"
+        lxc_exec "${container}" "ip link set ${down_iface} up && ip addr add $ip/32 dev ${down_iface}"
+
+        output+="$container@$ip,"
+    done
+
+    echo "$output"
+}
+
+function connect_containers_to_network_ipv6() {
+    local containers=$1; shift
+    local network_name=$1; shift
+    local ipv6_subnet=$1; shift
+
+    local base_ip
+    local ip_counter
+
+    base_ip=$(echo "$ipv6_subnet" | sed 's/[^:]*\/.*$//')
+    ip_counter=2  # Start assigning from the second IP in the subnet
+
+    output=""
+    for container in $containers; do
+        # Add a NIC to the container and attach it to the network
+        lxc config device add "${container}" eth1 nic nictype=bridged parent="${network_name}" > /dev/null 2>&1
+
+        # Calculate the next IP address
+        local ip="${base_ip}$ip_counter"
+        ((ip_counter++))
+
+        # Get the first interface that is down
+        down_virtIface=$(lxc_exec ${container} "ip link show | grep 'state DOWN' | awk -F': ' '{print $2}' | head -n 1")
+        down_iface="${down_virtIface%@*}"
+        lxc_exec "${container}" "ip link set ${down_iface} up && ip addr add $ip/128 dev ${down_iface}"
+
+        output+="$container@$ip,"
+    done
+
+    echo "$output"
+}
+
 function wait_containers_ready() {
     local containers=$*
 

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -114,6 +114,28 @@ function wait_ovn_services() {
 function microovn_init_create_cluster() {
     local container=$1; shift
     local address=$1; shift
+    local custom_encapsulation_ip=$1; shift
+
+    custom_encapsulation_ip_dialog=""
+    if [ -n "$custom_encapsulation_ip" ]; then
+        custom_encapsulation_ip_dialog=$(cat <<EOF
+expect "Would you like to define a custom encapsulation IP address for this member?" {
+    send "yes\n"
+}
+
+expect "Please enter the custom encapsulation IP address for this member" {
+    send "$custom_encapsulation_ip\n"
+}
+EOF
+)
+    else
+        custom_encapsulation_ip_dialog=$(cat <<EOF
+expect "Would you like to define a custom encapsulation IP address for this member?" {
+    send "\n"
+}
+EOF
+)
+    fi
 
     cat << EOF | lxc_exec "$container" "expect -"
 spawn "sudo" "microovn" "init"
@@ -127,8 +149,10 @@ expect "Would you like to create a new MicroOVN cluster?" {
 }
 
 expect "Please choose a name for this system" {
-    send "\n"
+    send "$container\n"
 }
+
+$custom_encapsulation_ip_dialog
 
 expect "Would you like to add additional servers to the cluster?" {
     send "no\n"
@@ -142,6 +166,29 @@ function microovn_init_join_cluster() {
     local container=$1; shift
     local address=$1; shift
     local token=$1; shift
+    local custom_encapsulation_ip=$1; shift
+
+    custom_encapsulation_ip_dialog=""
+    if [ -n "$custom_encapsulation_ip" ]; then
+        custom_encapsulation_ip_dialog=$(cat <<EOF
+expect "Would you like to define a custom encapsulation IP address for this member?" {
+    send "yes\n"
+}
+
+expect "Please enter the custom encapsulation IP address for this member" {
+    send "$custom_encapsulation_ip\n"
+}
+EOF
+)
+    else
+        custom_encapsulation_ip_dialog=$(cat <<EOF
+expect "Would you like to define a custom encapsulation IP address for this member?" {
+    send "\n"
+}
+EOF
+)
+    fi
+
     cat << EOF | lxc_exec "$container" "expect -"
 spawn "sudo" "microovn" "init"
 
@@ -156,6 +203,8 @@ expect "Would you like to create a new MicroOVN cluster?" {
 expect "Please enter your join token:" {
     send "$token\n"
 }
+
+$custom_encapsulation_ip_dialog
 
 expect eof
 EOF

--- a/tests/test_helper/setup_teardown/init_cluster.bash
+++ b/tests/test_helper/setup_teardown/init_cluster.bash
@@ -18,12 +18,12 @@ setup_file() {
                "$(test_is_ipv6_test && echo inet6 || echo inet)")
         assert [ -n "$addr" ]
         if [ -z "$leader" ]; then
-            microovn_init_create_cluster "$container" "$addr"
+            microovn_init_create_cluster "$container" "$addr" ""
             leader="$container"
         else
             local token
             token=$(microovn_cluster_get_join_token "$leader" "$container")
-            microovn_init_join_cluster "$container" "$addr" "$token"
+            microovn_init_join_cluster "$container" "$addr" "$token" ""
         fi
     done
 }

--- a/tests/test_helper/setup_teardown/init_cluster_custom_encap.bash
+++ b/tests/test_helper/setup_teardown/init_cluster_custom_encap.bash
@@ -1,0 +1,48 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
+    export TEST_CONTAINERS
+    launch_containers jammy $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+
+    # Create a dedicated bridge for the east-west traffic
+    network_output=$(create_lxd_network "br-east-west")
+    ipv4_subnet=$(echo "$network_output" | cut -d'|' -f1)
+
+    # Give each container an IP address from the subnet
+    east_west_ips_to_containers=$(connect_containers_to_network_ipv4 "$TEST_CONTAINERS" "br-east-west" $ipv4_subnet)
+    IFS=',' read -ra east_west_addrs <<< "$east_west_ips_to_containers"
+    EAST_WEST_ADDRS=("${east_west_addrs[@]}")
+    printf '%s\n' "${EAST_WEST_ADDRS[@]}" > "$BATS_TMPDIR/east_west_addrs.txt"
+
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    local leader
+    for pair in "${EAST_WEST_ADDRS[@]}"; do
+        IFS='@' read -r container ip_east_west <<< "$pair"
+
+        local addr
+        addr=$(container_get_default_ip "$container" \
+               "$(test_is_ipv6_test && echo inet6 || echo inet)")
+        assert [ -n "$addr" ]
+        if [ -z "$leader" ]; then
+            microovn_init_create_cluster "$container" "$addr" "$ip_east_west"
+            leader="$container"
+        else
+            local token
+            token=$(microovn_cluster_get_join_token "$leader" "$container")
+            microovn_init_join_cluster "$container" "$addr" "$token" "$ip_east_west"
+        fi
+    done
+}
+
+teardown_file() {
+    delete_containers $TEST_CONTAINERS
+    delete_lxd_network "br-east-west"
+    rm -f "$BATS_TMPDIR/east_west_addrs.txt"
+}

--- a/tests/test_helper/setup_teardown/init_cluster_custom_encap_ipv6.bash
+++ b/tests/test_helper/setup_teardown/init_cluster_custom_encap_ipv6.bash
@@ -1,0 +1,49 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
+    export TEST_CONTAINERS
+    launch_containers jammy $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+
+    # Create a dedicated bridge for the east-west traffic
+    network_output=$(create_lxd_network "br-east-west")
+    ipv6_subnet=$(echo "$network_output" | cut -d'|' -f2)
+
+    # Give each container an IP address from the subnet
+    east_west_ips_to_containers=$(connect_containers_to_network_ipv6 "$TEST_CONTAINERS" "br-east-west" $ipv6_subnet)
+
+    IFS=',' read -ra east_west_addrs <<< "$east_west_ips_to_containers"
+    EAST_WEST_ADDRS=("${east_west_addrs[@]}")
+    printf '%s\n' "${EAST_WEST_ADDRS[@]}" > "$BATS_TMPDIR/east_west_addrs.txt"
+
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    local leader
+    for pair in "${EAST_WEST_ADDRS[@]}"; do
+        IFS='@' read -r container ip_east_west <<< "$pair"
+
+        local addr
+        addr=$(container_get_default_ip "$container" \
+               "$(test_is_ipv6_test && echo inet6 || echo inet)")
+        assert [ -n "$addr" ]
+        if [ -z "$leader" ]; then
+            microovn_init_create_cluster "$container" "$addr" "$ip_east_west"
+            leader="$container"
+        else
+            local token
+            token=$(microovn_cluster_get_join_token "$leader" "$container")
+            microovn_init_join_cluster "$container" "$addr" "$token" "$ip_east_west"
+        fi
+    done
+}
+
+teardown_file() {
+    delete_containers $TEST_CONTAINERS
+    delete_lxd_network "br-east-west"
+    rm -f "$BATS_TMPDIR/east_west_addrs.txt"
+}


### PR DESCRIPTION
This is needed by: https://github.com/canonical/microcloud/pull/245 