### PR TITLE
Added the ability to disable/enable services

### DIFF
--- a/microovn/api/endpoints.go
+++ b/microovn/api/endpoints.go
@@ -19,6 +19,7 @@ var Server = rest.Server{
 			PathPrefix: types.APIVersion,
 			Endpoints: []rest.Endpoint{
 				services.ListCmd,
+				services.ServiceControlCmd,
 				certificates.IssueCertificatesEndpoint,
 				certificates.IssueCertificatesAllEndpoint,
 				certificates.RegenerateCaEndpoint,

--- a/microovn/api/endpoints.go
+++ b/microovn/api/endpoints.go
@@ -6,6 +6,7 @@ import (
 	"github.com/canonical/microovn/microovn/api/ovsdb"
 
 	"github.com/canonical/microovn/microovn/api/certificates"
+	"github.com/canonical/microovn/microovn/api/services"
 	"github.com/canonical/microovn/microovn/api/types"
 )
 
@@ -16,7 +17,8 @@ var Server = rest.Server{
 	Resources: []rest.Resources{
 		{
 			PathPrefix: types.APIVersion,
-			Endpoints: []rest.Endpoint{servicesCmd,
+			Endpoints: []rest.Endpoint{
+				services.ListCmd,
 				certificates.IssueCertificatesEndpoint,
 				certificates.IssueCertificatesAllEndpoint,
 				certificates.RegenerateCaEndpoint,

--- a/microovn/api/services/control.go
+++ b/microovn/api/services/control.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/microovn/microovn/ovn"
+)
+
+// /1.0/services/service endpoint.
+var ServiceControlCmd = rest.Endpoint{
+	Path:   "service/{service}",
+	Delete: rest.EndpointAction{Handler: disableService, AllowUntrusted: false, ProxyTarget: true},
+	Put:    rest.EndpointAction{Handler: enableService, AllowUntrusted: false, ProxyTarget: true},
+}
+
+func enableService(s *state.State, r *http.Request) response.Response {
+	requestedService, err := url.PathUnescape(mux.Vars(r)["service"])
+	if err != nil {
+		return response.InternalError(err)
+	}
+	if !ovn.CheckValidService(requestedService) {
+		return response.InternalError(errors.New("Service does not exist"))
+	}
+	err = ovn.EnableService(s, requestedService)
+	if err != nil {
+		return response.InternalError(err)
+	}
+	return response.SyncResponse(true, requestedService+" enabled")
+}
+
+func disableService(s *state.State, r *http.Request) response.Response {
+	requestedService, err := url.PathUnescape(mux.Vars(r)["service"])
+	if err != nil {
+		return response.InternalError(err)
+	}
+	if !ovn.CheckValidService(requestedService) {
+		return response.InternalError(errors.New("Service does not exist"))
+	}
+	err = ovn.DisableService(s, requestedService)
+	if err != nil {
+		return response.InternalError(err)
+	}
+	return response.SyncResponse(true, requestedService+" disabled")
+}

--- a/microovn/api/services/list.go
+++ b/microovn/api/services/list.go
@@ -1,4 +1,4 @@
-package api
+package services
 
 import (
 	"net/http"
@@ -11,7 +11,7 @@ import (
 )
 
 // /1.0/services endpoint.
-var servicesCmd = rest.Endpoint{
+var ListCmd = rest.Endpoint{
 	Path: "services",
 
 	Get: rest.EndpointAction{Handler: cmdServicesGet, ProxyTarget: true},

--- a/microovn/client/client.go
+++ b/microovn/client/client.go
@@ -132,3 +132,27 @@ func getOvsdbSchemaVersion(ctx context.Context, c *client.Client, dbSpec *ovnCmd
 
 	return response, types.OvsdbSchemaFetchErrorNone
 }
+
+func DisableService(ctx context.Context, c *client.Client, serviceName string) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	err := c.Query(queryCtx, "DELETE", types.APIVersion, api.NewURL().Path("service", serviceName), nil, nil)
+
+	if err != nil {
+		return fmt.Errorf("Failed to disable service '%s': '%s'", serviceName, err)
+	}
+	return nil
+}
+
+func EnableService(ctx context.Context, c *client.Client, serviceName string) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	err := c.Query(queryCtx, "PUT", types.APIVersion, api.NewURL().Path("service", serviceName), nil, nil)
+
+	if err != nil {
+		return fmt.Errorf("Failed to enable service '%s': '%s'", serviceName, err)
+	}
+	return nil
+}

--- a/microovn/cmd/microovn/main.go
+++ b/microovn/cmd/microovn/main.go
@@ -62,6 +62,12 @@ func main() {
 	var cmdStatus = cmdStatus{common: &commonCmd}
 	app.AddCommand(cmdStatus.Command())
 
+	var cmdDisable = cmdDisable{common: &commonCmd}
+	app.AddCommand(cmdDisable.Command())
+
+	var cmdEnable = cmdEnable{common: &commonCmd}
+	app.AddCommand(cmdEnable.Command())
+
 	// Nested.
 	var cmdCluster = cmdCluster{common: &commonCmd}
 	app.AddCommand(cmdCluster.Command())

--- a/microovn/cmd/microovn/service_control.go
+++ b/microovn/cmd/microovn/service_control.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microovn/microovn/client"
+)
+
+type cmdDisable struct {
+	common  *CmdControl
+	cluster *cmdCluster
+}
+
+func (c *cmdDisable) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disable <SERVICE>",
+		Short: "disables a service",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdDisable) Run(cmd *cobra.Command, args []string) error {
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+
+	targetService := args[0]
+	err = client.DisableService(context.Background(), cli, targetService)
+
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Service %s disabled\n", targetService)
+	return nil
+}
+
+type cmdEnable struct {
+	common  *CmdControl
+	cluster *cmdCluster
+}
+
+func (c *cmdEnable) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable <SERVICE>",
+		Short: "enables a service",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdEnable) Run(cmd *cobra.Command, args []string) error {
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+
+	targetService := args[0]
+	err = client.EnableService(context.Background(), cli, targetService)
+
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Service %s enabled\n", targetService)
+	return nil
+}

--- a/microovn/ovn/services.go
+++ b/microovn/ovn/services.go
@@ -1,0 +1,90 @@
+package ovn
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/canonical/microcluster/state"
+	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/node"
+)
+
+type SrvName string
+
+const (
+	SrvChassis SrvName = "chassis"
+	SrvCentral SrvName = "central"
+	SrvSwitch  SrvName = "switch"
+)
+
+var ServiceNames = []SrvName{SrvChassis, SrvCentral, SrvSwitch}
+
+func CheckValidService(service string) bool {
+	return slices.Contains(ServiceNames, SrvName(service))
+}
+
+func DisableService(s *state.State, service string) error {
+	exists, err := node.HasServiceActive(s, service)
+
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errors.New("This service is not enabled")
+	}
+
+	if SrvName(service) == SrvCentral {
+		err = snapStop("ovn-ovsdb-server-nb", true)
+		if err != nil {
+			return err
+		}
+		err = snapStop("ovn-ovsdb-server-sb", true)
+		if err != nil {
+			return err
+		}
+		err = snapStop("ovn-northd", true)
+	} else {
+		err = snapStop(service, true)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Snapctl error, likely due to service not existing:\n %w", err)
+	}
+
+	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
+		err := database.DeleteService(ctx, tx, s.Name(), service)
+		return err
+	})
+
+	return err
+
+}
+
+func EnableService(s *state.State, service string) error {
+	exists, err := node.HasServiceActive(s, service)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return errors.New("This Service is already enabled")
+	}
+
+	if !CheckValidService(service) {
+		return errors.New("Service does not exist")
+	}
+	err = snapStart(service, true)
+	if err != nil {
+		return fmt.Errorf("Snapctl error, likely due to service not existing:\n%w", err)
+	}
+
+	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
+		_, err := database.CreateService(ctx, tx, database.Service{Member: s.Name(), Service: service})
+		return err
+	})
+
+	return err
+
+}

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -1,0 +1,1 @@
+test_helper/bats/services.bats

--- a/tests/test_helper/bats/services.bats
+++ b/tests/test_helper/bats/services.bats
@@ -1,0 +1,61 @@
+
+load "${ABS_TOP_TEST_DIRNAME}test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+setup() {
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/common.bash
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/lxd.bash
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/microovn.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-support/load.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+}
+
+services_register_test_functions() {
+    bats_test_function \
+        --description "Testing of service functionality" \
+        -- service_tests
+}
+
+service_tests() {
+    for container in $TEST_CONTAINERS; do
+        # enable enabled service
+        run lxc_exec "$container" "microovn enable switch"
+        assert_output "Error: Failed to enable service 'switch': 'This Service is already enabled'"
+
+        # enable non existing service
+        run lxc_exec "$container" "microovn enable switchh"
+        assert_output "Error: Failed to enable service 'switchh': 'Service does not exist'"
+
+        # disable non existing service
+        run lxc_exec "$container" "microovn disable switchh"
+        assert_output "Error: Failed to disable service 'switchh': 'Service does not exist'"
+
+        # disable service
+        run lxc_exec "$container" "microovn disable switch"
+        assert_output "Service switch disabled"
+
+        # disable disabled service
+        run lxc_exec "$container" "microovn disable switch"
+        assert_output "Error: Failed to disable service 'switch': 'This service is not enabled'"
+
+        run lxc_exec "$container" "microovn status | grep switch"
+        assert_output ""
+
+        run lxc_exec "$container" "snap services microovn | grep switch | grep enabled"
+        assert_output ""
+
+        # enable disabled service
+        run lxc_exec "$container" "microovn enable switch"
+        assert_output "Service switch enabled"
+
+        assert [ -n "$(run lxc_exec "$container" "microovn status | grep switch")"]
+        assert [ -n "$(run lxc_exec "$container" "snap services microovn | grep switch | grep enabled")"]
+    done
+
+}
+
+
+services_register_test_functions

--- a/tests/test_helper/setup_teardown/services.bash
+++ b/tests/test_helper/setup_teardown/services.bash
@@ -1,0 +1,17 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 1)
+    export TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    bootstrap_cluster $TEST_CONTAINERS
+}
+
+teardown_file() {
+    delete_containers $TEST_CONTAINERS
+}


### PR DESCRIPTION
Adds commands and testing for the disabling and enabling of services, this is done through microovn enable <service> and microovn disable <service>.

This is deemed useful as the inability to control what nodes important services, such as central, are running on can mean a user may have their central database on lower performance nodes without the ability to move them.