### PR TITLE
Update dqlite to release candidate

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -160,6 +160,7 @@ parts:
     source: https://github.com/canonical/dqlite
     source-type: git
     source-depth: 1
+    source-tag: v1.17.0-rc1
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=


### PR DESCRIPTION
getting snapcraft to build dqlite from the release candidate version which is tagged.