### PR TITLE
golangci-lint: Increase timeout.

### DIFF
--- a/microovn/.golangci.yml
+++ b/microovn/.golangci.yml
@@ -1,3 +1,8 @@
+run:
+  # The default of 1 minute is a pretty low number when taking into account the
+  # size of the project and its dependencies and the potential load of the
+  # various build environments this project is exposed to.
+  timeout: 5m
 issues:
   # The default exclude rules disable the requirement for GoDoc comments in the
   # revive linter, so we can't use them.


### PR DESCRIPTION
By default, `golangci-lint` operates with a timeout for execution of 1 minute [0].

That is a pretty low number when taking into account the size of the project and its dependencies and the potential load of the various build environments this project is exposed to.

0: https://golangci-lint.run/usage/configuration/
Reported-at: https://launchpad.net/bugs/2076157
Fixes: a1495d98bb00 ("snap: Run golangci-lint as part of build.")
Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>