### PR TITLE
tests: Use alias for containers' release version

### DIFF
--- a/docs/developers/testing.rst
+++ b/docs/developers/testing.rst
@@ -77,6 +77,17 @@ To run individual test suites you can execute:
 
    make tests/<name_of_the_test_suite>.bats
 
+By default, functional tests run in LXD containers based on ``ubuntu:lts``
+image. This can be changed by exporting environment variable
+``MICROOVN_TEST_CONTAINER_IMAGE`` and setting it to a valid LXD image name.
+
+For example:
+
+.. code-block:: none
+
+    export MICROOVN_TEST_CONTAINER_IMAGE="ubuntu:jammy"
+    make check-system
+
 .. tip::
 
    If your hardware can handle it, you can run test suites in parallel by

--- a/tests/scaleup_cluster.bats
+++ b/tests/scaleup_cluster.bats
@@ -30,7 +30,7 @@ teardown() {
         local container
         container=${containers[*]:$((( $i - 1 ))):1}
 
-        launch_containers jammy $container
+        launch_containers $container
         wait_containers_ready $container
         install_microovn "$MICROOVN_SNAP_PATH" $container
 

--- a/tests/test_helper/bats/lifecycle.bats
+++ b/tests/test_helper/bats/lifecycle.bats
@@ -8,7 +8,7 @@ setup_file() {
 
     TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 1)
     export TEST_CONTAINERS
-    launch_containers jammy $TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
     wait_containers_ready $TEST_CONTAINERS
 }
 

--- a/tests/test_helper/lxd.bash
+++ b/tests/test_helper/lxd.bash
@@ -1,10 +1,9 @@
 function launch_containers() {
-    local image_name=$1; shift
     local containers=$*
-
+    local image="${MICROOVN_TEST_CONTAINER_IMAGE:-ubuntu:lts}"
     for container in $containers; do
-        echo "# Launching $container" >&3
-        lxc launch -q "ubuntu:$image_name" "$container" < \
+        echo "# Launching '$image' container: $container" >&3
+        lxc launch -q "$image" "$container" < \
             "$BATS_TEST_DIRNAME/lxd-instance-config.yaml"
     done
 }

--- a/tests/test_helper/setup_teardown/basic_cluster.bash
+++ b/tests/test_helper/setup_teardown/basic_cluster.bash
@@ -6,7 +6,7 @@ setup_file() {
 
     TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
     export TEST_CONTAINERS
-    launch_containers jammy $TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
     wait_containers_ready $TEST_CONTAINERS
     install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
     bootstrap_cluster $TEST_CONTAINERS

--- a/tests/test_helper/setup_teardown/init_cluster.bash
+++ b/tests/test_helper/setup_teardown/init_cluster.bash
@@ -8,7 +8,7 @@ setup_file() {
 
     TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
     export TEST_CONTAINERS
-    launch_containers jammy $TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
     wait_containers_ready $TEST_CONTAINERS
     install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
     local leader

--- a/tests/test_helper/setup_teardown/tls_cluster.bash
+++ b/tests/test_helper/setup_teardown/tls_cluster.bash
@@ -11,7 +11,7 @@ setup_file() {
     export TEST_CONTAINERS
     export CENTRAL_CONTAINERS
     export CHASSIS_CONTAINERS
-    launch_containers jammy $TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
     wait_containers_ready $TEST_CONTAINERS
     install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
     bootstrap_cluster $TEST_CONTAINERS

--- a/tests/test_helper/setup_teardown/upgrade.bash
+++ b/tests/test_helper/setup_teardown/upgrade.bash
@@ -20,7 +20,7 @@ setup_file() {
     export CENTRAL_CONTAINERS
     export CHASSIS_CONTAINERS
 
-    launch_containers jammy $TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
     wait_containers_ready $TEST_CONTAINERS
     install_microovn_from_store "$MICROOVN_SNAP_CHANNEL" $TEST_CONTAINERS
     bootstrap_cluster $TEST_CONTAINERS


### PR DESCRIPTION
Instead of using hardcoded name of the Ubuntu release that's used for test containers, we can leverage alias "lts" that will keep pointing to current LTS release.

-----
Alternatively, we can use `ubuntu:default` that will point to the latest release, but we went with `jammy` so far and I don't think it matters too much for the tests.