### PR TITLE
snap: Use only directories for ovn-api content interface

### DIFF
--- a/microovn/ovn/paths/paths.go
+++ b/microovn/ovn/paths/paths.go
@@ -47,7 +47,7 @@ func SwitchDataDir() string {
 
 // OvnEnvFile returns path to the file used to configure env variables for OVN commands
 func OvnEnvFile() string {
-	return filepath.Join(dataDir, "ovn.env")
+	return filepath.Join(EnvDir(), "ovn.env")
 }
 
 // OvnNBDatabaseSock returns path to the local unix socket used by Northbound OVN database
@@ -78,6 +78,11 @@ func OvsDatabaseSock() string {
 // PkiDir returns path to the directory that store OVN certificates
 func PkiDir() string {
 	return filepath.Join(dataDir, "pki")
+}
+
+// EnvDir returns path to the directory that store OVN environment variables.
+func EnvDir() string {
+	return filepath.Join(dataDir, "env")
 }
 
 // PkiCaCertFile returns path to CA certificate file
@@ -129,6 +134,7 @@ func RequiredDirs() []string {
 		SwitchDataDir(),
 		LogsDir(),
 		PkiDir(),
+		EnvDir(),
 	}
 }
 

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -2,3 +2,9 @@
 
 mkdir -p $SNAP_COMMON/logs
 cp $SNAP/docs/microovn/how-to/logs.txt $SNAP_COMMON/logs/README
+
+# If we upgraded from snap revision 379 (24.03.0+snap395808ff84) or earlier, ensure we move ovn.env to its own directory before running the start commands.
+if test -e "${SNAP_COMMON}/data/ovn.env" ; then
+  mkdir "${SNAP_COMMON}/data/env" || true
+  mv "${SNAP_COMMON}/data/ovn.env" "${SNAP_COMMON}/data/env/ovn.env"
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,14 +14,16 @@ description: |-
 confinement: strict
 
 slots:
-  ovn-api:
+  ovn-certificates:
     interface: content
     source:
       read:
-        - "$SNAP_COMMON/data/pki/client-cert.pem"
-        - "$SNAP_COMMON/data/pki/client-privkey.pem"
-        - "$SNAP_COMMON/data/pki/cacert.pem"
-        - "$SNAP_COMMON/data/ovn.env"
+        - "$SNAP_COMMON/data/pki"
+  ovn-env:
+    interface: content
+    source:
+      read:
+        - "$SNAP_COMMON/data/env"
   ovn-chassis:
     interface: content
     source:

--- a/snapcraft/commands/chassis.start
+++ b/snapcraft/commands/chassis.start
@@ -2,7 +2,7 @@
 set -eux
 
 # Load the environment
-. "${SNAP_COMMON}/data/ovn.env"
+. "${SNAP_COMMON}/data/env/ovn.env"
 
 # Setup directories
 export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"

--- a/snapcraft/ovn-central.env
+++ b/snapcraft/ovn-central.env
@@ -1,7 +1,7 @@
 # Set of environment variables used by OVN Central services
 
 # Load runtime OVN environment variables
-. "${SNAP_COMMON}/data/ovn.env"
+. "${SNAP_COMMON}/data/env/ovn.env"
 
 # Setup directories
 export OVN_DBDIR="${SNAP_COMMON}/data/central/db"

--- a/snapcraft/ovn.env
+++ b/snapcraft/ovn.env
@@ -1,7 +1,7 @@
 # Set of environment variables for OVN commands
 
 # Load runtime environment variables
-. "${SNAP_COMMON}/data/ovn.env"
+. "${SNAP_COMMON}/data/env/ovn.env"
 
 export OVN_PKI_DIR="${SNAP_COMMON}/data/pki"
 export CA_CERT="${OVN_PKI_DIR}/cacert.pem"

--- a/tests/test_helper/bats/cluster.bats
+++ b/tests/test_helper/bats/cluster.bats
@@ -184,7 +184,7 @@ function _test_db_connection_string() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec \
             "$container" \
-            "grep ^$check_var /var/snap/microovn/common/data/ovn.env"
+            "grep ^$check_var /var/snap/microovn/common/data/env/ovn.env"
         for addr in "${cluster_addresses[@]}"; do
             local expected_addr
             expected_addr=$(print_address $addr)


### PR DESCRIPTION
Sadly, as it turns out, we are not able to specify individual files to a content interface. On the consuming side, each entry will be created as a directory and populated with its contents. The current implementation is resulting in LXD seeing this, where each directory is empty:

```
snap run --shell lxd -c  "aa-exec -p unconfined ls -l /var/snap/lxd/current/microovn/api"
total 16
drwxr-xr-x 2 root root 4096 Feb 26 21:54 cacert.pem
drwxr-xr-x 2 root root 4096 Feb 26 21:54 client-cert.pem
drwxr-xr-x 2 root root 4096 Feb 26 21:54 client-privkey.pem
drwxr-xr-x 2 root root 4096 Feb 26 21:54 ovn.env

```

This isn't just the case with the LXD state directory, the actual source is also overwritten in microovn:
```
ls -l /var/snap/microovn/common/data/pki/
total 12
drwxr-xr-x 2 root root 4096 Feb 26 21:54 cacert.pem
drwxr-xr-x 2 root root 4096 Feb 26 21:54 client-cert.pem
drwxr-xr-x 2 root root 4096 Feb 26 21:54 client-privkey.pem
```

So I've had to include all of `data` into the content interface. The other option here would be to restructure the `data` directory.