### PR TITLE
[branch-22.03] Backport snap content interfaces

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,21 @@ description: |-
 
 confinement: strict
 
+slots:
+  ovn-api:
+    interface: content
+    source:
+      read:
+        - "$SNAP_COMMON/data/pki/client-cert.pem"
+        - "$SNAP_COMMON/data/pki/client-privkey.pem"
+        - "$SNAP_COMMON/data/pki/cacert.pem"
+        - "$SNAP_COMMON/data/ovn.env"
+  ovn-chassis:
+    interface: content
+    source:
+      write:
+        - "$SNAP_COMMON/run/switch"
+
 hooks:
   install:
     plugs:


### PR DESCRIPTION
Backports using snap content interfaces to share ovn-specific information with other snaps (namely LXD) from #107  into branch-22.03