### PR TITLE
tests: Increase upgrade timeout

### DIFF
--- a/tests/test_helper/bats/ovsdb_schema_upgrade.bats
+++ b/tests/test_helper/bats/ovsdb_schema_upgrade.bats
@@ -86,7 +86,7 @@ setup() {
 
         # If we upgraded all systems because of a dqlite schema update, ensure all nodes are online.
         if [ "$upgraded_size" -eq "$containers_size" ] ; then
-            run wait_microovn_online "$container" 45
+            run wait_microovn_online "$container" 65
             assert_success
         else
             # check that the schema upgrade was not triggered yet if we have not updated all nodes.


### PR DESCRIPTION
Due to the `microcluster` version used in `22.03` release, it can sometimes take two (30 seconds) heartbeats to fully converge cluster after upgrade. This was fixed in later versions [0], but we are increasing timeout to accommodate tests of older versions.

[0] https://github.com/canonical/microcluster/pull/113/commits/d78347458c4a3efb38cf86c5cfb8f26355b8093f