### PR TITLE
Migration of ovn/snap.go to its own package

### DIFF
--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/database"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/snap"
 )
 
 // Bootstrap will initialize a new OVN deployment.
@@ -74,7 +75,7 @@ func Bootstrap(s *state.State, initConfig map[string]string) error {
 	}
 
 	// Enable OVS switch.
-	err = snapStart("switch", true)
+	err = snap.SnapStart("switch", true)
 	if err != nil {
 		return fmt.Errorf("Failed to start OVS switch: %w", err)
 	}
@@ -94,17 +95,17 @@ func Bootstrap(s *state.State, initConfig map[string]string) error {
 	}
 
 	// Enable OVN central.
-	err = snapStart("ovn-ovsdb-server-nb", true)
+	err = snap.SnapStart("ovn-ovsdb-server-nb", true)
 	if err != nil {
 		return fmt.Errorf("Failed to start OVN NB: %w", err)
 	}
 
-	err = snapStart("ovn-ovsdb-server-sb", true)
+	err = snap.SnapStart("ovn-ovsdb-server-sb", true)
 	if err != nil {
 		return fmt.Errorf("Failed to start OVN SB: %w", err)
 	}
 
-	err = snapStart("ovn-northd", true)
+	err = snap.SnapStart("ovn-northd", true)
 	if err != nil {
 		return fmt.Errorf("Failed to start OVN northd: %w", err)
 	}
@@ -116,7 +117,7 @@ func Bootstrap(s *state.State, initConfig map[string]string) error {
 	}
 
 	// Enable OVN chassis.
-	err = snapStart("chassis", true)
+	err = snap.SnapStart("chassis", true)
 	if err != nil {
 		return fmt.Errorf("Failed to start OVN chassis: %w", err)
 	}

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/database"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/snap"
 )
 
 // Join will join an existing OVN deployment.
@@ -89,7 +90,7 @@ func Join(s *state.State, initConfig map[string]string) error {
 	}
 
 	// Enable OVS switch.
-	err = snapStart("switch", true)
+	err = snap.SnapStart("switch", true)
 	if err != nil {
 		return fmt.Errorf("Failed to start OVS switch: %w", err)
 	}
@@ -110,17 +111,17 @@ func Join(s *state.State, initConfig map[string]string) error {
 			return fmt.Errorf("failed to generate TLS certificate for ovn-northd service")
 		}
 
-		err = snapStart("ovn-ovsdb-server-nb", true)
+		err = snap.SnapStart("ovn-ovsdb-server-nb", true)
 		if err != nil {
 			return fmt.Errorf("Failed to start OVN NB: %w", err)
 		}
 
-		err = snapStart("ovn-ovsdb-server-sb", true)
+		err = snap.SnapStart("ovn-ovsdb-server-sb", true)
 		if err != nil {
 			return fmt.Errorf("Failed to start OVN SB: %w", err)
 		}
 
-		err = snapStart("ovn-northd", true)
+		err = snap.SnapStart("ovn-northd", true)
 		if err != nil {
 			return fmt.Errorf("Failed to start OVN northd: %w", err)
 		}
@@ -131,7 +132,7 @@ func Join(s *state.State, initConfig map[string]string) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovn-controller service")
 	}
-	err = snapStart("chassis", true)
+	err = snap.SnapStart("chassis", true)
 	if err != nil {
 		return fmt.Errorf("Failed to start OVN chassis: %w", err)
 	}

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -6,6 +6,7 @@ import (
 
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/ovn/paths"
+	"github.com/canonical/microovn/microovn/snap"
 )
 
 // Leave function gracefully departs from the OVN cluster before the member is removed from MicroOVN
@@ -28,12 +29,12 @@ func Leave(s *state.State, force bool) error {
 		logger.Warnf("Failed to gracefully stop OVN Controller: %s", err)
 	}
 
-	err = snapStop("chassis", true)
+	err = snap.SnapStop("chassis", true)
 	if err != nil {
 		logger.Warnf("Failed to stop Chassis service: %s", err)
 	}
 
-	err = snapStop("switch", true)
+	err = snap.SnapStop("switch", true)
 	if err != nil {
 		logger.Warnf("Failed to stop Switch service: %s", err)
 	}
@@ -72,17 +73,17 @@ func Leave(s *state.State, force bool) error {
 		logger.Warnf("Failed to get SB database specification: %s", err)
 	}
 
-	err = snapStop("ovn-northd", true)
+	err = snap.SnapStop("ovn-northd", true)
 	if err != nil {
 		logger.Warnf("Failed to stop OVN northd service: %s", err)
 	}
 
-	err = snapStop("ovn-ovsdb-server-nb", true)
+	err = snap.SnapStop("ovn-ovsdb-server-nb", true)
 	if err != nil {
 		logger.Warnf("Failed to stop OVN NB service: %s", err)
 	}
 
-	err = snapStop("ovn-ovsdb-server-sb", true)
+	err = snap.SnapStop("ovn-ovsdb-server-sb", true)
 	if err != nil {
 		logger.Warnf("Failed to stop OVN SB service: %s", err)
 	}

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/snap"
 )
 
 // Refresh will update the existing OVN central and OVS switch configs.
@@ -55,7 +56,7 @@ func refresh(s *state.State) error {
 
 	// Restart OVN Northd service to account for NB/SB cluster changes.
 	if hasCentral {
-		err = snapRestart("ovn-northd")
+		err = snap.SnapRestart("ovn-northd")
 		if err != nil {
 			return fmt.Errorf("Failed to restart OVN northd: %w", err)
 		}

--- a/microovn/ovn/services.go
+++ b/microovn/ovn/services.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/microcluster/state"
 	"github.com/canonical/microovn/microovn/database"
 	"github.com/canonical/microovn/microovn/node"
+	"github.com/canonical/microovn/microovn/snap"
 )
 
 type SrvName string
@@ -37,17 +38,17 @@ func DisableService(s *state.State, service string) error {
 	}
 
 	if SrvName(service) == SrvCentral {
-		err = snapStop("ovn-ovsdb-server-nb", true)
+		err = snap.SnapStop("ovn-ovsdb-server-nb", true)
 		if err != nil {
 			return err
 		}
-		err = snapStop("ovn-ovsdb-server-sb", true)
+		err = snap.SnapStop("ovn-ovsdb-server-sb", true)
 		if err != nil {
 			return err
 		}
-		err = snapStop("ovn-northd", true)
+		err = snap.SnapStop("ovn-northd", true)
 	} else {
-		err = snapStop(service, true)
+		err = snap.SnapStop(service, true)
 	}
 
 	if err != nil {
@@ -75,7 +76,7 @@ func EnableService(s *state.State, service string) error {
 	if !CheckValidService(service) {
 		return errors.New("Service does not exist")
 	}
-	err = snapStart(service, true)
+	err = snap.SnapStart(service, true)
 	if err != nil {
 		return fmt.Errorf("Snapctl error, likely due to service not existing:\n%w", err)
 	}

--- a/microovn/snap/snap.go
+++ b/microovn/snap/snap.go
@@ -1,4 +1,4 @@
-package ovn
+package snap
 
 import (
 	"fmt"
@@ -6,7 +6,7 @@ import (
 	"github.com/canonical/lxd/shared"
 )
 
-func snapStart(service string, enable bool) error {
+func SnapStart(service string, enable bool) error {
 	args := []string{
 		"start",
 		fmt.Sprintf("microovn.%s", service),
@@ -26,7 +26,7 @@ func snapStart(service string, enable bool) error {
 
 // snapStop stops specified snap service. Service can be optionally also disabled, ensuring
 // that it won't be automatically started on system reboot.
-func snapStop(service string, disable bool) error {
+func SnapStop(service string, disable bool) error {
 	args := []string{
 		"stop",
 		fmt.Sprintf("microovn.%s", service),
@@ -44,7 +44,7 @@ func snapStop(service string, disable bool) error {
 	return nil
 }
 
-func snapRestart(service string) error {
+func SnapRestart(service string) error {
 	args := []string{
 		"restart",
 		fmt.Sprintf("microovn.%s", service),
@@ -58,7 +58,7 @@ func snapRestart(service string) error {
 	return nil
 }
 
-func snapReload(service string) error {
+func SnapReload(service string) error {
 	args := []string{
 		"restart",
 		"--reload",


### PR DESCRIPTION
The ovn package has been getting somewhat bloated with unnecessary functionality unrelated to ovn, This is the 1st of two patches in an attempt to debloat the ovn package and minimize unnecessary dependencies