### PR TITLE
Fix for  BUG #2074365 "microovn certificates reissue" does not check for required arguments

### DIFF
--- a/microovn/cmd/microovn/certificates_reissue.go
+++ b/microovn/cmd/microovn/certificates_reissue.go
@@ -44,7 +44,10 @@ func (c *cmdCertificatesReissue) Command() *cobra.Command {
 
 // Run method is an implementation of "microovn certificates reissue" subcommand. It requests local MicroOVN
 // service to issue new certificate for selected OVN service.
-func (c *cmdCertificatesReissue) Run(_ *cobra.Command, args []string) error {
+func (c *cmdCertificatesReissue) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmd.Help()
+	}
 	var response types.IssueCertificateResponse
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
 	if err != nil {

--- a/tests/test_helper/bats/tls_cluster.bats
+++ b/tests/test_helper/bats/tls_cluster.bats
@@ -44,6 +44,9 @@ tls_cluster_register_test_functions() {
     bats_test_function \
         --description "Regenerate CA" \
         -- tls_cluster_regenerate_ca
+    bats_test_function \
+        --description "Reissue certificate without argument" \
+        -- tls_cluster_reissue_certificate_help    
 }
 
 tls_cluster_central_have_tls() {
@@ -314,6 +317,17 @@ tls_cluster_regenerate_ca() {
     for container in $CHASSIS_CONTAINERS; do
         verify_chassis_cert_files "$container"
     done
+}
+
+
+tls_cluster_reissue_certificate_help() {
+    # Ensure that MicroOVN return help function instead of an error when you run the command without any argument
+    local container=""
+    container=$(echo "$CHASSIS_CONTAINERS" | awk '{print $1;}')
+
+    run lxc_exec "$container" "microovn certificates reissue"
+    assert_success
+
 }
 
 tls_cluster_register_test_functions


### PR DESCRIPTION
1.  "cmd.Help()" function will be called if no argument is provided to "microovn certificates reissue"  command. 
2. "tls_cluster_reissue_certificate_help"  test case has been added. 
 