### PR TITLE
Fix for flapping ovsdb schema upgrade test

### DIFF
--- a/tests/test_helper/bats/ovsdb_schema_upgrade.bats
+++ b/tests/test_helper/bats/ovsdb_schema_upgrade.bats
@@ -110,6 +110,9 @@ setup() {
             break
         fi
 
+        # Get current `microovn status`
+        wait_ovn_services "$container"
+        wait_microovn_upgrading "$container" 30
         local status=""
         status=$(lxc_exec "$container" "microovn status")
 
@@ -150,6 +153,8 @@ setup() {
         assert [ "$current_sb" == "$original_sb" ]
     done
 
+
+    wait_microovn_online "$container" 60
     # After all cluster members are upgraded, verify that the cluster reports upgraded schema version
     # as well.
     local timeout=30

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -331,7 +331,9 @@ function microovn_wait_for_service_starttime() {
 #
 # If cluster members do not reach "online" state before the MAX_RETRY is reached, this
 # function returns 1 as a return code.
-function wait_microovn_online() {
+
+function wait_microovn_state(){
+    local state=$1; shift
     local container=$1; shift
     local max_retry=$1; shift
     local rc=1
@@ -339,11 +341,10 @@ function wait_microovn_online() {
     # Retry with 1s backoff until all MicroOVN members show ONLINE status
     for (( i = 1; i <= "$max_retry"; i++ )); do
         local all_online=1
-        echo "# ($container) Waiting for MicroOVN cluster to come ONLINE ($i/$max_retry)"
+        echo "# ($container) Waiting for MicroOVN cluster to come $state ($i/$max_retry)"
 
         # Each line in the output of command below shows individual cluster member status
         run lxc_exec "$container" "microovn cluster list -f json | jq -r .[].status"
-
         # Fail this iteration if 'microovn cluster list' fails.
         if [ "$status" -ne 0 ]; then
             all_online=0
@@ -353,14 +354,16 @@ function wait_microovn_online() {
         # the expected member status
         # shellcheck disable=SC2154 # Variable "$output" is exported from previous execution of 'run'
         while read -r status ; do
-            if [ "$status" != "ONLINE" ]; then
+            commandout="$(echo "$status" | grep "$state" | wc -l)"
+            echo $commandout
+            if [ "$commandout" -eq 0 ]; then
                 echo "# ($container) At least one member in state '$status'"
                 all_online=0
             fi
         done <<< "$output"
 
         if [ $all_online -eq 1 ] ; then
-            echo "# ($container) All cLuster members reach ONLINE state"
+            echo "# ($container) All cLuster members reach $state state"
             rc=0
             break
         fi
@@ -368,6 +371,15 @@ function wait_microovn_online() {
     done
 
     return $rc
+
+}
+
+function wait_microovn_online() {
+    wait_microovn_state "ONLINE" $1 $2
+}
+
+function wait_microovn_upgrading() {
+    wait_microovn_state "\(UPGRADING\|NEEDS UPGRADE\|ONLINE\)" $1 $2
 }
 
 # wait_ovsdb_cluster_changes_applied CONTAINER CONTROL_PATH DB_NAME TIMEOUT


### PR DESCRIPTION
Testsuite 'ovsdb_schema_upgrade.bats' was unstable and occasionally failed, this commit fixes that by modifying the wait_microovn_online to call a function that waits until each nodes status is valid given a regex string.

This function is used to check if node is upgrading, needing an upgrade or online instead of just online. This allows the test to pass reliably on my machine.

Reported-at: https://bugs.launchpad.net/microovn/+bug/2072658