### PR TITLE
Ovsdb schema upgrade

### DIFF
--- a/microovn/api/endpoints.go
+++ b/microovn/api/endpoints.go
@@ -15,4 +15,5 @@ var Endpoints = []rest.Endpoint{
 	certificates.IssueCertificatesAllEndpoint,
 	certificates.RegenerateCaEndpoint,
 	ovsdb.ExpectedSchemaVersion,
+	ovsdb.ActiveSchemaVersion,
 }

--- a/microovn/api/endpoints.go
+++ b/microovn/api/endpoints.go
@@ -14,6 +14,7 @@ var Endpoints = []rest.Endpoint{
 	certificates.IssueCertificatesEndpoint,
 	certificates.IssueCertificatesAllEndpoint,
 	certificates.RegenerateCaEndpoint,
-	ovsdb.ExpectedSchemaVersion,
 	ovsdb.ActiveSchemaVersion,
+	ovsdb.AllExpectedSchemaVersions,
+	ovsdb.ExpectedSchemaVersion,
 }

--- a/microovn/api/endpoints.go
+++ b/microovn/api/endpoints.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microovn/microovn/api/ovsdb"
 
 	"github.com/canonical/microovn/microovn/api/certificates"
 )
@@ -13,4 +14,5 @@ var Endpoints = []rest.Endpoint{
 	certificates.IssueCertificatesEndpoint,
 	certificates.IssueCertificatesAllEndpoint,
 	certificates.RegenerateCaEndpoint,
+	ovsdb.ExpectedSchemaVersion,
 }

--- a/microovn/api/ovsdb/schema_version.go
+++ b/microovn/api/ovsdb/schema_version.go
@@ -1,0 +1,64 @@
+package ovsdb
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/microovn/microovn/ovn/ovsdb"
+)
+
+// supportedDBs contains all database types that support reporting of
+// a schema version.
+var supportedDBs = map[string]ovnCmd.OvsdbType{
+	"sb":     ovnCmd.OvsdbTypeSBLocal,
+	"nb":     ovnCmd.OvsdbTypeNBLocal,
+	"switch": ovnCmd.OvsdbTypeSwitchLocal,
+}
+
+// ExpectedSchemaVersion defines endpoints for /1.0/ovsdb/schema/<db-name>/expected
+var ExpectedSchemaVersion = rest.Endpoint{
+	Path: "ovsdb/schema/{db}/expected",
+	Get:  rest.EndpointAction{Handler: getExpectedSchemaVersion, AllowUntrusted: false, ProxyTarget: false},
+}
+
+// getExpectedSchemaVersion implements GET method for /1.0/ovsdb/schema/<db-name>/expected. It returns
+// expected schema version of the specified database on this MicroOVN node. Expected schema version is
+// determined by looking at the schema file that is bundled with OVN/OVS packages.
+// URL variable <db-name> is expected to be one of the keys from supportedDBs.
+func getExpectedSchemaVersion(s *state.State, r *http.Request) response.Response {
+	requestedDB, err := url.PathUnescape(mux.Vars(r)["db"])
+	if err != nil {
+		logger.Errorf("failed to parse requested DB name from url '%s'", r.URL)
+		return response.ErrorResponse(500, "Internal Server Error")
+	}
+	requestedDB = strings.ToLower(requestedDB)
+
+	dbType, ok := supportedDBs[requestedDB]
+
+	if !ok {
+		return response.BadRequest(fmt.Errorf("DB '%s' not supported", requestedDB))
+	}
+
+	dbSpec, err := ovnCmd.NewOvsdbSpec(dbType)
+	if err != nil {
+		logger.Errorf("%s", err)
+		return response.ErrorResponse(500, "Internal Server Error")
+	}
+
+	expectedVersion, err := ovsdb.ExpectedOvsdbSchemaVersion(s, dbSpec)
+	if err != nil {
+		logger.Errorf("failed to get expected OVSDB schema version for '%s' database: %s", dbSpec.FriendlyName, err)
+		return response.ErrorResponse(500, "Internal Server Error")
+	}
+
+	return response.SyncResponse(true, expectedVersion)
+}

--- a/microovn/api/ovsdb/schema_version.go
+++ b/microovn/api/ovsdb/schema_version.go
@@ -10,6 +10,9 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
+	"github.com/canonical/microovn/microovn/api/types"
+	microovnClient "github.com/canonical/microovn/microovn/client"
+	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/gorilla/mux"
 
@@ -30,28 +33,20 @@ var ExpectedSchemaVersion = rest.Endpoint{
 	Get:  rest.EndpointAction{Handler: getExpectedSchemaVersion, AllowUntrusted: false, ProxyTarget: false},
 }
 
+// ActiveSchemaVersion defines endpoints for /1.0/ovsdb/schema/<db-name>/active
+var ActiveSchemaVersion = rest.Endpoint{
+	Path: "ovsdb/schema/{db}/active",
+	Get:  rest.EndpointAction{Handler: getActiveSchemaVersion, AllowUntrusted: false, ProxyTarget: false},
+}
+
 // getExpectedSchemaVersion implements GET method for /1.0/ovsdb/schema/<db-name>/expected. It returns
 // expected schema version of the specified database on this MicroOVN node. Expected schema version is
 // determined by looking at the schema file that is bundled with OVN/OVS packages.
 // URL variable <db-name> is expected to be one of the keys from supportedDBs.
 func getExpectedSchemaVersion(s *state.State, r *http.Request) response.Response {
-	requestedDB, err := url.PathUnescape(mux.Vars(r)["db"])
-	if err != nil {
-		logger.Errorf("failed to parse requested DB name from url '%s'", r.URL)
-		return response.ErrorResponse(500, "Internal Server Error")
-	}
-	requestedDB = strings.ToLower(requestedDB)
-
-	dbType, ok := supportedDBs[requestedDB]
-
-	if !ok {
-		return response.BadRequest(fmt.Errorf("DB '%s' not supported", requestedDB))
-	}
-
-	dbSpec, err := ovnCmd.NewOvsdbSpec(dbType)
-	if err != nil {
-		logger.Errorf("%s", err)
-		return response.ErrorResponse(500, "Internal Server Error")
+	dbSpec, errResponse := parseDbSpec(r)
+	if errResponse != nil {
+		return errResponse
 	}
 
 	expectedVersion, err := ovsdb.ExpectedOvsdbSchemaVersion(s, dbSpec)
@@ -61,4 +56,107 @@ func getExpectedSchemaVersion(s *state.State, r *http.Request) response.Response
 	}
 
 	return response.SyncResponse(true, expectedVersion)
+}
+
+// getActiveSchemaVersion implements GET method for /1.0/ovsdb/schema/<db-name>/active. It returns
+// currently active schema version of a database specified by <db-name>.
+// URL variable <db-name> is expected to be one of the keys from supportedDBs.
+//
+// If the node receives request for Northbound or Southbound DB schema version, but the not is not running
+// these central services, the request will be forwarded to a node that does run them.
+func getActiveSchemaVersion(s *state.State, r *http.Request) response.Response {
+	hasCentral, err := node.HasServiceActive(s, "central")
+	if err != nil {
+		logger.Errorf("failed to check if central is active on this node: %s", err)
+		return response.ErrorResponse(500, "Internal Server Error")
+	}
+
+	dbSpec, errResponse := parseDbSpec(r)
+	if errResponse != nil {
+		return errResponse
+	}
+
+	// If Northbound or Southbound database was requested, but we don't run "central" services,
+	// forward this request to a node that does.
+	if dbSpec.IsCentral && !hasCentral {
+		logger.Info("This node does not run 'central' service. Request will be forwarded.")
+		return forwardActiveSchemaVersion(s, r, dbSpec)
+	}
+
+	activeSchema, err := ovnCmd.OvsdbClient(s, dbSpec, 10, 30, "get-schema-version", dbSpec.SocketURL)
+	if err != nil {
+		logger.Errorf("failed to get active schema version for '%s' database: %s", dbSpec.FriendlyName, err)
+		return response.ErrorResponse(500, "Internal Server Error")
+	}
+
+	return response.SyncResponse(true, strings.TrimSpace(activeSchema))
+}
+
+// forwardActiveSchemaVersion forwards request to get active OVSDB schema version to a host that runs "central"
+// services.
+// Each host that is registered with "central" service is queried until one of the returns non-error response. First
+// successful response is returned to the caller.
+// If none of the "central" nodes return non-error message, this function returns response.ErrorResponse with code 500.
+func forwardActiveSchemaVersion(s *state.State, r *http.Request, dbSpec *ovnCmd.OvsdbSpec) response.Response {
+	centralNodes, err := node.FindService(s, "central")
+	if err != nil {
+		logger.Errorf("failed to find central node: %s", err)
+		return response.ErrorResponse(500, "Internal Server Error")
+	}
+
+	clusterClients, err := s.Cluster(r)
+
+	for _, client_ := range clusterClients {
+		for _, node_ := range centralNodes {
+			clientUrl := client_.URL()
+			clientAddr := fmt.Sprintf("%s:%s", clientUrl.Hostname(), clientUrl.Port())
+			if clientAddr == node_.Address {
+				logger.Infof(
+					"Forwarding request '%s' for active %s schema to %s",
+					r.URL,
+					dbSpec.FriendlyName,
+					node_.Name,
+				)
+				result, err := microovnClient.GetActiveOvsdbSchemaVersion(s.Context, &client_, dbSpec)
+				if err != types.OvsdbSchemaFetchErrorNone {
+					logger.Errorf(
+						"Failed to forward request for active %s schema version to node %s",
+						dbSpec.FriendlyName,
+						node_.Name,
+					)
+				} else {
+					return response.SyncResponse(true, &result)
+				}
+			}
+		}
+	}
+
+	logger.Error("None of the central nodes responded to the forwarded query")
+	return response.ErrorResponse(500, "Internal Server Error")
+}
+
+// parseDbSpec is a helper function that returns OvsdbSpec based on the database name
+// specified in the request's URL variable.
+//
+// For example: If request "r" has URL /schema/sb/active, this function  returns OvsdbSpec based on OvsdbTypeSBLocal.
+func parseDbSpec(r *http.Request) (*ovnCmd.OvsdbSpec, response.Response) {
+	requestedDB, err := url.PathUnescape(mux.Vars(r)["db"])
+	if err != nil {
+		logger.Errorf("failed to parse requested DB name from url '%s'", r.URL)
+		return nil, response.ErrorResponse(500, "Internal Server Error")
+	}
+	requestedDB = strings.ToLower(requestedDB)
+
+	dbType, ok := supportedDBs[requestedDB]
+
+	if !ok {
+		return nil, response.BadRequest(fmt.Errorf("DB '%s' not supported", requestedDB))
+	}
+
+	dbSpec, err := ovnCmd.NewOvsdbSpec(dbType)
+	if err != nil {
+		logger.Errorf("%s", err)
+		return nil, response.ErrorResponse(500, "Internal Server Error")
+	}
+	return dbSpec, nil
 }

--- a/microovn/api/services.go
+++ b/microovn/api/services.go
@@ -7,7 +7,7 @@ import (
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
 
-	"github.com/canonical/microovn/microovn/ovn"
+	"github.com/canonical/microovn/microovn/node"
 )
 
 // /1.0/services endpoint.
@@ -18,7 +18,7 @@ var servicesCmd = rest.Endpoint{
 }
 
 func cmdServicesGet(s *state.State, r *http.Request) response.Response {
-	services, err := ovn.ListServices(s)
+	services, err := node.ListServices(s)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/microovn/api/types/ovsdb.go
+++ b/microovn/api/types/ovsdb.go
@@ -1,0 +1,11 @@
+package types
+
+// OvsdbSchemaFetchError is a collection of error types that can be returned when fetching
+// OVSDB schema version via MicroOVN API.
+type OvsdbSchemaFetchError int
+
+const (
+	OvsdbSchemaFetchErrorNone         OvsdbSchemaFetchError = iota // No error occurred
+	OvsdbSchemaFetchErrorGeneric                                   // General catch-all error that did not fit more specific definition
+	OvsdbSchemaFetchErrorNotSupported                              // API endpoint returned 404, signaling that the node does not support it.
+)

--- a/microovn/api/types/ovsdb.go
+++ b/microovn/api/types/ovsdb.go
@@ -9,3 +9,14 @@ const (
 	OvsdbSchemaFetchErrorGeneric                                   // General catch-all error that did not fit more specific definition
 	OvsdbSchemaFetchErrorNotSupported                              // API endpoint returned 404, signaling that the node does not support it.
 )
+
+// OvsdbSchemaReport is just a collection of OvsdbSchemaVersionResult structs
+type OvsdbSchemaReport = []OvsdbSchemaVersionResult
+
+// OvsdbSchemaVersionResult is a rich representation of a schema result fetch. It encapsulates node's Hostname,
+// OVSDB schema version, and whether there were any error while fetching data from this node.
+type OvsdbSchemaVersionResult struct {
+	Host          string                `json:"host"`
+	SchemaVersion string                `json:"schemaVersion"`
+	Error         OvsdbSchemaFetchError `json:"error"`
+}

--- a/microovn/client/client.go
+++ b/microovn/client/client.go
@@ -86,6 +86,23 @@ func GetExpectedOvsdbSchemaVersion(ctx context.Context, c *client.Client, dbSpec
 	return getOvsdbSchemaVersion(ctx, c, dbSpec, "expected")
 }
 
+// GetAllExpectedOvsdbSchemaVersions returns types.OvsdbSchemaReport. It is a list containing every node of the MicroOVN
+// deployment and for each node it contains node's Hostname, a version of the OVSDB schema expected on that node and
+// whether there were any errors while fetching information from that node.
+func GetAllExpectedOvsdbSchemaVersions(ctx context.Context, c *client.Client, dbSpec *ovnCmd.OvsdbSpec) (types.OvsdbSchemaReport, error) {
+	var response types.OvsdbSchemaReport
+
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
+	err := c.Query(queryCtx, "GET", api.NewURL().Path("ovsdb", "schema", dbSpec.ShortName, "expected", "all"), nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get expected ovsdb schema versions from cluster: %w", err)
+	}
+
+	return response, nil
+}
+
 // GetActiveOvsdbSchemaVersion queries MicroOVN cluster for a version of the schema that's currently used by a database
 // specified by the "dbSpec" argument.
 func GetActiveOvsdbSchemaVersion(ctx context.Context, c *client.Client, dbSpec *ovnCmd.OvsdbSpec) (string, types.OvsdbSchemaFetchError) {

--- a/microovn/cmd/microovn/status.go
+++ b/microovn/cmd/microovn/status.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/canonical/microcluster/microcluster"
+	"github.com/canonical/microovn/microovn/api/types"
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/spf13/cobra"
 
+	microClusterClient "github.com/canonical/microcluster/client"
 	"github.com/canonical/microovn/microovn/client"
 )
 
@@ -67,5 +71,134 @@ func (c *cmdStatus) Run(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  Services: %s\n", strings.Join(srvServices, ", "))
 	}
 
+	// Get OVN clustered DB schema version status
+	fmt.Println("OVN Database summary:")
+	reportOvsdbSchemaStatus(cli, ovnCmd.OvsdbTypeNBLocal)
+	reportOvsdbSchemaStatus(cli, ovnCmd.OvsdbTypeSBLocal)
 	return nil
+}
+
+// reportOvsdbSchemaStatus fetches currently active schema version and list of expected schema version from each
+// node in the deployment. Based on the results it then prints a report for the user.
+func reportOvsdbSchemaStatus(cli *microClusterClient.Client, ovsdbType ovnCmd.OvsdbType) {
+	ovnDB, err := ovnCmd.NewOvsdbSpec(ovsdbType)
+	if err != nil {
+		printOvsdbSummaryError(err, nil)
+		return
+	}
+
+	activeSchema, errType := client.GetActiveOvsdbSchemaVersion(context.Background(), cli, ovnDB)
+	if errType != types.OvsdbSchemaFetchErrorNone {
+		printOvsdbSummaryError(
+			fmt.Errorf("failed to get OVN %s active schema version", ovnDB.FriendlyName),
+			ovnDB,
+		)
+	}
+
+	expectedSchemas, err := client.GetAllExpectedOvsdbSchemaVersions(context.Background(), cli, ovnDB)
+	if err != nil {
+		printOvsdbSummaryError(
+			fmt.Errorf("failed to get expected OVN %s schema versions", ovnDB.FriendlyName),
+			ovnDB,
+		)
+	}
+
+	printOvsdbSchemaReport(cli, ovnDB, activeSchema, expectedSchemas)
+}
+
+// printOvsdbSchemaReport evaluates active and expected schema versions of given OVN database and prints the report. If
+// there's no attention of a user required, it prints simple "OK" message, otherwise it prints detailed reported about
+// the database's active schema version and schema versions expected on each node in the deployment.
+func printOvsdbSchemaReport(cli *microClusterClient.Client, dbSpec *ovnCmd.OvsdbSpec, activeSchema string, expectedSchemas types.OvsdbSchemaReport) {
+	attentionRequired, err := ovsdbSchemaRequiresAttention(activeSchema, expectedSchemas)
+	if err != nil {
+		printOvsdbSummaryError(err, dbSpec)
+		return
+	}
+
+	if !attentionRequired {
+		fmt.Printf("OVN %s: OK (%s)\n", dbSpec.FriendlyName, activeSchema)
+		return
+	}
+
+	clusterMembers, _ := cli.GetClusterMembers(context.Background())
+
+	addrToName := func(addr string) (string, error) {
+		for _, member := range clusterMembers {
+			if member.Address.Addr().String() == addr {
+				return member.Name, nil
+			}
+		}
+		return "", fmt.Errorf("cluster member with address '%s' not found", addr)
+	}
+
+	msg := fmt.Sprintf("OVN %s: Upgrade or attention required!\n", dbSpec.FriendlyName)
+	msg += fmt.Sprintf("Currently active schema: %s\n", activeSchema)
+	msg += "Cluster report (expected schema versions):\n"
+	for _, node := range expectedSchemas {
+		nodeName, err := addrToName(node.Host)
+		if err != nil {
+			nodeName = node.Host
+		}
+		msg += fmt.Sprintf("\t%s: ", nodeName)
+		if node.Error == types.OvsdbSchemaFetchErrorGeneric {
+			msg += "Error. Failed to contact member\n"
+		} else if node.Error == types.OvsdbSchemaFetchErrorNotSupported {
+			msg += "Missing API. MicroOVN needs upgrade\n"
+		} else {
+			msg += fmt.Sprintf("%s\n", node.SchemaVersion)
+		}
+	}
+	msg += fmt.Sprintf("\n")
+
+	fmt.Printf(msg)
+}
+
+// ovsdbSchemaRequiresAttention is a function that determines whether an attention of the user is needed for given OVN
+// database. It takes currently active schema version, list of expected version and returns false if everything
+// is as expected.
+// It returns true if active version does not match expected version on all nodes or if there was any error reported
+// in expectedSchemas.
+// It returns error if expectedSchemas is an empty slice.
+func ovsdbSchemaRequiresAttention(activeSchema string, expectedSchemas types.OvsdbSchemaReport) (bool, error) {
+	if len(expectedSchemas) == 0 {
+		return false, errors.New("list of expected schema versions is empty")
+	}
+
+	versionSet := make(map[string]int)
+	nodeError := false
+	expectedVersion := "0.0"
+
+	// Iterate over all nodes and find unique expected versions as well as any errors
+	for _, node := range expectedSchemas {
+		expectedVersion = node.SchemaVersion
+		versionSet[node.SchemaVersion]++
+		if node.Error != types.OvsdbSchemaFetchErrorNone {
+			nodeError = true
+		}
+	}
+
+	// return True if any errors were encountered
+	if nodeError {
+		return true, nil
+	}
+
+	// return True if there's more than one unique schema version expected
+	if len(versionSet) > 1 {
+		return true, nil
+	}
+
+	// return True if expected schema version does not match the currently running version
+	return activeSchema != expectedVersion, nil
+}
+
+// printOvsdbSummaryError prepends unified prefix, and prints the error. It should be used when aborting OVSDB
+// summary report.
+// if ovsdbSpec is provided, name od the database will be included in the printer error.
+func printOvsdbSummaryError(err error, ovsdbSpec *ovnCmd.OvsdbSpec) {
+	dbName := ""
+	if ovsdbSpec != nil {
+		dbName = ovsdbSpec.FriendlyName
+	}
+	fmt.Printf("Error creating OVN %s Database summary: %s\n", dbName, err)
 }

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/microcluster/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 )
 
 // Bootstrap will initialize a new OVN deployment.
@@ -131,7 +132,7 @@ func Bootstrap(s *state.State, initConfig map[string]string) error {
 		return err
 	}
 
-	_, err = VSCtl(
+	_, err = ovnCmd.VSCtl(
 		s,
 		"set", "open_vswitch", ".",
 		fmt.Sprintf("external_ids:system-id=%s", s.Name()),

--- a/microovn/ovn/cmd/commands.go
+++ b/microovn/ovn/cmd/commands.go
@@ -192,3 +192,28 @@ func ControllerCtl(s *state.State, args ...string) (string, error) {
 
 	return stdout, err
 }
+
+// OvsdbClient is a wrapper function that executes 'ovsdb-client' command. It first ensures that the database
+// is connected and returns error if the database is not connected within <connectTimeout> seconds. Then it runs
+// "ovsdb-client" command with timeout of <resultTimeout> seconds.
+// Argument "args" should contain array of strings with subcommand and other arguments that will be passed directly
+// to the "ovsdb-client". Note that it is not necessary to pass "-t" argument, as the timeout is automatically included.
+func OvsdbClient(s *state.State, dbSpec *OvsdbSpec, connectTimeout int, resultTimeout int, args ...string) (string, error) {
+	err := WaitForDBState(s, dbSpec, OvsdbConnected, connectTimeout)
+	if err != nil {
+		return "", err
+	}
+
+	arguments := []string{"-t", strconv.Itoa(resultTimeout)}
+	arguments = append(arguments, args...)
+
+	stdout, _, err := shared.RunCommandSplit(
+		s.Context,
+		nil,
+		nil,
+		"ovsdb-client",
+		arguments...,
+	)
+
+	return stdout, err
+}

--- a/microovn/ovn/cmd/commands.go
+++ b/microovn/ovn/cmd/commands.go
@@ -1,4 +1,4 @@
-package ovn
+package cmd
 
 import (
 	"errors"
@@ -12,7 +12,7 @@ import (
 	"github.com/canonical/microovn/microovn/ovn/paths"
 )
 
-const defaultDBConnectWait = 30 //Default time to wait for connection to ovsdb
+const DefaultDBConnectWait = 30 //Default time to wait for connection to ovsdb
 const OvsdbConnected = "connected"
 const OvsdbRemoved = "removed"
 
@@ -76,11 +76,11 @@ func NewOvsdbSpec(dbType OvsdbType) (*OvsdbSpec, error) {
 	return dbSpec, err
 }
 
-// waitForDBState as the name suggests, waits for specified ovsdb database to settle in
+// WaitForDBState as the name suggests, waits for specified ovsdb database to settle in
 // specified state. If database does not reach this state within timeout, this function returns error.
 // SocketURL specified in "db" parameter does not need to necessarily exist before this function is executed,
 // creation of the database socket (db.SocketURL) will be awaited as well.
-func waitForDBState(s *state.State, db *OvsdbSpec, dbState string, timeout int) error {
+func WaitForDBState(s *state.State, db *OvsdbSpec, dbState string, timeout int) error {
 	_, err := shared.RunCommandContext(
 		s.Context,
 		"ovsdb-client",
@@ -118,7 +118,7 @@ func ovnDBCtl(s *state.State, dbType OvsdbType, timeout int, args ...string) (st
 		return "", err
 	}
 
-	err = waitForDBState(s, dbSpec, OvsdbConnected, timeout)
+	err = WaitForDBState(s, dbSpec, OvsdbConnected, timeout)
 	if err != nil {
 		return "", err
 	}
@@ -129,23 +129,23 @@ func ovnDBCtl(s *state.State, dbType OvsdbType, timeout int, args ...string) (st
 // NBCtl is a convenience function for execution of ovn-nbctl command. Parameter "args" is list of arguments
 // that are passed directly to the shell command. Before the command is executed, this
 // function ensures that underlying database is in connected state. If the database does not reach "connected"
-// state before timeout (defined in defaultDBConnectWait), an error is returned and command is not executed.
+// state before timeout (defined in DefaultDBConnectWait), an error is returned and command is not executed.
 func NBCtl(s *state.State, args ...string) (string, error) {
-	return ovnDBCtl(s, OvsdbTypeNBLocal, defaultDBConnectWait, args...)
+	return ovnDBCtl(s, OvsdbTypeNBLocal, DefaultDBConnectWait, args...)
 }
 
 // SBCtl is a convenience function for execution of ovn-sbctl command. Parameter "args" is list of arguments
 // that are passed directly to the shell command. Before the command is executed, this
 // function ensures that underlying database is in connected state. If the database does not reach "connected"
-// state before timeout (defined in defaultDBConnectWait), an error is returned and command is not executed.
+// state before timeout (defined in DefaultDBConnectWait), an error is returned and command is not executed.
 func SBCtl(s *state.State, args ...string) (string, error) {
-	return ovnDBCtl(s, OvsdbTypeSBLocal, defaultDBConnectWait, args...)
+	return ovnDBCtl(s, OvsdbTypeSBLocal, DefaultDBConnectWait, args...)
 }
 
 // VSCtl is a convenience function for execution of ovs-vsctl command. Parameter "args" is list of arguments
 // that are passed directly to the shell command. Before the command is executed, this
 // function ensures that underlying database is in connected state. If the database does not reach "connected"
-// state before timeout (defined in defaultDBConnectWait), an error is returned and command is not executed.
+// state before timeout (defined in DefaultDBConnectWait), an error is returned and command is not executed.
 func VSCtl(s *state.State, args ...string) (string, error) {
 
 	dbSpec, err := NewOvsdbSpec(OvsdbTypeSwitchLocal)
@@ -153,7 +153,7 @@ func VSCtl(s *state.State, args ...string) (string, error) {
 		return "", err
 	}
 
-	err = waitForDBState(s, dbSpec, OvsdbConnected, defaultDBConnectWait)
+	err = WaitForDBState(s, dbSpec, OvsdbConnected, DefaultDBConnectWait)
 	if err != nil {
 		return "", err
 	}

--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -42,31 +42,6 @@ func networkProtocol(s *state.State) string {
 
 }
 
-// localServiceActive function accepts service names (like "central" or "switch") and returns true/false based
-// on whether the selected service is running on this node.
-func localServiceActive(s *state.State, serviceName string) (bool, error) {
-	serviceActive := false
-	err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
-		// Get list of all active local services.
-		name := s.Name()
-		services, err := database.GetServices(ctx, tx, database.ServiceFilter{Member: &name})
-		if err != nil {
-			return err
-		}
-
-		// Check if the specified service is among active local services.
-		for _, srv := range services {
-			if srv.Service == serviceName {
-				serviceActive = true
-			}
-		}
-
-		return nil
-	})
-
-	return serviceActive, err
-}
-
 // Builds environment variable strings for OVN.
 func environmentString(s *state.State, port int) (string, string, error) {
 	var err error

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 
 	"github.com/canonical/microcluster/state"
+
 	"github.com/canonical/microovn/microovn/database"
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 )
 
 // Join will join an existing OVN deployment.
@@ -140,7 +142,7 @@ func Join(s *state.State, initConfig map[string]string) error {
 		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
 	}
 
-	_, err = VSCtl(
+	_, err = ovnCmd.VSCtl(
 		s,
 		"set", "open_vswitch", ".",
 		fmt.Sprintf("external_ids:system-id=%s", s.Name()),

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -4,6 +4,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/state"
 
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/ovn/paths"
 )
 
@@ -22,7 +23,7 @@ func Leave(s *state.State, force bool) error {
 
 	// Gracefully exit OVN controller causing chassis to be automatically removed.
 	logger.Infof("Stopping OVN Controller and removing Chassis '%s' from OVN SB database.", chassisName)
-	_, err = ControllerCtl(s, "exit")
+	_, err = ovnCmd.ControllerCtl(s, "exit")
 	if err != nil {
 		logger.Warnf("Failed to gracefully stop OVN Controller: %s", err)
 	}
@@ -39,21 +40,21 @@ func Leave(s *state.State, force bool) error {
 
 	// Leave SB and NB clusters
 	logger.Info("Leaving OVN Northbound cluster")
-	_, err = AppCtl(s, paths.OvnNBControlSock(), "cluster/leave", "OVN_Northbound")
+	_, err = ovnCmd.AppCtl(s, paths.OvnNBControlSock(), "cluster/leave", "OVN_Northbound")
 	if err != nil {
 		logger.Warnf("Failed to leave OVN Northbound cluster: %s", err)
 	}
 
 	logger.Info("Leaving OVN Southbound cluster")
-	_, err = AppCtl(s, paths.OvnSBControlSock(), "cluster/leave", "OVN_Southbound")
+	_, err = ovnCmd.AppCtl(s, paths.OvnSBControlSock(), "cluster/leave", "OVN_Southbound")
 	if err != nil {
 		logger.Warnf("Failed to leave OVN Southbound cluster: %s", err)
 	}
 
 	// Wait for NB and SB cluster members to complete departure process
-	nbDatabase, err := NewOvsdbSpec(OvsdbTypeNBLocal)
+	nbDatabase, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeNBLocal)
 	if err == nil {
-		err = waitForDBState(s, nbDatabase, OvsdbRemoved, defaultDBConnectWait)
+		err = ovnCmd.WaitForDBState(s, nbDatabase, ovnCmd.OvsdbRemoved, ovnCmd.DefaultDBConnectWait)
 		if err != nil {
 			logger.Warnf("Failed to wait for NB cluster departure: %s", err)
 		}
@@ -61,9 +62,9 @@ func Leave(s *state.State, force bool) error {
 		logger.Warnf("Failed to get NB database specification: %s", err)
 	}
 
-	sbDatabase, err := NewOvsdbSpec(OvsdbTypeSBLocal)
+	sbDatabase, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeSBLocal)
 	if err == nil {
-		err = waitForDBState(s, sbDatabase, OvsdbRemoved, defaultDBConnectWait)
+		err = ovnCmd.WaitForDBState(s, sbDatabase, ovnCmd.OvsdbRemoved, ovnCmd.DefaultDBConnectWait)
 		if err != nil {
 			logger.Warnf("Failed to wait for SB cluster departure: %s", err)
 		}

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -51,7 +51,7 @@ func Leave(s *state.State, force bool) error {
 	}
 
 	// Wait for NB and SB cluster members to complete departure process
-	nbDatabase, err := newOvsdbSpec(OvsdbTypeNBLocal)
+	nbDatabase, err := NewOvsdbSpec(OvsdbTypeNBLocal)
 	if err == nil {
 		err = waitForDBState(s, nbDatabase, OvsdbRemoved, defaultDBConnectWait)
 		if err != nil {
@@ -61,7 +61,7 @@ func Leave(s *state.State, force bool) error {
 		logger.Warnf("Failed to get NB database specification: %s", err)
 	}
 
-	sbDatabase, err := newOvsdbSpec(OvsdbTypeSBLocal)
+	sbDatabase, err := NewOvsdbSpec(OvsdbTypeSBLocal)
 	if err == nil {
 		err = waitForDBState(s, sbDatabase, OvsdbRemoved, defaultDBConnectWait)
 		if err != nil {

--- a/microovn/ovn/ovsdb/ovsdb.go
+++ b/microovn/ovn/ovsdb/ovsdb.go
@@ -1,14 +1,37 @@
 package ovsdb
 
 import (
+	"context"
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/state"
 
+	microovnClient "github.com/canonical/microovn/microovn/client"
+	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 )
+
+// Constants below should be used when implementing retry algorithms with increasingly longer back-offs between
+// attempts
+const (
+	backOffMsInitial  = 100  // amount of milliseconds to wait before first retry
+	backOffMsMax      = 2000 // Maximum amount of milliseconds to wait between retry attempts
+	backOffMultiplier = 2    // multiplier for increasingly longer back-offs after each retry attempt
+)
+
+// schemaStatus structure encapsulates information about schema version
+// status of a specific OVSDB.
+type schemaStatus struct {
+	LocalVersion    string // Version of the schema that's currently running
+	TargetVersion   string // Version of the schema that's expected to be running. (based on the schema supplied by the OVN/OVS package)
+	UpgradeRequired bool   // Whether an OVSDB schema upgrade is required
+}
 
 // ExpectedOvsdbSchemaVersion returns version of the database schema that was shipped with current OVN/OVS
 // packages. This value can be used to check whether current OVN/OVS processes are using up-to-date database
@@ -25,4 +48,242 @@ func ExpectedOvsdbSchemaVersion(s *state.State, dbSpec *ovnCmd.OvsdbSpec) (strin
 	}
 
 	return strings.TrimSpace(targetDbVersion), nil
+}
+
+// getLiveSchemaStatus returns information about schema status of the database specified by the "dbSpec" argument.
+// For more information about the returned value, see: schemaStatus.
+func getLiveSchemaStatus(s *state.State, dbSpec *ovnCmd.OvsdbSpec) (schemaStatus, error) {
+	var status schemaStatus
+
+	localDbVersion, err := ovnCmd.OvsdbClient(
+		s,
+		dbSpec,
+		10,
+		5,
+		"get-schema-version",
+		dbSpec.SocketURL,
+		dbSpec.Name,
+	)
+
+	if err != nil {
+		return schemaStatus{}, fmt.Errorf("failed to get local DB schema version: '%s'", err.Error())
+	}
+	localDbVersion = strings.TrimSpace(localDbVersion)
+
+	targetDbVersion, err := ExpectedOvsdbSchemaVersion(s, dbSpec)
+
+	_, err = shared.RunCommandContext(
+		s.Context,
+		"ovsdb-tool",
+		"compare-versions",
+		localDbVersion,
+		"==",
+		targetDbVersion,
+	)
+
+	msg := fmt.Sprintf(
+		"Curently running %s DB schema version: %s; Expected: %s;",
+		dbSpec.FriendlyName,
+		localDbVersion,
+		targetDbVersion,
+	)
+	if err != nil {
+		msg = fmt.Sprintf("%s Upgrade required", msg)
+	} else {
+		msg = fmt.Sprintf("%s No upgrade required", msg)
+	}
+
+	logger.Debug(msg)
+
+	status.UpgradeRequired = err != nil
+	status.LocalVersion = localDbVersion
+	status.TargetVersion = targetDbVersion
+
+	return status, nil
+}
+
+// isNodeUpgradeLeader returns "true" if current node is a designated leader for performing OVN database schema
+// upgrade.
+// It does not matter which node triggers the schema upgrade as long as it's running a OVN central service. Therefore,
+// a node with "central" service active and the lowest ID is chosen. A node ID is an internal value of a MicroOVN, and
+// it's kept consistent across the cluster via the underlying MicroCluster library.
+func isNodeUpgradeLeader(s *state.State) (bool, error) {
+	membersWithCentral, err := node.FindService(s, "central")
+	if err != nil {
+		return false, fmt.Errorf("failed to determine which member is OVSDB cluster upgrade leader: '%s'", err)
+	}
+
+	sort.Slice(membersWithCentral, func(i, j int) bool {
+		return membersWithCentral[i].ID < membersWithCentral[j].ID
+	})
+	upgradeLeader := membersWithCentral[0]
+
+	return s.Name() == upgradeLeader.Name, nil
+}
+
+// isClusterUpgradeReady returns "true" if expected schema version of a database, on every cluster member, matches an
+// expected schema version on current member.
+// This function scans every cluster member, regardless of whether they are running "central" services or not. This
+// ensures that even cluster members that are running on "chassis" service are prepared for the schema upgrade.
+func isClusterUpgradeReady(s *state.State, dbSpec *ovnCmd.OvsdbSpec, targetVersion string) (bool, error) {
+	clusterClient, err := s.Cluster(nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to get a client for every cluster member: %w", err)
+	}
+
+	results := map[string]string{}
+
+	// Gather expected schema version from every member in the cluster via their API.
+	err = clusterClient.Query(s.Context, true, func(ctx context.Context, c *client.Client) error {
+		clientUrl := c.URL()
+		clientUrlString := clientUrl.String()
+		logger.Debugf("Requesting OVSDB %s schema status from '%s'", dbSpec.FriendlyName, clientUrlString)
+		result, err := microovnClient.GetExpectedOvsdbSchemaVersion(ctx, c, dbSpec)
+		if err != nil {
+			logger.Errorf(
+				"Failed to get OVN %s DB schema status from '%s': %s",
+				dbSpec.FriendlyName,
+				clientUrlString,
+				err,
+			)
+			return err
+		}
+		results[clientUrlString] = result
+		return nil
+	})
+
+	if err != nil {
+		return false, fmt.Errorf("failed to assess overall cluster readiness for OVN cluster DB upgrade: '%s'", err)
+	}
+
+	// Match expected schema version from cluster members against our expected version. Only if all values match,
+	// return "true", indicating that the cluster is ready for the schema upgrade.
+	clusterReady := true
+	for host, status := range results {
+		if status == targetVersion {
+			logger.Infof("Host at '%s' has OVN %s DB ready for upgrade", host, dbSpec.FriendlyName)
+		} else {
+			logger.Infof("Host at '%s' does not have OVN %s DB ready for update", host, dbSpec.FriendlyName)
+			clusterReady = false
+		}
+	}
+
+	return clusterReady, nil
+}
+
+// UpgradeCentralDB checks whether a schema upgrade for the specified DB is required. If so, it triggers
+// a coordinated approach to an OVSDB cluster schema upgrade.
+// The function will wait in loop until every member in the cluster is ready for the schema upgrade. Once the cluster
+// is ready, a designated cluster member will trigger a schema upgrade. Non-designated members will keep looping until,
+// eventually, their expected schema version will match the currently running schema version.
+//
+// Note: This function supports upgrade only for the "central" databases (e.i. OVN_Northbound and OVN_Southbound). It
+//
+//	will return error if other database is specified in the 'dbType' argument.
+//
+// Note2: This function has no effect on a node that does not run OVN "central" services, and it will return silently.
+func UpgradeCentralDB(s *state.State, dbType ovnCmd.OvsdbType) error {
+	dbSpec, err := ovnCmd.NewOvsdbSpec(dbType)
+	if err != nil {
+		return fmt.Errorf("failed create DB specification: '%s'", err.Error())
+	}
+
+	if !dbSpec.IsCentral {
+		return fmt.Errorf("MicroOVN handles upgrades only for Northbound and Southbound clustered DBs")
+	}
+
+	centralActive, err := node.HasServiceActive(s, "central")
+	if err != nil {
+		return fmt.Errorf("failed to query local services: %s", err)
+	}
+
+	if !centralActive {
+		logger.Infof(
+			"OVN %s database won't be upgraded from this node because 'central' service is not active",
+			dbSpec.FriendlyName,
+		)
+		return nil
+	}
+
+	backOffMs := backOffMsInitial
+	var dbStatus schemaStatus
+
+	// Start of the loop that coordinates with other cluster members the OVSDB cluster schema upgrade.
+	for {
+		// Get current schema status
+		dbStatus, err = getLiveSchemaStatus(s, dbSpec)
+		if err != nil {
+			logger.Warnf(
+				"Error checking if OVN %s cluster needs upgrade: '%s' (retrying in %d ms)",
+				dbSpec.FriendlyName,
+				err,
+				backOffMs,
+			)
+		} else {
+			if !dbStatus.UpgradeRequired {
+				// If upgrade is not required, break out of the loop
+				logger.Infof("OVN %s DB is at expected version. No upgrade needed", dbSpec.FriendlyName)
+				break
+			} else {
+				logger.Infof("OVN %s DB schema needs upgrade.", dbSpec.FriendlyName)
+			}
+
+			// Check whether we are the designated node for triggering the schema upgrade
+			upgradeLeader, err := isNodeUpgradeLeader(s)
+			if err != nil {
+				logger.Warnf(
+					"Failed to determine if this host is OVN %s upgrade leader: '%s' (retrying in %d ms)",
+					dbSpec.FriendlyName,
+					err,
+					backOffMs,
+				)
+			} else if upgradeLeader {
+
+				// Leader verifies whether the cluster is ready for schema upgrade
+				upgradeReady, err := isClusterUpgradeReady(s, dbSpec, dbStatus.TargetVersion)
+				if err != nil {
+					logger.Warnf(
+						"OVN %s DB upgrade readycheck failed: '%s' (retrying in %d ms)",
+						dbSpec.FriendlyName,
+						err,
+						backOffMs,
+					)
+				} else if upgradeReady {
+
+					// If the cluster is ready, an upgrade is triggered. Otherwise, the loop continues.
+					logger.Infof("Triggering OVN %s schema upgrade.", dbSpec.FriendlyName)
+					_, err = ovnCmd.OvsdbClient(
+						s,
+						dbSpec,
+						10,
+						60,
+						"convert",
+						dbSpec.SocketURL,
+						fmt.Sprintf(dbSpec.Schema),
+					)
+					return err
+				}
+			} else {
+				// Nodes that are not designated to trigger the upgrade, continue looping. This ensures that in case
+				// that cluster has to be altered during the upgrade, e.g. if the original leader has to be replaced,
+				// a new member will become a designated leader, and it will trigger the upgrade.
+				logger.Infof(
+					"This host is not a designated to upgrade OVN %s DB schema. Rechecking schema status in %d",
+					dbSpec.FriendlyName,
+					backOffMs,
+				)
+			}
+		}
+
+		time.Sleep(time.Duration(backOffMs) * time.Millisecond)
+		if backOffMs < backOffMsMax {
+			backOffMs *= backOffMultiplier
+		}
+
+		if backOffMs > backOffMsMax {
+			backOffMs = backOffMsMax
+		}
+	}
+
+	return nil
 }

--- a/microovn/ovn/ovsdb/ovsdb.go
+++ b/microovn/ovn/ovsdb/ovsdb.go
@@ -1,0 +1,28 @@
+package ovsdb
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/microcluster/state"
+
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+)
+
+// ExpectedOvsdbSchemaVersion returns version of the database schema that was shipped with current OVN/OVS
+// packages. This value can be used to check whether current OVN/OVS processes are using up-to-date database
+// schemas.
+func ExpectedOvsdbSchemaVersion(s *state.State, dbSpec *ovnCmd.OvsdbSpec) (string, error) {
+	targetDbVersion, err := shared.RunCommandContext(
+		s.Context,
+		"ovsdb-tool",
+		"schema-version",
+		dbSpec.Schema,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get DB schema version from file '%s': '%s'", dbSpec.Schema, err)
+	}
+
+	return strings.TrimSpace(targetDbVersion), nil
+}

--- a/microovn/ovn/paths/paths.go
+++ b/microovn/ovn/paths/paths.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 )
 
+var snapRoot = os.Getenv("SNAP")
 var pathRoot = os.Getenv("SNAP_COMMON")
 var runtimeDir = filepath.Join(pathRoot, "run")
 var dataDir = filepath.Join(pathRoot, "data")
@@ -112,6 +113,17 @@ func PkiOvnControllerCertFiles() (string, string) {
 
 func PkiClientCertFiles() (string, string) {
 	return getServiceCertFiles("client")
+}
+
+// OvsdbSbSchema returns path to schema file for OVN Southbound database
+func OvsdbSbSchema() string { return filepath.Join(snapRoot, "share", "ovn", "ovn-sb.ovsschema") }
+
+// OvsdbNbSchema returns path to schema file for OVN Northbound database
+func OvsdbNbSchema() string { return filepath.Join(snapRoot, "share", "ovn", "ovn-nb.ovsschema") }
+
+// OvsdbSwitchSchema returns path to schema file for OpenvSwitch
+func OvsdbSwitchSchema() string {
+	return filepath.Join(snapRoot, "share", "openvswitch", "vswitch.ovsschema")
 }
 
 // getServiceCertFiles returns path to certificate and key of give service in format

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -81,11 +81,11 @@ func refresh(s *state.State) error {
 }
 
 func updateOvnListenConfig(s *state.State) error {
-	nbDB, err := GetOvsdbLocalPath(OvsdbTypeNBLocal)
+	nbDB, err := NewOvsdbSpec(OvsdbTypeNBLocal)
 	if err != nil {
 		return fmt.Errorf("Failed to get path to OVN NB database socket: %w", err)
 	}
-	sbDB, err := GetOvsdbLocalPath(OvsdbTypeSBLocal)
+	sbDB, err := NewOvsdbSpec(OvsdbTypeSBLocal)
 	if err != nil {
 		return fmt.Errorf("Failed to get path to OVN SB database socket: %w", err)
 	}
@@ -94,7 +94,7 @@ func updateOvnListenConfig(s *state.State) error {
 	_, err = NBCtl(
 		s,
 		"--no-leader-only",
-		fmt.Sprintf("--db=unix:%s", nbDB),
+		fmt.Sprintf("--db=%s", nbDB.SocketURL),
 		"set-connection",
 		fmt.Sprintf("p%s:6641:[::]", protocol),
 	)
@@ -105,7 +105,7 @@ func updateOvnListenConfig(s *state.State) error {
 	_, err = SBCtl(
 		s,
 		"--no-leader-only",
-		fmt.Sprintf("--db=unix:%s", sbDB),
+		fmt.Sprintf("--db=%s", sbDB.SocketURL),
 		"set-connection",
 		fmt.Sprintf("p%s:6642:[::]", protocol),
 	)

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -7,6 +7,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/canonical/microcluster/state"
+
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 )
 
 // Refresh will update the existing OVN central and OVS switch configs.
@@ -66,7 +68,7 @@ func refresh(s *state.State) error {
 			return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
 		}
 
-		_, err = VSCtl(
+		_, err = ovnCmd.VSCtl(
 			s,
 			"set", "open_vswitch", ".",
 			fmt.Sprintf("external_ids:ovn-remote=%s", sbConnect),
@@ -81,17 +83,17 @@ func refresh(s *state.State) error {
 }
 
 func updateOvnListenConfig(s *state.State) error {
-	nbDB, err := NewOvsdbSpec(OvsdbTypeNBLocal)
+	nbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeNBLocal)
 	if err != nil {
 		return fmt.Errorf("Failed to get path to OVN NB database socket: %w", err)
 	}
-	sbDB, err := NewOvsdbSpec(OvsdbTypeSBLocal)
+	sbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeSBLocal)
 	if err != nil {
 		return fmt.Errorf("Failed to get path to OVN SB database socket: %w", err)
 	}
 
 	protocol := networkProtocol(s)
-	_, err = NBCtl(
+	_, err = ovnCmd.NBCtl(
 		s,
 		"--no-leader-only",
 		fmt.Sprintf("--db=%s", nbDB.SocketURL),
@@ -102,7 +104,7 @@ func updateOvnListenConfig(s *state.State) error {
 		return errors.Errorf("Error setting ovn NB connection string: %s", err)
 	}
 
-	_, err = SBCtl(
+	_, err = ovnCmd.SBCtl(
 		s,
 		"--no-leader-only",
 		fmt.Sprintf("--db=%s", sbDB.SocketURL),

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canonical/microcluster/state"
 
+	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 )
 
@@ -36,12 +37,12 @@ func refresh(s *state.State) error {
 	}
 
 	// Query existing local services.
-	hasCentral, err := localServiceActive(s, "central")
+	hasCentral, err := node.HasServiceActive(s, "central")
 	if err != nil {
 		return err
 	}
 
-	hasSwitch, err := localServiceActive(s, "switch")
+	hasSwitch, err := node.HasServiceActive(s, "switch")
 	if err != nil {
 		return err
 	}

--- a/microovn/ovn/start.go
+++ b/microovn/ovn/start.go
@@ -6,6 +6,8 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 
 	"github.com/canonical/microcluster/state"
+
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 )
 
 // Start will update the existing OVN central and OVS switch configs.
@@ -44,7 +46,7 @@ func Start(s *state.State) error {
 		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
 	}
 
-	_, err = VSCtl(
+	_, err = ovnCmd.VSCtl(
 		s,
 		"set", "open_vswitch", ".",
 		fmt.Sprintf("external_ids:ovn-remote=%s", sbConnect),

--- a/microovn/ovn/start.go
+++ b/microovn/ovn/start.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/canonical/microcluster/state"
 
+	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 )
 
@@ -29,7 +30,7 @@ func Start(s *state.State) error {
 		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
 	}
 
-	centralActive, err := localServiceActive(s, "central")
+	centralActive, err := node.HasServiceActive(s, "central")
 	if err != nil {
 		return fmt.Errorf("failed to query local services: %w", err)
 	}

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -2,4 +2,4 @@
 export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
 export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
 
-exec microovnd --state-dir "${SNAP_COMMON}/state"
+exec microovnd --verbose --state-dir "${SNAP_COMMON}/state"

--- a/snapcraft/commands/ovn-ovsdb-server-nb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-nb.start
@@ -14,7 +14,8 @@ OVN_ARGS="--db-nb-addr="${OVN_LOCAL_IP}" \
 --db-nb-election-timer="${ELECTION_TIMER}" \
 --ovn-nb-db-ssl-key="${OVN_PKIDIR}"/ovnnb-privkey.pem \
 --ovn-nb-db-ssl-cert="${OVN_PKIDIR}"/ovnnb-cert.pem \
---ovn-nb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"
+--ovn-nb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem \
+--db-cluster-schema-upgrade=no"
 
 if [ "${OVN_INITIAL_NB}" != "${OVN_LOCAL_IP}" ]; then
     OVN_ARGS="${OVN_ARGS} --db-nb-cluster-remote-addr="${OVN_INITIAL_NB}""

--- a/snapcraft/commands/ovn-ovsdb-server-sb.start
+++ b/snapcraft/commands/ovn-ovsdb-server-sb.start
@@ -14,7 +14,8 @@ OVN_ARGS="--db-sb-addr="${OVN_LOCAL_IP}" \
 --db-sb-election-timer="${ELECTION_TIMER}" \
 --ovn-sb-db-ssl-key="${OVN_PKIDIR}"/ovnsb-privkey.pem \
 --ovn-sb-db-ssl-cert="${OVN_PKIDIR}"/ovnsb-cert.pem \
---ovn-sb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem"
+--ovn-sb-db-ssl-ca-cert="${OVN_PKIDIR}"/cacert.pem \
+--db-cluster-schema-upgrade=no"
 
 if [ "${OVN_INITIAL_SB}" != "${OVN_LOCAL_IP}" ]; then
     OVN_ARGS="${OVN_ARGS} --db-sb-cluster-remote-addr="${OVN_INITIAL_SB}""

--- a/tests/ovsdb_schema_upgrade.bats
+++ b/tests/ovsdb_schema_upgrade.bats
@@ -1,0 +1,1 @@
+test_helper/bats/ovsdb_schema_upgrade.bats

--- a/tests/test_helper/bats/ovsdb_schema_upgrade.bats
+++ b/tests/test_helper/bats/ovsdb_schema_upgrade.bats
@@ -1,0 +1,154 @@
+# This is a bash shell fragment -*- bash -*-
+
+load "test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+setup() {
+    load test_helper/lxd.bash
+    load test_helper/common.bash
+    load test_helper/microovn.bash
+    load test_helper/ovsdb.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+}
+
+@test "Test OVSDB cluster schema upgrade" {
+    echo "# Checking if SB or NB database schema changed from MicroOVN rev. $MICROOVN_SNAP_REV" >&3
+    local original_nb=""
+    local original_sb=""
+    local target_nb=""
+    local target_sb=""
+    local probe_container=""
+
+    read -r -a containers_to_upgrade <<< "$TEST_CONTAINERS"
+    probe_container="${containers_to_upgrade[0]}"
+
+    # Get currently running OVN schema versions
+    original_nb=$(get_current_ovsdb_schema_version "$probe_container" "nb")
+    original_sb=$(get_current_ovsdb_schema_version "$probe_container" "sb")
+    # Get schema versions that are included in the tested MicroOVN snap
+    target_nb=$(get_ovsdb_schema_version_from_snap "$probe_container" "$MICROOVN_SNAP_PATH" "nb")
+    target_sb=$(get_ovsdb_schema_version_from_snap "$probe_container" "$MICROOVN_SNAP_PATH" "sb")
+
+
+    # Skip this test if there's no change between schemas in running MicroOVN version
+    # (installed from snap store) and tested MicroOVN version (installed from source)
+    if [ "$original_nb" == "$target_nb" ] && [ "$original_sb" == "$target_sb" ]; then
+        skip "OVN database schemas did not change. Skipping this check"
+    fi
+
+    # Based on  the version of original MicroOVN snap, it may not have necessary API to
+    # report expected schema version. In that case we'll expect an error message from these members.
+    # Otherwise we expect them to report old schema version
+    local old_member_msg_nb=""
+    local old_member_msg_sb=""
+    if [ "$MICROOVN_SNAP_REV" -le 395 ]; then
+        old_member_msg_nb="Missing API. MicroOVN needs upgrade"
+        old_member_msg_sb="Missing API. MicroOVN needs upgrade"
+    else
+        old_member_msg_nb="$original_nb"
+        old_member_msg_sb="$original_sb"
+    fi
+
+    local container_index=0
+    local upgrade_container_index=0
+    local old_container_index=0
+    local containers_size="${#containers_to_upgrade[@]}"
+
+    for ((container_index = 0; container_index < "$containers_size"; container_index++)) do
+        local container="${containers_to_upgrade[$container_index]}"
+        # Upgrade MicroOVN cluster, one cluster member at a time.
+        install_microovn "$MICROOVN_SNAP_PATH" "$container"
+
+        # break out of the loop if every container has been upgraded
+        if [ $(( "$container_index" + 1 )) -eq  "$containers_size" ]; then
+            break
+        fi
+
+        # Get current `microovn status`
+        wait_ovn_services "$container"
+        wait_microovn_online "$container" 30
+        local status=""
+        status=$(lxc_exec "$container" "microovn status")
+
+        # Verify that upgraded members report the new expected schema versions
+        echo -e "Current status:\n $status"
+        for ((upgrade_container_index = 0; upgrade_container_index <= container_index; upgrade_container_index++)); do
+            local upgraded_container="${containers_to_upgrade[$upgrade_container_index]}"
+
+            echo "Checking status for '$upgraded_container: $target_nb'"
+            grep "$upgraded_container: $target_nb" <<< "$status" > /dev/null
+            echo "# $upgraded_container now expects NB schema version: $target_nb" >&3
+
+            echo "Checking status for '$upgraded_container: $target_sb'"
+            grep "$upgraded_container: $target_sb" <<< "$status" > /dev/null
+            echo "# $upgraded_container now expects SB schema version: $target_sb" >&3
+        done
+
+        # Verify that members, that are not upgraded yet, report either old version, or an error
+        # in case that they don't support required API at all.
+        for ((old_container_index = container_index + 1; old_container_index < "$containers_size"; old_container_index++)) do
+            local old_container="${containers_to_upgrade[$old_container_index]}"
+
+            echo "Checking status for '$old_container: $old_member_msg_sb'"
+            grep "$old_container: $old_member_msg_sb" <<< "$status" > /dev/null
+
+            echo "Checking status for '$old_container: $old_member_msg_nb'"
+            grep "$old_container: $old_member_msg_nb" <<< "$status" > /dev/null
+
+            echo "# $old_container is still awaiting upgrade" >&3
+        done
+
+        # check that the schema upgrade was not triggered yet.
+        local current_sb=""
+        local current_nb=""
+        current_nb=$(get_current_ovsdb_schema_version "$probe_container" "nb")
+        current_sb=$(get_current_ovsdb_schema_version "$probe_container" "sb")
+        assert [ "$current_nb" == "$original_nb" ]
+        assert [ "$current_sb" == "$original_sb" ]
+    done
+
+    # After all cluster members are upgraded, verify that the cluster reports upgraded schema version
+    # as well.
+    local timeout=30
+    for (( i = 0; i < "$timeout"; i++ )); do
+        echo "# Waiting for Southbound and Northbound databases to finish schema upgrade ($i/$timeout)"
+        local err=0
+
+        run lxc_exec "$probe_container" "microovn status | grep 'OVN Southbound: OK ($target_sb)' "
+        if [ "$status" -ne 0 ]; then
+            err=1
+            echo "# OVN Southbound database schema is not upgraded yet"
+        fi
+
+        run lxc_exec "$probe_container" "microovn status | grep 'OVN Northbound: OK ($target_nb)' "
+        if [ "$status" -ne 0 ]; then
+            err=1
+            echo "# OVN Northbound database schema is not upgraded yet"
+        fi
+
+        if [ "$err" -eq 0 ]; then
+            break
+        fi
+
+        sleep 1
+    done
+
+    if [ "$err" -ne 0 ]; then
+        echo "# OVN schema upgraded did not finish in expected timeout"
+        return 1
+    fi
+
+    # check that the schema upgrade was triggered.
+    local current_sb=""
+    local current_nb=""
+    current_nb=$(get_current_ovsdb_schema_version "$probe_container" "nb")
+    current_sb=$(get_current_ovsdb_schema_version "$probe_container" "sb")
+    assert [ "$current_nb" == "$target_nb" ]
+    assert [ "$current_sb" == "$target_sb" ]
+
+    echo "# OVN database schema upgrade finished" >&3
+}

--- a/tests/test_helper/ovsdb.bash
+++ b/tests/test_helper/ovsdb.bash
@@ -1,0 +1,81 @@
+# get_current_ovsdb_schema_version CONTAINER NBSB
+#
+# Use CONTAINER to retrieve currently active OVN Northbound or Southbound
+# database schema. This function expect that MicroOVN is already installed
+# and bootstrapped in the CONTAINER.
+# Valid values for NBSB argument are either lowercase "sb" or "nb".
+#
+# NOTE: This function can be run only on containers that run "central" services
+#       as it requires local unix socket for the database
+function get_current_ovsdb_schema_version() {
+    local container=$1; shift
+    local nbsb=$1; shift
+
+    local schema_name=""
+    local connection_string=""
+
+    if [ $nbsb == "nb" ]; then
+        schema_name="OVN_Northbound"
+        connection_string="unix:/var/snap/microovn/common/run/ovn/ovnnb_db.sock"
+        elif [ $nbsb == "sb" ]; then
+            schema_name="OVN_Southbound"
+            connection_string="unix:/var/snap/microovn/common/run/ovn/ovnsb_db.sock"
+        else
+            echo "# Unknown database type '$nbsb'. Valid values: 'nb', 'sb'"
+            return 1
+    fi
+
+    local pki_dir="/var/snap/microovn/common/data/pki/"
+    local cert="$pki_dir/client-cert.pem"
+    local key="$pki_dir/client-privkey.pem"
+    local ca_cert="$pki_dir/cacert.pem"
+
+    lxc_exec "$container" "microovn.ovsdb-client -t 10 -c $cert -p $key -C $ca_cert \
+                           get-schema-version $connection_string $schema_name"
+}
+
+# get_ovsdb_schema_version_from_snap CONTAINER SNAP_PATH NBSB
+#
+# This function returns Northbound or Southbound database schema version that's
+# packed with the MicroOVN snap package located at SNAP_PATH.
+#
+# This function does not install the snap in the CONTAINER. It only unpacks it and uses
+# OVS tools to determine the schema version.
+# This function expects that MicroOVN is already installed in the CONTAINER so that its
+# tools can be used to determine schema version.
+# Valid values for NBSB argument are either lowercase "sb" or "nb".
+function get_ovsdb_schema_version_from_snap(){
+    local container=$1; shift
+    local snap_path=$1; shift
+    local nbsb=$1; shift
+
+    local unsquash_path="/root/snap/microovn/common/microovn-squashfs-root"
+    local container_snap_path="/tmp/microovn-to-unsquash.snap"
+    local schema_path=""
+
+    if [ $nbsb == "nb" ]; then
+        schema_path="$unsquash_path/share/ovn/ovn-nb.ovsschema"
+        elif [ $nbsb == "sb" ]; then
+        schema_path="$unsquash_path/share/ovn/ovn-sb.ovsschema"
+        else
+            echo "# Unknown database type '$nbsb'. Valid values: 'nb', 'sb'"
+            return 1
+    fi
+
+
+    lxc_file_push "$snap_path" "$container$container_snap_path"
+    lxc_exec "$container" "unsquashfs -q -n -d $unsquash_path $container_snap_path"
+
+    local schema_version=""
+    schema_version=$(lxc_exec "$container" "microovn.ovsdb-tool schema-version $schema_path")
+
+
+    lxc_exec "$container" "rm -rf $unsquash_path"
+    lxc_exec "$container" "rm $container_snap_path"
+
+    if [ -z "$schema_version" ]; then
+        return 1
+    fi
+
+    echo "$schema_version"
+}

--- a/tests/test_helper/setup_teardown/ovsdb_schema_upgrade.bash
+++ b/tests/test_helper/setup_teardown/ovsdb_schema_upgrade.bash
@@ -1,0 +1,1 @@
+upgrade.bash


### PR DESCRIPTION
Please review each commit individually.

This change set lets MicroOVN to take control of the OVN OVSDB cluster schema upgrades.

It also includes few refactoring changes, that are in my opinion required.  The `microovn/ovn` package got bit bloated over time and it became hard to use its functionality from other packages. Importing `microovn/ovn` would often result in circular dependencies, so I attempted to extract, and group, functions that could stand on their own into standalone packages.

I consider the implementation good for review. Functional tests and documentation are in progress.