### PR TITLE
docs: Add cryptographic reference documentation.

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -5,11 +5,13 @@ LTS
 LXD
 Livepatch
 Makefile
+MicroCluster
 MicroOVN
 MicroOVN's
 OVN
 OVN's
 OVS
+OpenSSL
 OpenStack
 PKI
 Permalink

--- a/docs/reference/cryptography.rst
+++ b/docs/reference/cryptography.rst
@@ -1,0 +1,29 @@
+============
+Cryptography
+============
+
+Transport layer security (TLS)
+------------------------------
+All network endpoints exposed by MicroOVN services are secured using multiple
+components of the `TLS protocol`_, including encryption, authentication and
+integrity.  Through the use of the `Ubuntu OpenSSL`_ packages, TLS versions
+below 1.2 are disabled for security reasons.
+
+There are two self-signed certificate authorities in use, one for the
+`MicroCluster`_ based ``microovnd`` daemon, another for the `OVN`_ daemons.
+These are initialised during the initial bootstrap of the cluster.
+
+Keys are generated using a 384 bit `Elliptic Curve`_ algorithm often referred
+to as P-384.
+
+Both sets of daemons are by default configured to make use of TLS to encrypt
+on the wire communication, as well as using certificate data for authenticating
+and verifying remote peers, ensuring only trusted components can participate
+in the cluster.
+
+.. LINKS
+.. _Elliptic Curve: https://en.wikipedia.org/wiki/Elliptic-curve_cryptography
+.. _MicroCluster: https://github.com/canonical/microcluster
+.. _OVN: https://docs.ovn.org/en/latest/
+.. _TLS protocol: https://datatracker.ietf.org/doc/html/rfc8446
+.. _Ubuntu OpenSSL: https://ubuntu.com/server/docs/openssl

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,3 +9,4 @@ does not cover upstream OVN/OVS topics.
    :maxdepth: 1
 
    services
+   cryptography


### PR DESCRIPTION
It would be useful for our users to be able to look up the details of how MicroOVN makes use of cryptography in its implementation.