### PR TITLE
Better error message for cluster add

### DIFF
--- a/microovn/cmd/microovn/cluster_add.go
+++ b/microovn/cmd/microovn/cluster_add.go
@@ -35,7 +35,7 @@ func (c *cmdClusterAdd) Run(cmd *cobra.Command, args []string) error {
 
 	token, err := m.NewJoinToken(args[0])
 	if err != nil {
-		return err
+		return fmt.Errorf("Unable to add MicroCluster, name %q is taken",args[0])
 	}
 
 	fmt.Println(token)


### PR DESCRIPTION
Fix for microovn bug [#2039578](https://bugs.launchpad.net/microovn/+bug/2039578)
The error message now tells the user in a much more user friendly manner that the name is taken when trying to add a node with a non-unique error name