### PR TITLE
Revert "snap: Pin Dqlite dependency"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -165,7 +165,6 @@ parts:
     source: https://github.com/canonical/dqlite
     source-type: git
     source-depth: 1
-    source-tag: v1.16.7
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=


### PR DESCRIPTION
Issue in the dqlite "master" branch has been resolved.

This reverts commit 5802dc9a545e87df8c94a4f5c78b805ed7a6b9c5.