### PR TITLE
docs: Set up standard home page - take II

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,43 @@ automating much of the deployment process. It also provides a fully fledged,
 unrestricted OVN deployment that is suitable for both development and
 production environments.
 
+---------
+
+In this documentation
+---------------------
+
+..  grid:: 1 1 2 2
+
+   ..  grid-item:: :doc:`Tutorial <tutorial/index>`
+
+       **Start here**: a hands-on introduction to MicroOVN for new users
+
+   ..  grid-item:: :doc:`How-to guides <how-to/index>`
+
+      **Step-by-step guides** covering key operations and common tasks
+
+.. grid:: 1 1 2 2
+
+   .. grid-item:: :doc:`Reference <reference/index>`
+
+      **Technical information** - specifications, APIs, architecture
+
+---------
+
+Project and community
+---------------------
+
+MicroOVN is a member of the Ubuntu family. It’s an open source project that
+warmly welcomes community projects, contributions, suggestions, fixes and
+constructive feedback.
+
+* We follow the Ubuntu community `Code of conduct`_
+* Contribute to the project on `GitHub`_ (documentation contributions go under
+  the :file:`docs` directory)
+* GitHub is also used as our bug tracker
+* To speak with us, you can find us in our `MicroOVN Discourse`_ category. Use
+  the `Support`_ sub-category for technical assistance.
+
 .. toctree::
    :hidden:
    :maxdepth: 2
@@ -32,3 +69,7 @@ production environments.
 .. LINKS
 .. _strictly confined snap: https://snapcraft.io/docs/snap-confinement
 .. _Open Virtual Network: https://www.ovn.org/en/
+.. _Code of conduct: https://ubuntu.com/community/ethos/code-of-conduct
+.. _GitHub: https://github.com/canonical/microovn
+.. _MicroOVN Discourse: https://discourse.ubuntu.com/c/microovn/160
+.. _Support: https://discourse.ubuntu.com/c/microovn/support/164


### PR DESCRIPTION
This provides a standard docs home page for the MicroOVN documentation.