### PR TITLE
Migration of ovn/certificates to its own package

### DIFF
--- a/microovn/api/certificates/common.go
+++ b/microovn/api/certificates/common.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
-	"github.com/canonical/microovn/microovn/ovn"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 )
 
 // enabledOvnServices returns list of OVN services enabled on this MicroOVN cluster member.
@@ -53,7 +53,7 @@ func reissueAllCertificates(ctx context.Context, s state.State) (*types.IssueCer
 	}
 
 	for _, service := range activeServices {
-		err = ovn.GenerateNewServiceCertificate(ctx, s, service, ovn.CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, service, certificates.CertificateTypeServer)
 		if err != nil {
 			logger.Errorf("Failed to issue certificate for %s: %s", service, err)
 			responseData.Failed = append(responseData.Failed, service)

--- a/microovn/api/certificates/issue.go
+++ b/microovn/api/certificates/issue.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/microovn/microovn/api/types"
-	"github.com/canonical/microovn/microovn/ovn"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 )
 
 // IssueCertificatesEndpoint defines endpoint for /1.0/certificates/<service-name>.
@@ -61,7 +61,7 @@ func issueCertificatesPut(s state.State, r *http.Request) response.Response {
 	}
 
 	// Attempt to issue new certificate and return response object
-	err = ovn.GenerateNewServiceCertificate(r.Context(), s, requestedService, ovn.CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(r.Context(), s, requestedService, certificates.CertificateTypeServer)
 	result := types.IssueCertificateResponse{}
 
 	if err != nil {

--- a/microovn/api/certificates/regenerate_ca.go
+++ b/microovn/api/certificates/regenerate_ca.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/api/types"
 	microovnClient "github.com/canonical/microovn/microovn/client"
-	"github.com/canonical/microovn/microovn/ovn"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 )
 
 // RegenerateCaEndpoint defines endpoint for /1.0/ca
@@ -32,7 +32,7 @@ func regenerateCaPut(s state.State, r *http.Request) response.Response {
 	if client.IsNotification(r) {
 		// Only one recipient of this request needs to generate new CA
 		logger.Info("Re-issuing CA certificate and private key")
-		err = ovn.GenerateNewCACertificate(r.Context(), s)
+		err = certificates.GenerateNewCACertificate(r.Context(), s)
 		if err != nil {
 			logger.Errorf("Failed to generate new CA certificate: %v", err)
 			responseData.NewCa = false
@@ -69,7 +69,7 @@ func regenerateCaPut(s state.State, r *http.Request) response.Response {
 	}
 
 	logger.Info("Re-issuing all local OVN certificates")
-	err = ovn.DumpCA(r.Context(), s)
+	err = certificates.DumpCA(r.Context(), s)
 	if err != nil {
 		logger.Errorf("%v", err)
 		return response.SyncResponse(false, &responseData)

--- a/microovn/api/services/control.go
+++ b/microovn/api/services/control.go
@@ -6,10 +6,12 @@ import (
 	"net/url"
 
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/v2/rest"
 	"github.com/canonical/microcluster/v2/state"
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
 )
 
@@ -20,10 +22,16 @@ var ServiceControlCmd = rest.Endpoint{
 	Put:    rest.EndpointAction{Handler: enableService, AllowUntrusted: false, ProxyTarget: true},
 }
 
+// enableService - function to handle to service control put request,
+// which aims to enable a service.
+//
+// This will return a response which contains a WarningSet for the
+// current desired state and a response string on the operation
 func enableService(s state.State, r *http.Request) response.Response {
 	requestedService, err := url.PathUnescape(mux.Vars(r)["service"])
 	if err != nil {
-		return response.InternalError(err)
+		logger.Errorf("Failed to get service: %s", err)
+		return response.ErrorResponse(500, "Internal server error")
 	}
 	if !node.CheckValidService(requestedService) {
 		return response.InternalError(errors.New("Service does not exist"))
@@ -32,13 +40,28 @@ func enableService(s state.State, r *http.Request) response.Response {
 	if err != nil {
 		return response.InternalError(err)
 	}
-	return response.SyncResponse(true, requestedService+" enabled")
+
+	scr := types.ServiceControlResponse{}
+	scr.Warnings, err = node.ServiceWarnings(r.Context(), s)
+	if err != nil {
+		logger.Errorf("Failed to generate warnings for service: %s: %s", requestedService, err)
+		return response.ErrorResponse(500, "Internal server error")
+	}
+	scr.Message = requestedService + " enabled"
+
+	return response.SyncResponse(true, scr)
 }
 
+// disableService - function to handle to service control delete request,
+// which aims to disable a service.
+//
+// This will return a response which contains a WarningSet for the
+// current desired state and a response string on the operation
 func disableService(s state.State, r *http.Request) response.Response {
 	requestedService, err := url.PathUnescape(mux.Vars(r)["service"])
 	if err != nil {
-		return response.InternalError(err)
+		logger.Errorf("Failed to get service: %s", err)
+		return response.ErrorResponse(500, "Internal server error")
 	}
 	if !node.CheckValidService(requestedService) {
 		return response.InternalError(errors.New("Service does not exist"))
@@ -47,5 +70,14 @@ func disableService(s state.State, r *http.Request) response.Response {
 	if err != nil {
 		return response.InternalError(err)
 	}
-	return response.SyncResponse(true, requestedService+" disabled")
+
+	scr := types.ServiceControlResponse{}
+	scr.Warnings, err = node.ServiceWarnings(r.Context(), s)
+	if err != nil {
+		logger.Errorf("Failed to generate warnings for service: %s: %s", requestedService, err)
+		return response.ErrorResponse(500, "Internal server error")
+	}
+	scr.Message = requestedService + " disabled"
+
+	return response.SyncResponse(true, scr)
 }

--- a/microovn/api/services/list.go
+++ b/microovn/api/services/list.go
@@ -17,6 +17,9 @@ var ListCmd = rest.Endpoint{
 	Get: rest.EndpointAction{Handler: cmdServicesGet, ProxyTarget: true},
 }
 
+// cmdServicesGet - handles services endpoint functionality,
+// by calling the respective function within node and then handling
+// any errors it throws.
 func cmdServicesGet(s state.State, r *http.Request) response.Response {
 	services, err := node.ListServices(r.Context(), s)
 	if err != nil {

--- a/microovn/api/types/services.go
+++ b/microovn/api/types/services.go
@@ -1,13 +1,55 @@
 // Package types provides shared types and structs.
 package types
 
+import (
+	"log"
+)
+
 // Services - Slice with Service records.
 type Services []Service
 
 // Service  - A service.
 type Service struct {
-	// Service - name of Service
+	// Service - name of Service.
 	Service string `json:"service" yaml:"service"`
-	// Location - location of Service
+	// Location - location of Service.
 	Location string `json:"location" yaml:"location"`
+}
+
+// WarningSet - a set of warnings on the desired service state.
+type WarningSet struct {
+	// EvenCentral - are there an even number of central services which is
+	// inefficent due to how RAFT works.
+	EvenCentral bool `json:"EvenCentral" yaml:"EvenCentral"`
+	// FewCentral - are there not enough central services to handle one
+	// node failure.
+	FewCentral bool `json:"FewCentral" yaml:"FewCentral"`
+}
+
+// ServiceControlResponse (SCR) - a struct to return both a response and any
+// warnings, usually used when interfacing with the service control functions.
+type ServiceControlResponse struct {
+	// Message - any output needed from the service control functions.
+	Message string `json:"message" yaml:"message"`
+	// Warnings - the set of warnings with the desired state of services.
+	Warnings WarningSet `json:"warnings" yaml:"warnings"`
+}
+
+// PrettyPrint - Formats and prints contents of WarningSet object.
+func (w WarningSet) PrettyPrint(verbose bool) {
+	if w.EvenCentral {
+		if verbose {
+			log.Println("[central] Warning: Cluster with even number of members has same fault tolerance, but higher quorum requirements, than cluster with one less member.")
+		} else {
+			log.Println("[central] Warning: OVN Cluster has even number of members")
+		}
+	}
+
+	if w.FewCentral {
+		if verbose {
+			log.Println("[central] Warning: Cluster with less than 3 nodes can't tolerate any node failures.")
+		} else {
+			log.Println("[central] Warning: OVN Cluster has critically few members")
+		}
+	}
 }

--- a/microovn/client/client.go
+++ b/microovn/client/client.go
@@ -134,28 +134,28 @@ func getOvsdbSchemaVersion(ctx context.Context, c *client.Client, dbSpec *ovnCmd
 
 // DisableService sends request to disable service with name as specified in
 // "serviceName" argument.
-func DisableService(ctx context.Context, c *client.Client, serviceName string) error {
+func DisableService(ctx context.Context, c *client.Client, serviceName string) (types.WarningSet, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
-
-	err := c.Query(queryCtx, "DELETE", types.APIVersion, api.NewURL().Path("service", serviceName), nil, nil)
+	scr := types.ServiceControlResponse{}
+	err := c.Query(queryCtx, "DELETE", types.APIVersion, api.NewURL().Path("service", serviceName), nil, &scr)
 
 	if err != nil {
-		return fmt.Errorf("Failed to disable service '%s': '%s'", serviceName, err)
+		return types.WarningSet{}, fmt.Errorf("Failed to disable service '%s': '%s'", serviceName, err)
 	}
-	return nil
+	return scr.Warnings, nil
 }
 
 // EnableService sends request to disable service with name as as specified in
 // "serviceName" argument.
-func EnableService(ctx context.Context, c *client.Client, serviceName string) error {
+func EnableService(ctx context.Context, c *client.Client, serviceName string) (types.WarningSet, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
-
-	err := c.Query(queryCtx, "PUT", types.APIVersion, api.NewURL().Path("service", serviceName), nil, nil)
+	scr := types.ServiceControlResponse{}
+	err := c.Query(queryCtx, "PUT", types.APIVersion, api.NewURL().Path("service", serviceName), nil, &scr)
 
 	if err != nil {
-		return fmt.Errorf("Failed to enable service '%s': '%s'", serviceName, err)
+		return types.WarningSet{}, fmt.Errorf("Failed to enable service '%s': '%s'", serviceName, err)
 	}
-	return nil
+	return scr.Warnings, nil
 }

--- a/microovn/cmd/microovn/service_control.go
+++ b/microovn/cmd/microovn/service_control.go
@@ -40,12 +40,13 @@ func (c *cmdDisable) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	targetService := args[0]
-	err = client.DisableService(context.Background(), cli, targetService)
+	ws, err := client.DisableService(context.Background(), cli, targetService)
 
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Service %s disabled\n", targetService)
+	ws.PrettyPrint(c.common.FlagLogVerbose)
 	return nil
 }
 
@@ -79,11 +80,12 @@ func (c *cmdEnable) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	targetService := args[0]
-	err = client.EnableService(context.Background(), cli, targetService)
+	ws, err := client.EnableService(context.Background(), cli, targetService)
 
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Service %s enabled\n", targetService)
+	ws.PrettyPrint(c.common.FlagLogVerbose)
 	return nil
 }

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/snap"
 )
@@ -49,12 +50,12 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Generate CA certificate and key
-	err = GenerateNewCACertificate(ctx, s)
+	err = certificates.GenerateNewCACertificate(ctx, s)
 	if err != nil {
 		return err
 	}
 
-	err = DumpCA(ctx, s)
+	err = certificates.DumpCA(ctx, s)
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	// Note that we intentially use a sever type certificate here due to
 	// all OVS-based programs ability to specify active or passive (listen)
 	// connection types.
-	err = GenerateNewServiceCertificate(ctx, s, "client", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "client", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
 	}
@@ -81,15 +82,15 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Generate certificate for OVN Central services
-	err = GenerateNewServiceCertificate(ctx, s, "ovnnb", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnnb", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovnnb service: %s", err)
 	}
-	err = GenerateNewServiceCertificate(ctx, s, "ovnsb", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnsb", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovnsb service: %s", err)
 	}
-	err = GenerateNewServiceCertificate(ctx, s, "ovn-northd", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-northd", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovn-northd service: %s", err)
 	}
@@ -111,7 +112,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Generate certificate for OVN chassis (controller)
-	err = GenerateNewServiceCertificate(ctx, s, "ovn-controller", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-controller", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovn-controller service: %s", err)
 	}

--- a/microovn/ovn/certificates/certificates.go
+++ b/microovn/ovn/certificates/certificates.go
@@ -1,4 +1,6 @@
-package ovn
+// Package certificates is for exposing certificate generation functionality within
+// ovn
+package certificates
 
 import (
 	"context"
@@ -220,9 +222,9 @@ func DumpCA(ctx context.Context, s state.State) error {
 	return nil
 }
 
-// getCA pulls PEM encoded CA certificate and private key from shared database and returns
+// GetCA pulls PEM encoded CA certificate and private key from shared database and returns
 // them as parsed objects x509.Certificate and ecdsa.PrivateKey (+ error if any occurred).
-func getCA(ctx context.Context, s state.State) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+func GetCA(ctx context.Context, s state.State) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	var err error
 	var CACertRecord *database.ConfigItem
 	var CAKeyRecord *database.ConfigItem
@@ -299,7 +301,7 @@ func GenerateNewServiceCertificate(ctx context.Context, s state.State, serviceNa
 		return fmt.Errorf("unable to set permissions for %s private key: %w", serviceName, err)
 	}
 
-	caCert, caKey, err := getCA(ctx, s)
+	caCert, caKey, err := GetCA(ctx, s)
 	if err != nil {
 		return err
 	}

--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 	"github.com/canonical/microovn/microovn/ovn/paths"
 )
 
@@ -33,7 +34,7 @@ OVN_LOCAL_IP="{{ .localAddr }}"
 // networkProtocol returns appropriate network protocol that should be used
 // by OVN services.
 func networkProtocol(ctx context.Context, s state.State) string {
-	_, _, err := getCA(ctx, s)
+	_, _, err := certificates.GetCA(ctx, s)
 	if err != nil {
 		return "tcp"
 	}

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/snap"
 )
@@ -78,13 +79,13 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	// Note that we intentially use a sever type certificate here due to
 	// all OVS-based programs ability to specify active or passive (listen)
 	// connection types.
-	err = GenerateNewServiceCertificate(ctx, s, "client", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "client", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
 	}
 
 	// Copy shared CA certificate from shared database to file on disk
-	err = DumpCA(ctx, s)
+	err = certificates.DumpCA(ctx, s)
 	if err != nil {
 		return err
 	}
@@ -98,15 +99,15 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	// Enable OVN central (if needed).
 	if srvCentral < 3 {
 		// Generate certificate for OVN Central services
-		err = GenerateNewServiceCertificate(ctx, s, "ovnnb", CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnnb", certificates.CertificateTypeServer)
 		if err != nil {
 			return fmt.Errorf("failed to generate TLS certificate for ovnnb service")
 		}
-		err = GenerateNewServiceCertificate(ctx, s, "ovnsb", CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnsb", certificates.CertificateTypeServer)
 		if err != nil {
 			return fmt.Errorf("failed to generate TLS certificate for ovnsb service")
 		}
-		err = GenerateNewServiceCertificate(ctx, s, "ovn-northd", CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-northd", certificates.CertificateTypeServer)
 		if err != nil {
 			return fmt.Errorf("failed to generate TLS certificate for ovn-northd service")
 		}
@@ -128,7 +129,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	}
 
 	// Generate certificate for OVN chassis (controller)
-	err = GenerateNewServiceCertificate(ctx, s, "ovn-controller", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-controller", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovn-controller service")
 	}

--- a/tests/test_helper/bats/services.bats
+++ b/tests/test_helper/bats/services.bats
@@ -17,6 +17,9 @@ services_register_test_functions() {
     bats_test_function \
         --description "Testing of service functionality" \
         -- service_tests
+    bats_test_function \
+        --description "Testing of service control warnings and errors" \
+        -- service_warning_tests
 }
 
 service_tests() {
@@ -41,7 +44,7 @@ service_tests() {
         run lxc_exec "$container" "microovn disable switch"
         assert_output "Error: Failed to disable service 'switch': 'This service is not enabled'"
 
-        run lxc_exec "$container" "microovn status | grep switch"
+        run lxc_exec "$container" "microovn status | grep -ozE '${container}[^-]*' | grep switch"
         assert_output ""
 
         run lxc_exec "$container" "snap services microovn | grep switch | grep enabled"
@@ -51,10 +54,25 @@ service_tests() {
         run lxc_exec "$container" "microovn enable switch"
         assert_output "Service switch enabled"
 
-        assert [ -n "$(run lxc_exec "$container" "microovn status | grep switch")"]
+        assert [ -n "$(run lxc_exec "$container" "microovn status | grep -ozE '${container}[^-]*' | grep switch")"]
         assert [ -n "$(run lxc_exec "$container" "snap services microovn | grep switch | grep enabled")"]
     done
+}
 
+service_warning_tests() {
+    run lxc_exec "microovn-services-1" "microovn disable central -v 1>/dev/null"
+    assert_output -p "[central] Warning: Cluster with even number of members has same fault tolerance, but higher quorum requirements, than cluster with one less member."
+    assert_output -p "[central] Warning: Cluster with less than 3 nodes can't tolerate any node failures."
+
+    run lxc_exec "microovn-services-2" "microovn disable central -v 1>/dev/null"
+    assert_output -p "[central] Warning: Cluster with less than 3 nodes can't tolerate any node failures."
+
+    run lxc_exec "microovn-services-3" "microovn disable central"
+    assert_output "Error: Failed to disable service 'central': 'You cannot delete the final enabled central service'"
+
+    # ensure central is actually still enabled
+    assert [ -n "$(run lxc_exec "microovn-services-3" "microovn status | grep -ozE 'microovn-services-3[^-]*' | grep central")"]
+    assert [ -n "$(run lxc_exec "microovn-services-3" "snap services microovn | grep ovn-northd | grep enabled")"]
 }
 
 

--- a/tests/test_helper/setup_teardown/services.bash
+++ b/tests/test_helper/setup_teardown/services.bash
@@ -4,7 +4,7 @@ setup_file() {
     load test_helper/microovn.bash
 
 
-    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 1)
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
     export TEST_CONTAINERS
     launch_containers $TEST_CONTAINERS
     wait_containers_ready $TEST_CONTAINERS


### PR DESCRIPTION
By moving ovn/certificates to its own package it both debloats the ovn package and allows its functionality to be used by packages which the ovn package depends on such as within node/EnableServices.

This will be necessary for ensuring central nodes have full functionality when enabled from being a non central node, as they need valid certificates to interface with other central nodes

requires #157 to be merged
