### PR TITLE
Removed old version package

### DIFF
--- a/microovn/cmd/microovn/main.go
+++ b/microovn/cmd/microovn/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cli "github.com/canonical/lxd/shared/cmd"
-	"github.com/canonical/microovn/microovn/version"
 )
 
 // CmdControl has functions that are common to the microctl commands.
@@ -42,7 +41,7 @@ func main() {
 	app := &cobra.Command{
 		Use:               "microovn",
 		Short:             "Command for managing the MicroOVN deployment",
-		Version:           version.Version,
+		Version:           MicroOvnVersion,
 		SilenceUsage:      true,
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	}

--- a/microovn/cmd/microovnd/main.go
+++ b/microovn/cmd/microovnd/main.go
@@ -16,8 +16,9 @@ import (
 	"github.com/canonical/microovn/microovn/api"
 	"github.com/canonical/microovn/microovn/database"
 	"github.com/canonical/microovn/microovn/ovn"
-	"github.com/canonical/microovn/microovn/version"
 )
+
+var MicroOvnVersion string
 
 // Debug indicates whether to log debug messages or not.
 var Debug bool
@@ -52,7 +53,7 @@ func (c *cmdDaemon) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "microd",
 		Short:   "Example daemon for MicroCluster - This will start a daemon with a running control socket and no database",
-		Version: version.Version,
+		Version:  MicroOvnVersion,
 	}
 
 	cmd.RunE = c.Run

--- a/microovn/version/version.go
+++ b/microovn/version/version.go
@@ -1,5 +1,0 @@
-// Package version provides shared version information.
-package version
-
-// Version is the current API version.
-const Version = "0.1"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -296,7 +296,10 @@ parts:
                          -X 'main.OvnVersion=${ovn_pkg_version}' \
                          -X 'main.OvsVersion=${ovs_pkg_version}'" \
                ./cmd/microovn
-      go build -o "${CRAFT_PART_INSTALL}/bin/microovnd" -tags=libsqlite3 ./cmd/microovnd
+      go build -o "${CRAFT_PART_INSTALL}/bin/microovnd" \
+               -ldflags "-X 'main.MicroOvnVersion=${git_version}'" \
+               -tags=libsqlite3 \
+               ./cmd/microovnd
     prime:
       - bin/microovn
       - bin/microovnd


### PR DESCRIPTION
Fix for microovn bug [#2030489](https://bugs.launchpad.net/ubuntu/+source/ovn/+bug/2030489)

The static 0.1 version package has now been removed This makes the cobra command use the new ovn version and in the case of microovnd, the build system is modified to also include a build time variable of the git version which is used in the cobra command