### PR TITLE
refactor: centralize OVS/OVN_RUNDIR usage

### DIFF
--- a/snapcraft/commands/chassis.start
+++ b/snapcraft/commands/chassis.start
@@ -1,14 +1,12 @@
 #!/bin/sh
 set -eux
 
-# Load the environment
+. "${SNAP}/ovn.env"
 . "${SNAP_COMMON}/data/env/ovn.env"
 
 # Setup directories
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
 export OVN_DBDIR="${SNAP_COMMON}/data/central/db"
 export OVN_LOGDIR="${SNAP_COMMON}/logs"
-export OVN_RUNDIR="${SNAP_COMMON}/run/ovn"
 export OVN_PKGDATADIR="${SNAP}/share/ovn"
 export OVN_SYSCONFDIR="${SNAP}/etc"
 export OVN_PKIDIR="${SNAP_COMMON}/data/pki"

--- a/snapcraft/commands/chassis.stop
+++ b/snapcraft/commands/chassis.stop
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -eux
 
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
-export OVN_RUNDIR="${SNAP_COMMON}/run/ovn"
+. "${SNAP}/ovn.env"
 
 # Stop the OVN controller
 "${SNAP}/share/ovn/scripts/ovn-ctl" stop_controller

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -1,6 +1,8 @@
 #!/bin/sh
+
+. "${SNAP}/ovn.env"
+
 export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
 
 . "$SNAP/coverage.env" 2>/dev/null || true
 exec microovnd --verbose --state-dir "${SNAP_COMMON}/state"

--- a/snapcraft/commands/ovn-trace
+++ b/snapcraft/commands/ovn-trace
@@ -2,7 +2,7 @@
 # Load the environment
 . ${SNAP}/commands/ovn-sb
 
-# ovn-trace may also interrogate the local Open vSwitch instance
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
+# importing OVS_RUNDIR, since ovn-trace may also interrogate the local Open vSwitch instance
+. "${SNAP}/ovn.env"
 
 exec ovn-trace -c "$CERT" -p "$KEY" -C "$CA_CERT" "${@}"

--- a/snapcraft/commands/ovs
+++ b/snapcraft/commands/ovs
@@ -1,4 +1,3 @@
 #!/bin/sh
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
-
+. "${SNAP}/ovn.env"
 exec "$(basename ${0})" "${@}"

--- a/snapcraft/commands/ovs-ssl-wrapper
+++ b/snapcraft/commands/ovs-ssl-wrapper
@@ -1,5 +1,4 @@
 #!/bin/sh
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
 . "${SNAP}/ovn.env"
 
 # Optionally load SSL certificates if they are readable

--- a/snapcraft/commands/switch.start
+++ b/snapcraft/commands/switch.start
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eu
 
+. "${SNAP}/ovn.env"
+
 # Setup directories
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch"
 export OVS_LOGDIR="${SNAP_COMMON}/logs"
 export OVS_SYSCONFDIR="${SNAP_COMMON}/data/switch"
 export OVS_DBDIR="${SNAP_COMMON}/data/switch/db"

--- a/snapcraft/commands/switch.stop
+++ b/snapcraft/commands/switch.stop
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-export OVS_RUNDIR="${SNAP_COMMON}/run/switch"
+. "${SNAP}/ovn.env"
 
 # Stop vswitchd
 "${SNAP}/commands/ovs-appctl" exit --cleanup

--- a/snapcraft/ovn-central.env
+++ b/snapcraft/ovn-central.env
@@ -1,12 +1,11 @@
 # Set of environment variables used by OVN Central services
 
-# Load runtime OVN environment variables
+. "${SNAP}/ovn.env"
 . "${SNAP_COMMON}/data/env/ovn.env"
 
 # Setup directories
 export OVN_DBDIR="${SNAP_COMMON}/data/central/db"
 export OVN_LOGDIR="${SNAP_COMMON}/logs"
-export OVN_RUNDIR="${SNAP_COMMON}/run/ovn"
 export OVN_PKGDATADIR="${SNAP}/share/ovn"
 export OVN_SYSCONFDIR="${SNAP}/etc"
 export OVN_PKIDIR="${SNAP_COMMON}/data/pki"

--- a/snapcraft/ovn.env
+++ b/snapcraft/ovn.env
@@ -6,9 +6,11 @@ if [ -r "$runtime_env" ]; then
     . "$runtime_env"
 fi
 
-export OVN_PKI_DIR="${SNAP_COMMON}/data/pki"
 export CA_CERT="${OVN_PKI_DIR}/cacert.pem"
 
+export OVN_PKI_DIR="${SNAP_COMMON}/data/pki"
 export OVN_RUNDIR="${SNAP_COMMON}/run/ovn/"
 export OVN_NB_DB="${OVN_NB_CONNECT}"
 export OVN_SB_DB="${OVN_SB_CONNECT}"
+
+export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"


### PR DESCRIPTION
addressing some small bites as part of the onboarding, suggested by @mkalcok 
https://bugs.launchpad.net/microovn/+bug/2042843

- [X] check runtime `$SNAP_COMMON/data/env/ovn.env` vs.  constant/unchanging `$SNAP/ovn.env` 
i'm explicitly putting the runtime  config after the static one in case there is an override
  ```
  . "${SNAP}/ovn.env"
  . "${SNAP_COMMON}/data/env/ovn.env"
  ````

side-quest
- [ ] if you see value on it, i can try find a way to help maintain the export proliferation on keys that exist on the `ovn.env` file