### PR TITLE
Newdocs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -6,7 +6,9 @@ LXD
 Livepatch
 Makefile
 MicroOVN
+MicroOVN's
 OVN
+OVN's
 OVS
 OpenStack
 PKI

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,3 +14,4 @@ a basic understanding of OVN.
    logs
    major-upgrades
    ovn-underlay
+   service-control

--- a/docs/how-to/service-control.rst
+++ b/docs/how-to/service-control.rst
@@ -1,0 +1,157 @@
+===============
+Service Control
+===============
+
+Service control refers to the set of commands for enabling and disabling a
+given MicroOVN service. MicroOVN has a set of services referred to here
+:doc:`Services Reference </reference/services>`, which are responsible for
+handling core functionality.
+
+You can disable services manually using snap, but the service control does not
+update the desired state or handle joining clusters and configuring the service
+properly, hence the strong reasoning to interact with services through this
+method.
+
+.. note::
+
+   This assumes you have MicroOVN installed and a clustered across three of more
+   nodes. These nodes will be referred to as ``first``, ``second`` and ``third``
+   respectively.
+
+Disabling a MicroOVN service
+----------------------------
+
+Disabling a MicroOVN service will configure it to not start automatically at
+boot and stop the service if it is running.
+
+run on ``first``:
+
+.. code-block:: none
+
+   microovn disable switch
+
+.. code-block:: none
+
+   Service switch disabled
+
+To validate that this has worked, we can query the status of MicroOVN and check
+which services are enabled. We should find that all nodes have central, chassis
+and switch, except first having only central and chassis. This shows the
+disabling worked
+
+run on ``first``:
+
+.. code-block:: none
+
+   microovn status
+
+.. code-block:: none
+
+   MicroOVN deployment summary:
+   - first (10.190.155.5)
+   Services: central, chassis
+   - second (10.190.155.174)
+   Services: central, chassis, switch
+   - third (10.190.155.55)
+   Services: central, chassis, switch
+   OVN Database summary:
+   OVN Northbound: OK (7.3.0)
+   OVN Southbound: OK (20.33.0)
+
+The other nodes have also been informed of this change to the service placement
+and when queried will confirm that switch is disabled on first from their
+perspective too.
+
+run on ``second``:
+
+.. code-block:: none
+
+   microovn status
+
+.. code-block:: none
+
+   MicroOVN deployment summary:
+   - first (10.190.155.5)
+   Services: central, chassis
+   - second (10.190.155.174)
+   Services: central, chassis, switch
+   - third (10.190.155.55)
+   Services: central, chassis, switch
+   OVN Database summary:
+   OVN Northbound: OK (7.3.0)
+   OVN Southbound: OK (20.33.0)
+
+
+Enabling a MicroOVN service
+---------------------------
+
+Enabling a MicroOVN service will configure it to start automatically at boot and
+if the service is not running, start it.
+
+run on ``first``:
+
+.. code-block:: none
+
+   microovn enable switch
+
+.. code-block:: none
+
+   Service switch enabled
+
+.. note::
+
+   If the switch service is enabled you may get an error, this is fine.
+
+This will enable the switch service in MicroOVN, This can be shown through the
+listing of system services owned by MicroOVN. As mentioned in the disable
+section, these do not always translate directly to a MicroOVN service, but in
+this case it does.
+
+run on ``first``:
+
+.. code-block:: none
+
+   microovn status
+
+.. code-block:: none
+
+   MicroOVN deployment summary:
+   - first (10.190.155.5)
+   Services: central, chassis, switch
+   - second (10.190.155.174)
+   Services: central, chassis, switch
+   - third (10.190.155.55)
+   Services: central, chassis, switch
+   OVN Database summary:
+   OVN Northbound: OK (7.3.0)
+   OVN Southbound: OK (20.33.0)
+
+You should be able to see here that the service is running and enabled on
+startup. The other nodes are also aware of this as if you query the status you
+will see it there and running.
+
+run on ``second``:
+
+.. code-block:: none
+
+   microovn status
+
+.. code-block:: none
+
+   MicroOVN deployment summary:
+   - first (10.190.155.5)
+   Services: central, chassis, switch
+   - second (10.190.155.174)
+   Services: central, chassis, switch
+   - third (10.190.155.55)
+   Services: central, chassis, switch
+   OVN Database summary:
+   OVN Northbound: OK (7.3.0)
+   OVN Southbound: OK (20.33.0)
+
+Uses
+----
+
+Typically the most common use case of this will be to control the nodes the
+central services are running on and to increase the number of central services
+beyond the default of 3.

--- a/docs/reference/services.rst
+++ b/docs/reference/services.rst
@@ -4,9 +4,60 @@
 MicroOVN services
 =================
 
+MicroOVN functionality is separated into distinct services that can be easily
+controlled via ``microovn enable`` and ``microovn disable``.
+
 This page presents a list of all MicroOVN services. Their descriptions are
 for reference only - the user is not expected to interact directly with these
 services.
+
+Handling services with enable/disable
+-------------------------------------
+
+The status of all services is displayed by running:
+
+.. code-block:: none
+
+   microovn status
+
+``central service``
+-------------------
+
+This is responsible for the database control. The database is clustered and uses
+the `RAFT <https://docs.openvswitch.org/en/latest/ref/ovsdb.7/#clustered-database-service-model>`_
+algorithm for consensus it can handle (n-1)/2 failures, where n is the number of
+nodes.
+
+Central is enabled on a new node whenever there are less than 3 nodes running
+the central services
+
+This service controls the following `Snap services`_:
+
+- ``microovn.ovn-ovsdb-server-nb``
+- ``microovn.ovn-ovsdb-server-sb``
+- ``microovn.ovn-northd``
+
+``chassis service``
+-------------------
+
+This service controls the ``ovn-controller`` daemon, which is OVN's agent on each
+hypervisor and software gateway. It is a distributed component running on the
+side of every Open vSwitch instance.
+It is enabled by default.
+
+The snap service this controls is ``microovn.chassis``
+
+`switch service``
+-------------------
+
+This service ``Open vSwitch`` and ensures its running properly. Much like chassis it
+is enabled by default.
+
+The snap service this controls is ``microovn.switch``
+
+
+Snap services
+-------------
 
 The status of all services is displayed by running:
 


### PR DESCRIPTION
This changes the current service documentation to be about how microovn
handles services, and the service available through enable/disable.

This also includes a howto documentation going over an example of
service control using microovn enable/disable