### PR TITLE
tests: Determine initial version from filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 MICROOVN_SNAP=microovn.snap
 export MICROOVN_SNAP_PATH := $(CURDIR)/$(MICROOVN_SNAP)
 
-ifndef MICROOVN_SNAP_CHANNEL
-	export MICROOVN_SNAP_CHANNEL="22.03/stable"
-endif
-
 .DEFAULT_GOAL := $(MICROOVN_SNAP)
 
 ALL_TESTS := $(wildcard tests/*.bats)

--- a/tests/test_helper/bats/ovsdb_schema_upgrade.bats
+++ b/tests/test_helper/bats/ovsdb_schema_upgrade.bats
@@ -1,5 +1,9 @@
 # This is a bash shell fragment -*- bash -*-
 
+# Define test filename prefix that helps to determine from which version should
+# the upgrade be tested.
+export TEST_NAME_PREFIX="ovsdb_schema_upgrade"
+
 load "test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
 
 setup() {

--- a/tests/test_helper/bats/upgrade.bats
+++ b/tests/test_helper/bats/upgrade.bats
@@ -1,5 +1,9 @@
 # This is a bash shell fragment -*- bash -*-
 
+# Define test filename prefix that helps to determine from which version should
+# the upgrade be tested.
+export TEST_NAME_PREFIX="upgrade"
+
 # Instruct the ``setup_file`` function to perform the upgrade.
 export UPGRADE_DO_UPGRADE=1
 load "test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -45,14 +45,21 @@ function install_microovn() {
 
 # install_microovn_from_store CHANNEL CONTAINER1 [CONTAINER2 ...]
 #
-# Install MicroOVN snap from specified CHANNEL from Snap store in all CONTAINERs.
+# Install MicroOVN snap from specified CHANNEL from Snap store in all CONTAINERs. If
+# the CHANNEL argument is an empty string, a default channel will be used.
 function install_microovn_from_store() {
     local channel=$1; shift
     local containers=$*
+    local source_channel=""
+    local channel_pretty_name="default"
 
+    if [ -n "$channel" ]; then
+        channel_pretty_name="$channel"
+        source_channel="--channel $channel"
+    fi
     for container in $containers; do
-        echo "# Installing MicroOVN from SnapStore in container $container" >&3
-        lxc_exec "$container" "snap install microovn --channel $channel"
+        echo "# Installing MicroOVN from SnapStore ('$channel_pretty_name' channel) in container $container" >&3
+        lxc_exec "$container" "snap install microovn $source_channel"
     done
 }
 

--- a/tests/test_helper/setup_teardown/upgrade.bash
+++ b/tests/test_helper/setup_teardown/upgrade.bash
@@ -9,10 +9,11 @@ setup_file() {
     ABS_TOP_TEST_DIRNAME="${BATS_TEST_DIRNAME}/"
     export ABS_TOP_TEST_DIRNAME
 
-    # Env variable MICROOVN_SNAP_CHANNEL must be specified for tests to know
-    # from which channel should be MicroOVN installed before upgrading
-    assert [ -n "$MICROOVN_SNAP_CHANNEL" ]
+    # Determine MicroOVN channel from which we are upgrading
+    test_name=$(basename "$BATS_TEST_FILENAME")
+    MICROOVN_SNAP_CHANNEL=$(get_upgrade_test_version "$test_name" "$TEST_NAME_PREFIX")
 
+    # Create test deployment
     TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 4)
     CENTRAL_CONTAINERS=""
     CHASSIS_CONTAINERS=""


### PR DESCRIPTION
Upgrade tests need to determine the initial MicroOVN version so that it can be deployed, and then upgraded to the MicroOVN built from source. This verifies that the upgrade path is possible.

This initial version was previously controlled by env variable `MICROOVN_SNAP_CHANNEL`, but the limitation was that in a single run, we could define only one set of upgrade tests (from `MICROOVN_SNAP_CHANNEL` to currently built).

This change introduces a mechanism to determine the initial MicroOVN version based on the test filename instead. With this approach, we can create multiple symbolic links (e.g. `upgrade_22.03.bats -> upgrade.bast`, `upgrade_24.03.bats -> upgrade.bats`) to trigger multiple parallel upgrade tests.

Upgrade tests with the original/generic name (e.g. `upgrade.bats`) will upgrade from the version that's in the default channel for the MicroOVN snap.


---

Some general thoughts/discussion:
Every branch, `main`, `branch-22.03`, `branch-24.03` will have to have a different set of upgrade tests.

For `branch-22.03` we will:
* backport this change
* replace `upgrade.bats` with `upgrade_22.03.bats`
This will ensure that any change backported to `branch-22.03` will test upgrade against `22.03/stable` channel

For `main` branch we'll keep only the `upgrade.bats` file. This ensures that whatever goes to `main` branch (as eventual successor to the current default channel), will be tested against whatever is currently default MicroOVN. We can not add something like `upgrade_22.03.bats` to the `main` branch because we'll eventually build MicroOVN based on `OVN 24.09` (and later), and that won't be compatible for upgrade from `22.03`.
Also, since the `main` will become the development of `26.03`, we do not have to keep direct backward compatibility with `22.03`, only with `24.03`.

For `branch-24.03` we will keep only `upgrade.bats` for now. Once the `24.03/stable` channel is released, we will:
* remove `upgrade.bats`
* add `upgrade_22.03.bats`
* add `upgrade_24.03.bats`
This will ensure that whatever we backport to `branch-24.03` will be tested for upgrade with `22.03/stable` and `24.03/stable`.

I know this sounds like a lot, but after the initial setup, all we need to do in future releases is, at the point of publishing new stable channel, replace `upgrade.bats` with `upgrade_<current_LTS>.bats` and `upgrade_<previous_LTS>` in the corresponding branch. 