### PR TITLE
Revert "Avoid blocking issue in snapd 2.62"

### DIFF
--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -8,9 +8,6 @@ function install_microovn() {
     snap_base=$(snap_print_base $snap_file)
 
     for container in $containers; do
-        # Note: Temporary workaround to avoid blocking issue in snapd 2.62
-        lxc_exec "$container" "snap refresh snapd --channel latest/beta"
-
         if ! test_snap_is_stable_base "$snap_base"; then
             echo "# !!NOTE!! Installing $snap_base \
                   from edge channel for $snap_file" >&3


### PR DESCRIPTION
Now that the snapd 2.63 is in the stable channel, we no longer need this workaround

This reverts commit 50063c2fbe3bc1bcfb25ef5e1820ad333059fa3c.