### PR TITLE
ci: Use {upload,download}-artifact v4 action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snaps
           path: ${{ env.MICROOVN_SNAP }}
@@ -112,7 +112,7 @@ jobs:
           submodules: recursive
 
       - name: Download built snap
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snaps
 


### PR DESCRIPTION
Github actions "upload-artifact" and "download-artifact" v3 are getting deprecated.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This change bumps these actions to v4.