### PR TITLE
Support daemon mode for ovn-*bctl commands.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -119,10 +119,12 @@ apps:
     command: commands/ovn-nbctl
     plugs:
       - network
+      - network-bind
   ovn-sbctl:
     command: commands/ovn-sbctl
     plugs:
       - network
+      - network-bind
   ovn-trace:
     command: commands/ovn-trace
     plugs:


### PR DESCRIPTION
When running the ``ovn-nbctl`` and ``ovn-sbctl`` commands with the ``--detach`` argument the binary will daemonize and listen on a unix socket.

To allow this we need to add the ``network-bind`` plug.