### PR TITLE
QuickFix for failing build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,6 @@
 name: microovn
 icon: microovn.png
 base: core24
-build-base: devel
 assumes:
  - snapd2.59
 adopt-info: microovn


### PR DESCRIPTION
Revert the build base to core24 allowing the vms to properly deploy and pack the snap, this is done to address the failing CI as a QuickFix.

This is passing the tests and the CI is nonfailing on my machine 

Signed-off-by: Mj Ponsonby <mj.ponsonby@canonical.com>