### PR TITLE
CI: Run lightweight tasks on Github-hosted runners

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   cla-check:
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     name: Canonical CLA signed
@@ -16,7 +16,7 @@ jobs:
         uses: canonical/has-signed-canonical-cla@v1
 
   dco-check:
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # for tim-actions/get-pr-commits to get list of commits from the PR
     name: Signed-off-by (DCO)
@@ -33,7 +33,7 @@ jobs:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 
   signed-commits-check:
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: ubuntu-latest
     name: Check signed commits in PR
     permissions:
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name: lint
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
     name: Generate matrix
     needs:
       - build
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
We switched all our jobs to self-hosted runners when we experienced very long queues on GH-hosted runners. However, there should now be enough GH-hosted runners for us to safely run the lightweight tasks on them again.