### PR TITLE
CI: Install snapcraft from latest/edge on main branch.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,15 @@ jobs:
     runs-on: [self-hosted, linux, X64, jammy, large]
     env:
       MICROOVN_SNAP: microovn.snap
+      # The `base_ref` will only be set for PR and contain the name of the
+      # target branch.  The `ref_name` will be correct for the final push
+      # check after a PR is merged.
+      #
+      # This setup may lead to failures on push to arbitrarily named branches
+      # on a fork, but that is a price worth paying.
+      #
+      # Contributors can raise a draft PR to get accurate results.
+      POSSIBLE_TARGET_BRANCH: "${{ github.base_ref || github.ref_name }}"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -43,7 +52,11 @@ jobs:
           sudo snap refresh
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
-          sudo snap install snapcraft --classic
+          test $POSSIBLE_TARGET_BRANCH = main && \
+              export SNAPCRAFT_CHANNEL=latest/edge
+          sudo snap install snapcraft \
+              --channel "${SNAPCRAFT_CHANNEL:-latest/stable}" \
+              --classic
 
       - name: Build snap
         run: make $MICROOVN_SNAP

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -228,7 +228,7 @@ parts:
         pkg_version=$(
             dpkg-deb -f \
             $CRAFT_PART_SRC/../stage_packages/ovn-host*.deb \
-            Version | sed -rne 's/([0-9.]+)[-+].*$$/\1/p')
+            Version | sed -rne 's/([0-9.]+)[-+~].*$$/\1/p')
         git_version=$(
             git -C $CRAFT_PROJECT_DIR describe \
                 --always \


### PR DESCRIPTION
The main branch tracks the current Ubuntu development release, this gives us early warning on coming issues for future releases which we can use both to prepare and to feed issues to projects we depend on early.

We now have a concrete example where builds are blocked and a fix is available on the snapcraft latest/edge channel.

Use the latest/edge channel for snapcraft on main branch, with fallback to the latest/stable channel on other branches.

The fallback minimizes the manual work required when branching for future stable releases.