### PR TITLE
regenerate_ca: Fix requests not being forwarded

### DIFF
--- a/microovn/api/certificates/regenerate_ca.go
+++ b/microovn/api/certificates/regenerate_ca.go
@@ -29,7 +29,7 @@ func regenerateCaPut(s state.State, r *http.Request) response.Response {
 	responseData := types.NewRegenerateCaResponse()
 
 	// Check that this is the initial node that received the request and recreate new CA certificate
-	if client.IsNotification(r) {
+	if !client.IsNotification(r) {
 		// Only one recipient of this request needs to generate new CA
 		logger.Info("Re-issuing CA certificate and private key")
 		err = ovn.GenerateNewCACertificate(r.Context(), s)
@@ -41,7 +41,7 @@ func regenerateCaPut(s state.State, r *http.Request) response.Response {
 		responseData.NewCa = true
 
 		// Get clients for rest of the cluster members
-		cluster, err := s.Cluster(false)
+		cluster, err := s.Cluster(true)
 		if err != nil {
 			logger.Errorf("Failed to get a client for every cluster member: %v", err)
 			return response.SyncResponse(false, &responseData)

--- a/tests/test_helper/bats/tls_cluster.bats
+++ b/tests/test_helper/bats/tls_cluster.bats
@@ -297,6 +297,11 @@ tls_cluster_regenerate_ca() {
     # Sample new CA certificate fingerprint from random host
     new_ca_hash=$(get_cert_fingerprint "$container" "$CA_CERT_PATH")
 
+    # Ensure that the CA actually changed
+    assert [ -n "$old_ca_hash" ]
+    assert [ -n "$new_ca_hash" ]
+    assert_not_equal "$old_ca_hash" "$new_ca_hash"
+
     # Ensure that all members have new CA
     for container in $TEST_CONTAINERS; do
         local local_ca_hash=""


### PR DESCRIPTION
API endpoint for regenerating CA certificates was broken after recent upgrade to `microcluster` library[0] that changed signature of the `State.Cluster()` method. This method now accepts boolean value that must be set to `true` if we want recipient to properly recognized the request with the `client.IsNotification()` method.

Current code was not properly recognizing the initial request from the client and as a consequence, it did not trigger re-issue of the CA certificate and subsequent notification to the rest of the cluster.

[0] https://github.com/canonical/microovn/commit/5b42b2ed7a291de6c5a5551b5b3edfbb35a45adb