### PR TITLE
Better (enabling|disabling) of central services

### DIFF
--- a/microovn/api/certificates/common.go
+++ b/microovn/api/certificates/common.go
@@ -18,12 +18,12 @@ func enabledOvnServices(ctx context.Context, s state.State) ([]string, error) {
 	var enabledServices []string
 	var wrappedError error
 
-	hasCentral, err := node.HasServiceActive(ctx, s, "central")
+	hasCentral, err := node.HasServiceActive(ctx, s, types.SrvCentral)
 	if err != nil {
 		wrappedError = errors.Join(wrappedError, fmt.Errorf("failed to lookup local services eligible for certificate refresh: %s", err))
 	}
 
-	hasSwitch, err := node.HasServiceActive(ctx, s, "switch")
+	hasSwitch, err := node.HasServiceActive(ctx, s, types.SrvSwitch)
 	if err != nil {
 		wrappedError = errors.Join(wrappedError, fmt.Errorf("failed to lookup local services eligible for certificate refresh: %s", err))
 	}

--- a/microovn/api/certificates/common.go
+++ b/microovn/api/certificates/common.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
-	"github.com/canonical/microovn/microovn/ovn"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 )
 
 // enabledOvnServices returns list of OVN services enabled on this MicroOVN cluster member.
@@ -53,7 +53,7 @@ func reissueAllCertificates(ctx context.Context, s state.State) (*types.IssueCer
 	}
 
 	for _, service := range activeServices {
-		err = ovn.GenerateNewServiceCertificate(ctx, s, service, ovn.CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, service, certificates.CertificateTypeServer)
 		if err != nil {
 			logger.Errorf("Failed to issue certificate for %s: %s", service, err)
 			responseData.Failed = append(responseData.Failed, service)

--- a/microovn/api/certificates/issue.go
+++ b/microovn/api/certificates/issue.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/microovn/microovn/api/types"
-	"github.com/canonical/microovn/microovn/ovn"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 )
 
 // IssueCertificatesEndpoint defines endpoint for /1.0/certificates/<service-name>.
@@ -61,7 +61,7 @@ func issueCertificatesPut(s state.State, r *http.Request) response.Response {
 	}
 
 	// Attempt to issue new certificate and return response object
-	err = ovn.GenerateNewServiceCertificate(r.Context(), s, requestedService, ovn.CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(r.Context(), s, requestedService, certificates.CertificateTypeServer)
 	result := types.IssueCertificateResponse{}
 
 	if err != nil {

--- a/microovn/api/certificates/regenerate_ca.go
+++ b/microovn/api/certificates/regenerate_ca.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/api/types"
 	microovnClient "github.com/canonical/microovn/microovn/client"
-	"github.com/canonical/microovn/microovn/ovn"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 )
 
 // RegenerateCaEndpoint defines endpoint for /1.0/ca
@@ -32,7 +32,7 @@ func regenerateCaPut(s state.State, r *http.Request) response.Response {
 	if !client.IsNotification(r) {
 		// Only one recipient of this request needs to generate new CA
 		logger.Info("Re-issuing CA certificate and private key")
-		err = ovn.GenerateNewCACertificate(r.Context(), s)
+		err = certificates.GenerateNewCACertificate(r.Context(), s)
 		if err != nil {
 			logger.Errorf("Failed to generate new CA certificate: %v", err)
 			responseData.NewCa = false
@@ -69,7 +69,7 @@ func regenerateCaPut(s state.State, r *http.Request) response.Response {
 	}
 
 	logger.Info("Re-issuing all local OVN certificates")
-	err = ovn.DumpCA(r.Context(), s)
+	err = certificates.DumpCA(r.Context(), s)
 	if err != nil {
 		logger.Errorf("%v", err)
 		return response.SyncResponse(false, &responseData)

--- a/microovn/api/endpoints.go
+++ b/microovn/api/endpoints.go
@@ -21,6 +21,7 @@ var Server = map[string]rest.Server{
 				Endpoints: []rest.Endpoint{
 					services.ListCmd,
 					services.ServiceControlCmd,
+					RegenerateEnvEndpoint,
 					certificates.IssueCertificatesEndpoint,
 					certificates.IssueCertificatesAllEndpoint,
 					certificates.RegenerateCaEndpoint,

--- a/microovn/api/ovsdb/schema_version.go
+++ b/microovn/api/ovsdb/schema_version.go
@@ -121,7 +121,7 @@ func getAllExpectedSchemaVersions(s state.State, r *http.Request) response.Respo
 // If the node receives request for Northbound or Southbound DB schema version, but the not is not running
 // these central services, the request will be forwarded to a node that does run them.
 func getActiveSchemaVersion(s state.State, r *http.Request) response.Response {
-	hasCentral, err := node.HasServiceActive(r.Context(), s, "central")
+	hasCentral, err := node.HasServiceActive(r.Context(), s, types.SrvCentral)
 	if err != nil {
 		logger.Errorf("failed to check if central is active on this node: %s", err)
 		return response.ErrorResponse(500, "Internal Server Error")

--- a/microovn/api/refresh.go
+++ b/microovn/api/refresh.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microcluster/v2/client"
+	"github.com/canonical/microcluster/v2/rest"
+	"github.com/canonical/microcluster/v2/state"
+
+	"github.com/canonical/microovn/microovn/api/types"
+	microovnClient "github.com/canonical/microovn/microovn/client"
+	"github.com/canonical/microovn/microovn/ovn"
+)
+
+// RegenerateEnvEndpoint defines endpoint for /1.0/env
+var RegenerateEnvEndpoint = rest.Endpoint{
+	Path: "env",
+	Post: rest.EndpointAction{Handler: regenerateEnvPost, AllowUntrusted: false, ProxyTarget: true},
+}
+
+// regenerateEnvPost implements POST method for /1.0/env endpoint.
+// This function triggers and environment update on all MicroOVN cluster members.
+// This is typically to be used with enabling and disabling entral services.
+func regenerateEnvPost(s state.State, r *http.Request) response.Response {
+	var err error
+	responseData := types.NewRegenerateEnvResponse()
+
+	// Check that this is the initial node to recive this request
+	if !client.IsNotification(r) {
+		logger.Infof("Understood notification, forwarding refresh env request")
+		// Get clients for the rest of the cluster members
+		cluster, err := s.Cluster(true)
+		if err != nil {
+			logger.Errorf("Failed to get a client for every cluster member: %v", err)
+			responseData.Success = false
+			return response.SyncResponse(false, &responseData)
+		}
+		responseData.Success = true
+
+		// Bump rest of the cluster members to regenerate their environment
+		err = cluster.Query(r.Context(), true, func(ctx context.Context, c *client.Client) error {
+			clientURL := c.URL()
+			logger.Infof("Requesting cluster member at '%s' to regenerate its environment file", clientURL.String())
+
+			_, err := microovnClient.RegenerateEnvironment(ctx, c)
+
+			if err != nil {
+				errMsg := fmt.Sprintf("Failed to contact cluster member with address %q: %s", clientURL.String(), err)
+				responseData.Errors = append(responseData.Errors, errMsg)
+			}
+			return nil
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	logger.Info("Regenerating environment file")
+
+	err = ovn.Refresh(context.Background(), r.Context(), s)
+	if err != nil {
+		logger.Errorf("Failed to refresh environment: %s", err)
+		return response.SyncResponse(false, &responseData)
+	}
+	return response.SyncResponse(true, &responseData)
+}

--- a/microovn/api/services/control.go
+++ b/microovn/api/services/control.go
@@ -33,7 +33,7 @@ func enableService(s state.State, r *http.Request) response.Response {
 		logger.Errorf("Failed to get service: %s", err)
 		return response.ErrorResponse(500, "Internal server error")
 	}
-	if !node.CheckValidService(requestedService) {
+	if !types.CheckValidService(requestedService) {
 		return response.InternalError(errors.New("Service does not exist"))
 	}
 
@@ -64,7 +64,7 @@ func disableService(s state.State, r *http.Request) response.Response {
 		logger.Errorf("Failed to get service: %s", err)
 		return response.ErrorResponse(500, "Internal server error")
 	}
-	if !node.CheckValidService(requestedService) {
+	if !types.CheckValidService(requestedService) {
 		return response.InternalError(errors.New("Service does not exist"))
 	}
 	err = node.DisableService(r.Context(), s, requestedService)

--- a/microovn/api/services/control.go
+++ b/microovn/api/services/control.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
-	"github.com/canonical/microovn/microovn/ovn"
 )
 
 // ServiceControlCmd - /1.0/services/service endpoint.
@@ -37,15 +35,6 @@ func enableService(s state.State, r *http.Request) response.Response {
 	}
 	if !node.CheckValidService(requestedService) {
 		return response.InternalError(errors.New("Service does not exist"))
-	}
-	if node.SrvName(requestedService) == node.SrvCentral {
-		shutdownCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		err = ovn.Refresh(shutdownCtx, r.Context(), s)
-		if err != nil {
-			logger.Errorf("Failed to refresh environment: %s", err)
-			return response.ErrorResponse(500, "Internal server error")
-		}
 	}
 
 	err = node.EnableService(r.Context(), s, requestedService)

--- a/microovn/api/types/services.go
+++ b/microovn/api/types/services.go
@@ -12,7 +12,7 @@ type Services []Service
 // Service  - A service.
 type Service struct {
 	// Service - name of Service.
-	Service string `json:"service" yaml:"service"`
+	Service SrvName `json:"service" yaml:"service"`
 	// Location - location of Service.
 	Location string `json:"location" yaml:"location"`
 }
@@ -87,4 +87,30 @@ func NewRegenerateEnvResponse() RegenerateEnvResponse {
 		Success: false,
 		Errors:  make([]string, 0),
 	}
+}
+
+// SrvName - string representation of a service.
+type SrvName = string
+
+const (
+	// SrvChassis - string representation of chassis service.
+	SrvChassis SrvName = "chassis"
+	// SrvCentral - string representation of central service.
+	SrvCentral SrvName = "central"
+	// SrvSwitch - string representation of switch service.
+	SrvSwitch SrvName = "switch"
+)
+
+// ServiceNames - slice containing all known SrvName strings.
+var ServiceNames = []SrvName{SrvChassis, SrvCentral, SrvSwitch}
+
+// CheckValidService - checks whether the string in "service" is in fact a
+// known and valid service name.
+func CheckValidService(service string) bool {
+	for _, s := range ServiceNames {
+		if s == service {
+			return true
+		}
+	}
+	return false
 }

--- a/microovn/api/types/services.go
+++ b/microovn/api/types/services.go
@@ -2,6 +2,7 @@
 package types
 
 import (
+	"fmt"
 	"log"
 )
 
@@ -51,5 +52,39 @@ func (w WarningSet) PrettyPrint(verbose bool) {
 		} else {
 			log.Println("[central] Warning: OVN Cluster has critically few members")
 		}
+	}
+}
+
+// RegenerateEnvResponse is a structure that models response to requests for
+// a environment file regeneration for all nodes
+type RegenerateEnvResponse struct {
+	Success bool     `json:"success" yaml:"success"` // True if this node regenerates its environment
+	Errors  []string `json:"error"`                  // List of Errors
+}
+
+// PrettyPrint method formats and prints contents of RegenerateEnvResponse object
+func (r *RegenerateEnvResponse) PrettyPrint() {
+	var newEnvSuccess string
+	if r.Success {
+		newEnvSuccess = "Generated"
+	} else {
+		newEnvSuccess = "Not Generated"
+	}
+
+	fmt.Printf("New Environment: %s\n\n", newEnvSuccess)
+
+	if len(r.Errors) != 0 {
+		fmt.Println("\n[Errors]")
+		for _, errMsg := range r.Errors {
+			fmt.Println(errMsg)
+		}
+	}
+}
+
+// NewRegenerateEnvResponse returns pointer to initialized RegenerateEnvResponse object
+func NewRegenerateEnvResponse() RegenerateEnvResponse {
+	return RegenerateEnvResponse{
+		Success: false,
+		Errors:  make([]string, 0),
 	}
 }

--- a/microovn/client/client.go
+++ b/microovn/client/client.go
@@ -145,7 +145,7 @@ func DisableService(ctx context.Context, c *client.Client, serviceName string) (
 	}
 
 	regenerateEnvResponse := types.RegenerateEnvResponse{}
-	if serviceName == "central" {
+	if types.SrvName(serviceName) == types.SrvCentral {
 		regenerateEnvResponse, err = RegenerateEnvironment(ctx, c)
 		if err != nil {
 			return types.WarningSet{}, types.RegenerateEnvResponse{}, err
@@ -167,7 +167,7 @@ func EnableService(ctx context.Context, c *client.Client, serviceName string) (t
 	}
 
 	regenerateEnvResponse := types.RegenerateEnvResponse{}
-	if serviceName == "central" {
+	if types.SrvName(serviceName) == types.SrvCentral {
 		regenerateEnvResponse, err = RegenerateEnvironment(ctx, c)
 		if err != nil {
 			return types.WarningSet{}, types.RegenerateEnvResponse{}, err

--- a/microovn/cmd/microovn/certificates_list.go
+++ b/microovn/cmd/microovn/certificates_list.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/canonical/microcluster/v2/microcluster"
+	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/client"
 	"github.com/canonical/microovn/microovn/ovn/paths"
 	"github.com/spf13/cobra"
@@ -90,7 +91,7 @@ func (c *cmdCertificatesList) Run(cmd *cobra.Command, _ []string) error {
 			continue
 		}
 
-		if srv.Service == "central" {
+		if srv.Service == types.SrvCentral {
 			nbCert, nbKey := paths.PkiOvnNbCertFiles()
 			sbCert, sbKey := paths.PkiOvnSbCertFiles()
 			northdCert, northdKey := paths.PkiOvnNorthdCertFiles()
@@ -100,7 +101,7 @@ func (c *cmdCertificatesList) Run(cmd *cobra.Command, _ []string) error {
 			expectedCertificates.Northd = &certBundle{northdCert, northdKey}
 		}
 
-		if srv.Service == "switch" {
+		if srv.Service == types.SrvChassis {
 			ctlCert, ctlKey := paths.PkiOvnControllerCertFiles()
 			expectedCertificates.Chassis = &certBundle{ctlCert, ctlKey}
 		}

--- a/microovn/cmd/microovn/certificates_list.go
+++ b/microovn/cmd/microovn/certificates_list.go
@@ -101,7 +101,7 @@ func (c *cmdCertificatesList) Run(cmd *cobra.Command, _ []string) error {
 			expectedCertificates.Northd = &certBundle{northdCert, northdKey}
 		}
 
-		if srv.Service == types.SrvSwitch {
+		if srv.Service == types.SrvChassis {
 			ctlCert, ctlKey := paths.PkiOvnControllerCertFiles()
 			expectedCertificates.Chassis = &certBundle{ctlCert, ctlKey}
 		}

--- a/microovn/cmd/microovn/certificates_list.go
+++ b/microovn/cmd/microovn/certificates_list.go
@@ -101,7 +101,7 @@ func (c *cmdCertificatesList) Run(cmd *cobra.Command, _ []string) error {
 			expectedCertificates.Northd = &certBundle{northdCert, northdKey}
 		}
 
-		if srv.Service == types.SrvChassis {
+		if srv.Service == types.SrvSwitch {
 			ctlCert, ctlKey := paths.PkiOvnControllerCertFiles()
 			expectedCertificates.Chassis = &certBundle{ctlCert, ctlKey}
 		}

--- a/microovn/cmd/microovn/service_control.go
+++ b/microovn/cmd/microovn/service_control.go
@@ -47,13 +47,15 @@ func (c *cmdDisable) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	targetService := args[0]
-	ws, err := client.DisableService(context.Background(), cli, targetService)
-
+	ws, regenEnv, err := client.DisableService(context.Background(), cli, targetService)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Service %s disabled\n", targetService)
 	ws.PrettyPrint(c.common.FlagLogVerbose)
+	if c.common.FlagLogVerbose {
+		regenEnv.PrettyPrint()
+	}
 	return nil
 }
 
@@ -92,12 +94,15 @@ func (c *cmdEnable) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	targetService := args[0]
-	ws, err := client.EnableService(context.Background(), cli, targetService)
+	ws, regenEnv, err := client.EnableService(context.Background(), cli, targetService)
 
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Service %s enabled\n", targetService)
 	ws.PrettyPrint(c.common.FlagLogVerbose)
+	if c.common.FlagLogVerbose {
+		regenEnv.PrettyPrint()
+	}
 	return nil
 }

--- a/microovn/cmd/microovn/service_control.go
+++ b/microovn/cmd/microovn/service_control.go
@@ -8,8 +8,8 @@ import (
 	"github.com/canonical/microcluster/v2/microcluster"
 	"github.com/spf13/cobra"
 
+	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/client"
-	"github.com/canonical/microovn/microovn/node"
 )
 
 type cmdDisable struct {
@@ -21,9 +21,9 @@ func (c *cmdDisable) Command() *cobra.Command {
 		Use: "disable <SERVICE>",
 		Short: fmt.Sprintf(
 			"Disable selected service on the local node. (Valid service names: %s)",
-			strings.Join(node.ServiceNames, ", "),
+			strings.Join(types.ServiceNames, ", "),
 		),
-		ValidArgs: node.ServiceNames,
+		ValidArgs: types.ServiceNames,
 		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE:      c.Run,
 	}
@@ -68,9 +68,9 @@ func (c *cmdEnable) Command() *cobra.Command {
 		Use: "enable <SERVICE>",
 		Short: fmt.Sprintf(
 			"Enable selected service on the local node. (Valid service names: %s)",
-			strings.Join(node.ServiceNames, ", "),
+			strings.Join(types.ServiceNames, ", "),
 		),
-		ValidArgs: node.ServiceNames,
+		ValidArgs: types.ServiceNames,
 		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE:      c.Run,
 	}

--- a/microovn/node/node.go
+++ b/microovn/node/node.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/v2/cluster"
@@ -284,6 +285,16 @@ func leaveCentral(ctx context.Context, s state.State) error {
 		}
 	} else {
 		logger.Warnf("Failed to get SB database specification: %s", err)
+	}
+
+	err = os.Rename(paths.CentralDBNBPath(), paths.CentralDBNBBackupPath())
+	if err != nil {
+		logger.Warnf("Failed to move Northbound database to backup: %s", err)
+	}
+
+	err = os.Rename(paths.CentralDBSBPath(), paths.CentralDBSBBackupPath())
+	if err != nil {
+		logger.Warnf("Failed to move Southbound database to backup: %s", err)
 	}
 
 	err = snap.Stop("ovn-northd", true)

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/snap"
 )
@@ -49,12 +50,12 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Generate CA certificate and key
-	err = GenerateNewCACertificate(ctx, s)
+	err = certificates.GenerateNewCACertificate(ctx, s)
 	if err != nil {
 		return err
 	}
 
-	err = DumpCA(ctx, s)
+	err = certificates.DumpCA(ctx, s)
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	// Note that we intentially use a sever type certificate here due to
 	// all OVS-based programs ability to specify active or passive (listen)
 	// connection types.
-	err = GenerateNewServiceCertificate(ctx, s, "client", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "client", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
 	}
@@ -81,15 +82,15 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Generate certificate for OVN Central services
-	err = GenerateNewServiceCertificate(ctx, s, "ovnnb", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnnb", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovnnb service: %s", err)
 	}
-	err = GenerateNewServiceCertificate(ctx, s, "ovnsb", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnsb", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovnsb service: %s", err)
 	}
-	err = GenerateNewServiceCertificate(ctx, s, "ovn-northd", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-northd", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovn-northd service: %s", err)
 	}
@@ -111,7 +112,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Generate certificate for OVN chassis (controller)
-	err = GenerateNewServiceCertificate(ctx, s, "ovn-controller", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-controller", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovn-controller service: %s", err)
 	}

--- a/microovn/ovn/certificates/certificates.go
+++ b/microovn/ovn/certificates/certificates.go
@@ -1,4 +1,6 @@
-package ovn
+// Package certificates is for exposing certificate generation functionality within
+// ovn
+package certificates
 
 import (
 	"context"
@@ -220,9 +222,9 @@ func DumpCA(ctx context.Context, s state.State) error {
 	return nil
 }
 
-// getCA pulls PEM encoded CA certificate and private key from shared database and returns
+// GetCA pulls PEM encoded CA certificate and private key from shared database and returns
 // them as parsed objects x509.Certificate and ecdsa.PrivateKey (+ error if any occurred).
-func getCA(ctx context.Context, s state.State) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+func GetCA(ctx context.Context, s state.State) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	var err error
 	var CACertRecord *database.ConfigItem
 	var CAKeyRecord *database.ConfigItem
@@ -299,7 +301,7 @@ func GenerateNewServiceCertificate(ctx context.Context, s state.State, serviceNa
 		return fmt.Errorf("unable to set permissions for %s private key: %w", serviceName, err)
 	}
 
-	caCert, caKey, err := getCA(ctx, s)
+	caCert, caKey, err := GetCA(ctx, s)
 	if err != nil {
 		return err
 	}

--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 	"github.com/canonical/microovn/microovn/ovn/paths"
 )
 
@@ -33,7 +34,7 @@ OVN_LOCAL_IP="{{ .localAddr }}"
 // networkProtocol returns appropriate network protocol that should be used
 // by OVN services.
 func networkProtocol(ctx context.Context, s state.State) string {
-	_, _, err := getCA(ctx, s)
+	_, _, err := certificates.GetCA(ctx, s)
 	if err != nil {
 		return "tcp"
 	}

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/node"
 	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/snap"
@@ -98,33 +99,9 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 
 	// Enable OVN central (if needed).
 	if srvCentral < 3 {
-		// Generate certificate for OVN Central services
-		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnnb", certificates.CertificateTypeServer)
+		err = node.StartCentral(ctx, s)
 		if err != nil {
-			return fmt.Errorf("failed to generate TLS certificate for ovnnb service")
-		}
-		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnsb", certificates.CertificateTypeServer)
-		if err != nil {
-			return fmt.Errorf("failed to generate TLS certificate for ovnsb service")
-		}
-		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-northd", certificates.CertificateTypeServer)
-		if err != nil {
-			return fmt.Errorf("failed to generate TLS certificate for ovn-northd service")
-		}
-
-		err = snap.Start("ovn-ovsdb-server-nb", true)
-		if err != nil {
-			return fmt.Errorf("Failed to start OVN NB: %w", err)
-		}
-
-		err = snap.Start("ovn-ovsdb-server-sb", true)
-		if err != nil {
-			return fmt.Errorf("Failed to start OVN SB: %w", err)
-		}
-
-		err = snap.Start("ovn-northd", true)
-		if err != nil {
-			return fmt.Errorf("Failed to start OVN northd: %w", err)
+			return fmt.Errorf("Failed to start OVN central: %w", err)
 		}
 	}
 

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -99,7 +99,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 
 	// Enable OVN central (if needed).
 	if srvCentral < 3 {
-		err = node.StartCentral(ctx, s)
+		err = node.JoinCentral(ctx, s)
 		if err != nil {
 			return fmt.Errorf("Failed to start OVN central: %w", err)
 		}

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/database"
+	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/snap"
 )
@@ -78,13 +79,13 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	// Note that we intentially use a sever type certificate here due to
 	// all OVS-based programs ability to specify active or passive (listen)
 	// connection types.
-	err = GenerateNewServiceCertificate(ctx, s, "client", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "client", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for client: %s", err)
 	}
 
 	// Copy shared CA certificate from shared database to file on disk
-	err = DumpCA(ctx, s)
+	err = certificates.DumpCA(ctx, s)
 	if err != nil {
 		return err
 	}
@@ -98,15 +99,15 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	// Enable OVN central (if needed).
 	if srvCentral < 3 {
 		// Generate certificate for OVN Central services
-		err = GenerateNewServiceCertificate(ctx, s, "ovnnb", CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnnb", certificates.CertificateTypeServer)
 		if err != nil {
 			return fmt.Errorf("failed to generate TLS certificate for ovnnb service")
 		}
-		err = GenerateNewServiceCertificate(ctx, s, "ovnsb", CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovnsb", certificates.CertificateTypeServer)
 		if err != nil {
 			return fmt.Errorf("failed to generate TLS certificate for ovnsb service")
 		}
-		err = GenerateNewServiceCertificate(ctx, s, "ovn-northd", CertificateTypeServer)
+		err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-northd", certificates.CertificateTypeServer)
 		if err != nil {
 			return fmt.Errorf("failed to generate TLS certificate for ovn-northd service")
 		}
@@ -128,7 +129,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	}
 
 	// Generate certificate for OVN chassis (controller)
-	err = GenerateNewServiceCertificate(ctx, s, "ovn-controller", CertificateTypeServer)
+	err = certificates.GenerateNewServiceCertificate(ctx, s, "ovn-controller", certificates.CertificateTypeServer)
 	if err != nil {
 		return fmt.Errorf("failed to generate TLS certificate for ovn-controller service")
 	}

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -7,8 +7,6 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/node"
-	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
-	"github.com/canonical/microovn/microovn/snap"
 )
 
 // Leave function gracefully departs from the OVN cluster before the member is removed from MicroOVN
@@ -21,29 +19,10 @@ import (
 // for departing cluster member, so we'll try to exit/leave/stop all possible services
 // ignoring any errors from services that are not actually running.
 func Leave(ctx context.Context, s state.State, _ bool) error {
-	var err error
-	chassisName := s.Name()
-
-	// Gracefully exit OVN controller causing chassis to be automatically removed.
-	logger.Infof("Stopping OVN Controller and removing Chassis '%s' from OVN SB database.", chassisName)
-	_, err = ovnCmd.ControllerCtl(ctx, s, "exit")
+	// Attempt to disable each service
+	err := node.DisableAllServices(ctx, s)
 	if err != nil {
-		logger.Warnf("Failed to gracefully stop OVN Controller: %s", err)
-	}
-
-	err = snap.Stop("chassis", true)
-	if err != nil {
-		logger.Warnf("Failed to stop Chassis service: %s", err)
-	}
-
-	err = snap.Stop("switch", true)
-	if err != nil {
-		logger.Warnf("Failed to stop Switch service: %s", err)
-	}
-
-	err = node.LeaveCentral(ctx, s)
-	if err != nil {
-		logger.Warnf("Failed to stop Central service: %s", err)
+		return err
 	}
 
 	logger.Info("Cleaning up runtime and data directories.")

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -41,7 +41,7 @@ func Leave(ctx context.Context, s state.State, _ bool) error {
 		logger.Warnf("Failed to stop Switch service: %s", err)
 	}
 
-	err = node.StopCentral(ctx, s)
+	err = node.LeaveCentral(ctx, s)
 	if err != nil {
 		logger.Warnf("Failed to stop Central service: %s", err)
 	}

--- a/microovn/ovn/paths/paths.go
+++ b/microovn/ovn/paths/paths.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 var snapRoot = os.Getenv("SNAP")
@@ -30,6 +31,26 @@ func OvnRuntimeDir() string {
 // CentralDBDir returns path to the directory where OVN Central stores its databases
 func CentralDBDir() string {
 	return filepath.Join(dataDir, "central", "db")
+}
+
+// CentralDBNBPath returns path to the Northbound database file
+func CentralDBNBPath() string { return filepath.Join(CentralDBDir(), "ovnnb_db.db") }
+
+// CentralDBSBPath returns path to the Southbound database file
+func CentralDBSBPath() string { return filepath.Join(CentralDBDir(), "ovnsb_db.db") }
+
+// CentralDBSBBackupPath returns path to the where the Southbound database file should
+// be backed up to
+func CentralDBSBBackupPath() string {
+	return filepath.Join(CentralDBDir(),
+		"ovnsb_db_backup_"+time.Now().Format(time.DateTime)+".db")
+}
+
+// CentralDBNBBackupPath returns path to the where the Northbound database file should
+// be backed up to
+func CentralDBNBBackupPath() string {
+	return filepath.Join(CentralDBDir(),
+		"ovnnb_db_backup_"+time.Now().Format(time.DateTime)+".db")
 }
 
 // SwitchDBDir returns path to the directory where OpenvSwitch stores its database

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/v2/state"
 
+	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/snap"
@@ -39,12 +40,12 @@ func refresh(ctx context.Context, s state.State) error {
 	}
 
 	// Query existing local services.
-	hasCentral, err := node.HasServiceActive(ctx, s, "central")
+	hasCentral, err := node.HasServiceActive(ctx, s, types.SrvCentral)
 	if err != nil {
 		return err
 	}
 
-	hasSwitch, err := node.HasServiceActive(ctx, s, "switch")
+	hasSwitch, err := node.HasServiceActive(ctx, s, types.SrvSwitch)
 	if err != nil {
 		return err
 	}

--- a/tests/central_control.bats
+++ b/tests/central_control.bats
@@ -1,0 +1,1 @@
+test_helper/bats/central_control.bats

--- a/tests/services_restart.bats
+++ b/tests/services_restart.bats
@@ -1,0 +1,1 @@
+test_helper/bats/services_restart.bats

--- a/tests/test_helper/bats/central_control.bats
+++ b/tests/test_helper/bats/central_control.bats
@@ -7,6 +7,7 @@ setup() {
     load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-support/load.bash
     load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-assert/load.bash
 
+
     # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
     # provide false positive results.
     assert [ -n "$TEST_CONTAINERS" ]
@@ -16,46 +17,37 @@ central_register_test_functions() {
     bats_test_function \
         --description "Testing of central node migration" \
         -- central_tests
-    bats_test_function \
-        --description "Testing of database functionality" \
-        -- central_db_test
 }
 
 central_tests() {
-    run lxc_exec "microovn-central-control-1" "microovn disable central"
+    read -r -a containers_to_upgrade <<< "$TEST_CONTAINERS"
+    run lxc_exec "${containers_to_upgrade[0]}" "microovn disable central"
     assert_output -p "Service central disabled"
-    run lxc_exec "microovn-central-control-2" "microovn disable central"
+    run lxc_exec "${containers_to_upgrade[1]}" "microovn disable central"
     assert_output -p "Service central disabled"
-    run lxc_exec "microovn-central-control-4" "microovn enable central"
+    run lxc_exec "${containers_to_upgrade[3]}" "microovn enable central"
     assert_output -p "Service central enabled"
-    run lxc_exec "microovn-central-control-3" "microovn disable central"
+    run lxc_exec "${containers_to_upgrade[2]}" "microovn disable central"
     assert_output -p "Service central disabled"
-    run lxc_exec "microovn-central-control-5" "microovn enable central"
+    run lxc_exec "${containers_to_upgrade[4]}" "microovn enable central"
     assert_output -p "Service central enabled"
-    run lxc_exec "microovn-central-control-6" "microovn enable central"
+    run lxc_exec "${containers_to_upgrade[5]}" "microovn enable central"
     assert_output -p "Service central enabled"
-    assert [ -z "$(run lxc_exec "microovn-central-control-1" "microovn status | grep -ozE 'microovn-central-control-1[^-]*' | grep central")"]
-    assert [ -z "$(run lxc_exec "microovn-central-control-1" "snap services microovn | grep ovn-northd | grep enabled")"]
-    assert [ -z "$(run lxc_exec "microovn-central-control-2" "microovn status | grep -ozE 'microovn-central-control-2[^-]*' | grep central")"]
-    assert [ -z "$(run lxc_exec "microovn-central-control-2" "snap services microovn | grep ovn-northd | grep enabled")"]
-    assert [ -z "$(run lxc_exec "microovn-central-control-3" "microovn status | grep -ozE 'microovn-central-control-3[^-]*' | grep central")"]
-    assert [ -z "$(run lxc_exec "microovn-central-control-3" "snap services microovn | grep ovn-northd | grep enabled")"]
-    assert [ -n "$(run lxc_exec "microovn-central-control-4" "microovn status | grep -ozE 'microovn-central-control-4[^-]*' | grep central")"]
-    assert [ -n "$(run lxc_exec "microovn-central-control-4" "snap services microovn | grep ovn-northd | grep enabled")"]
-    assert [ -n "$(run lxc_exec "microovn-central-control-5" "microovn status | grep -ozE 'microovn-central-control-5[^-]*' | grep central")"]
-    assert [ -n "$(run lxc_exec "microovn-central-control-5" "snap services microovn | grep ovn-northd | grep enabled")"]
-    assert [ -n "$(run lxc_exec "microovn-central-control-6" "microovn status | grep -ozE 'microovn-central-control-6[^-]*' | grep central")"]
-    assert [ -n "$(run lxc_exec "microovn-central-control-6" "snap services microovn | grep ovn-northd | grep enabled")"]
-
-}
-
-central_db_test() {
-    for container in $TEST_CONTAINERS; do
-        run lxc_exec "$container" "microovn status"
-        assert_output -p "OVN Northbound: OK"
-        assert_output -p "OVN Southbound: OK"
-    done
-
+    assert [ -z "$(run lxc_exec "${containers_to_upgrade[0]}" "microovn status | grep -ozE 'microovn-central-control-1[^-]*' | grep central")"]
+    assert [ -z "$(run lxc_exec "${containers_to_upgrade[0]}" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -z "$(run lxc_exec "${containers_to_upgrade[1]}" "microovn status | grep -ozE 'microovn-central-control-2[^-]*' | grep central")"]
+    assert [ -z "$(run lxc_exec "${containers_to_upgrade[1]}" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -z "$(run lxc_exec "${containers_to_upgrade[2]}" "microovn status | grep -ozE 'microovn-central-control-3[^-]*' | grep central")"]
+    assert [ -z "$(run lxc_exec "${containers_to_upgrade[2]}" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -n "$(run lxc_exec "${containers_to_upgrade[3]}" "microovn status | grep -ozE 'microovn-central-control-4[^-]*' | grep central")"]
+    assert [ -n "$(run lxc_exec "${containers_to_upgrade[3]}" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -n "$(run lxc_exec "${containers_to_upgrade[4]}" "microovn status | grep -ozE 'microovn-central-control-5[^-]*' | grep central")"]
+    assert [ -n "$(run lxc_exec "${containers_to_upgrade[4]}" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -n "$(run lxc_exec "${containers_to_upgrade[5]}" "microovn status | grep -ozE 'microovn-central-control-6[^-]*' | grep central")"]
+    assert [ -n "$(run lxc_exec "${containers_to_upgrade[5]}" "snap services microovn | grep ovn-northd | grep enabled")"]
 }
 
 central_register_test_functions
+
+
+load ${ABS_TOP_TEST_DIRNAME}test_helper/bats/cluster.bats

--- a/tests/test_helper/bats/central_control.bats
+++ b/tests/test_helper/bats/central_control.bats
@@ -1,0 +1,61 @@
+load "${ABS_TOP_TEST_DIRNAME}test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+setup() {
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/common.bash
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/lxd.bash
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/microovn.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-support/load.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+}
+
+central_register_test_functions() {
+    bats_test_function \
+        --description "Testing of central node migration" \
+        -- central_tests
+    bats_test_function \
+        --description "Testing of database functionality" \
+        -- central_db_test
+}
+
+central_tests() {
+    run lxc_exec "microovn-central-control-1" "microovn disable central"
+    assert_output -p "Service central disabled"
+    run lxc_exec "microovn-central-control-2" "microovn disable central"
+    assert_output -p "Service central disabled"
+    run lxc_exec "microovn-central-control-4" "microovn enable central"
+    assert_output -p "Service central enabled"
+    run lxc_exec "microovn-central-control-3" "microovn disable central"
+    assert_output -p "Service central disabled"
+    run lxc_exec "microovn-central-control-5" "microovn enable central"
+    assert_output -p "Service central enabled"
+    run lxc_exec "microovn-central-control-6" "microovn enable central"
+    assert_output -p "Service central enabled"
+    assert [ -z "$(run lxc_exec "microovn-central-control-1" "microovn status | grep -ozE 'microovn-central-control-1[^-]*' | grep central")"]
+    assert [ -z "$(run lxc_exec "microovn-central-control-1" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -z "$(run lxc_exec "microovn-central-control-2" "microovn status | grep -ozE 'microovn-central-control-2[^-]*' | grep central")"]
+    assert [ -z "$(run lxc_exec "microovn-central-control-2" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -z "$(run lxc_exec "microovn-central-control-3" "microovn status | grep -ozE 'microovn-central-control-3[^-]*' | grep central")"]
+    assert [ -z "$(run lxc_exec "microovn-central-control-3" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -n "$(run lxc_exec "microovn-central-control-4" "microovn status | grep -ozE 'microovn-central-control-4[^-]*' | grep central")"]
+    assert [ -n "$(run lxc_exec "microovn-central-control-4" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -n "$(run lxc_exec "microovn-central-control-5" "microovn status | grep -ozE 'microovn-central-control-5[^-]*' | grep central")"]
+    assert [ -n "$(run lxc_exec "microovn-central-control-5" "snap services microovn | grep ovn-northd | grep enabled")"]
+    assert [ -n "$(run lxc_exec "microovn-central-control-6" "microovn status | grep -ozE 'microovn-central-control-6[^-]*' | grep central")"]
+    assert [ -n "$(run lxc_exec "microovn-central-control-6" "snap services microovn | grep ovn-northd | grep enabled")"]
+
+}
+
+central_db_test() {
+    for container in $TEST_CONTAINERS; do
+        run lxc_exec "$container" "microovn status"
+        assert_output -p "OVN Northbound: OK"
+        assert_output -p "OVN Southbound: OK"
+    done
+
+}
+
+central_register_test_functions

--- a/tests/test_helper/bats/cli_ovsovn.bats
+++ b/tests/test_helper/bats/cli_ovsovn.bats
@@ -36,7 +36,46 @@ teardown() {
     fi
 }
 
-@test "ovs-appctl ovs-vswitchd" {
+cli_ovsovn_register_test_functions() {
+    bats_test_function \
+        --description "ovs-appctl ovs-vswitchd" \
+        -- ovs-appctl_ovs-vswitchd
+    bats_test_function \
+        --description "ovs-dpctl" \
+        -- ovs-dpctl
+    bats_test_function \
+        --description "ovs-ofctl" \
+        -- ovs-ofctl
+    bats_test_function \
+        --description "ovs-vsctl" \
+        -- ovs-vsctl
+    bats_test_function \
+        --description "ovs-appctl ovsdb-server" \
+        -- ovs-appctl_ovsdb-server
+    bats_test_function \
+        --description "ovn-appctl ovn-controller" \
+        -- ovn-appctl_ovn-controller
+    bats_test_function \
+        --description "ovn-appctl ovn-northd" \
+        -- ovn-appctl_ovn-northd
+    bats_test_function \
+        --description "ovn-nbctl" \
+        -- ovn-nbctl
+    bats_test_function \
+        --description "ovn-nbctl daemon" \
+        -- ovn-nbctl_daemon
+    bats_test_function \
+        --description "ovn-sbctl" \
+        -- ovn-sbctl
+    bats_test_function \
+        --description "ovn-sbctl daemon" \
+        -- ovn-sbctl_daemon
+    bats_test_function \
+        --description "ovn-trace" \
+        -- ovn-trace
+}
+
+ovs-appctl_ovs-vswitchd() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovs-appctl version"
@@ -45,7 +84,7 @@ teardown() {
     done
 }
 
-@test "ovs-dpctl" {
+ovs-dpctl() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovs-dpctl dump-dps"
@@ -54,7 +93,7 @@ teardown() {
     done
 }
 
-@test "ovs-ofctl" {
+ovs-ofctl() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovs-ofctl dump-flows br-int >/dev/null"
@@ -62,7 +101,7 @@ teardown() {
     done
 }
 
-@test "ovs-vsctl" {
+ovs-vsctl() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovs-vsctl show >/dev/null"
@@ -70,7 +109,7 @@ teardown() {
     done
 }
 
-@test "ovs-appctl ovsdb-server" {
+ovs-appctl_ovsdb-server() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovs-appctl -t ovsdb-server version"
@@ -79,7 +118,7 @@ teardown() {
     done
 }
 
-@test "ovn-appctl ovn-controller" {
+ovn-appctl_ovn-controller() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovn-appctl version"
@@ -88,7 +127,7 @@ teardown() {
     done
 }
 
-@test "ovn-appctl ovn-northd" {
+ovn-appctl_ovn-northd() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovn-appctl -t ovn-northd version"
@@ -97,7 +136,7 @@ teardown() {
     done
 }
 
-@test "ovn-nbctl" {
+ovn-nbctl() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovn-nbctl show > /dev/null"
@@ -105,7 +144,7 @@ teardown() {
     done
 }
 
-@test "ovn-nbctl daemon" {
+ovn-nbctl_daemon() {
     local ovn_nbctl_socket
 
     for container in $TEST_CONTAINERS; do
@@ -121,7 +160,7 @@ teardown() {
     done
 }
 
-@test "ovn-sbctl" {
+ovn-sbctl() {
     for container in $TEST_CONTAINERS; do
         run lxc_exec "$container" \
             "microovn.ovn-sbctl show > /dev/null"
@@ -129,7 +168,7 @@ teardown() {
     done
 }
 
-@test "ovn-sbctl daemon" {
+ovn-sbctl_daemon() {
     local ovn_sbctl_socket
 
     for container in $TEST_CONTAINERS; do
@@ -145,7 +184,7 @@ teardown() {
     done
 }
 
-@test "ovn-trace" {
+ovn-trace() {
     local first_container
     for container in $TEST_CONTAINERS; do
         if [ -z "$first_container" ]; then
@@ -167,3 +206,5 @@ teardown() {
         refute_output -p WARN
     done
 }
+
+cli_ovsovn_register_test_functions

--- a/tests/test_helper/bats/services_restart.bats
+++ b/tests/test_helper/bats/services_restart.bats
@@ -1,0 +1,4 @@
+load "${ABS_TOP_TEST_DIRNAME}test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+load test_helper/bats/cluster.bats
+load test_helper/bats/cli_ovsovn.bats

--- a/tests/test_helper/setup_teardown/central_control.bash
+++ b/tests/test_helper/setup_teardown/central_control.bash
@@ -1,0 +1,17 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 6)
+    export TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    bootstrap_cluster $TEST_CONTAINERS
+}
+
+teardown_file() {
+    delete_containers $TEST_CONTAINERS
+}

--- a/tests/test_helper/setup_teardown/services_restart.bash
+++ b/tests/test_helper/setup_teardown/services_restart.bash
@@ -1,0 +1,29 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
+    export TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    bootstrap_cluster $TEST_CONTAINERS
+
+    for container in $TEST_CONTAINERS; do
+        lxc_exec "$container" "microovn disable central"
+        lxc_exec "$container" "microovn enable central"
+
+        lxc_exec "$container" "microovn disable chassis"
+        lxc_exec "$container" "microovn enable chassis"
+
+        lxc_exec "$container" "microovn disable switch"
+        lxc_exec "$container" "microovn enable switch"
+    done
+
+}
+
+teardown_file() {
+    delete_containers $TEST_CONTAINERS
+}


### PR DESCRIPTION
This changes the central service enabling to, regenerate the env file before enabling, generate certificates to allow secure communication with the other nodes.

This changes the central service disabling to properly leave the cluster and transfer ownership if they are the leader.
    
This set of patches allows central services to be successfully controlled and not cause database errors as they do in the current state of microovn (enable|disable) central