### PR TITLE
[branch-22.03] tests: fix missing wait in TLS test suite

### DIFF
--- a/tests/test_helper/bats/upgrade.bats
+++ b/tests/test_helper/bats/upgrade.bats
@@ -25,8 +25,8 @@ setup() {
         if [[ "$container_services" != *"central"* ]]; then
             continue
         fi
-        microovn_wait_ovndb_state "$container" nb connected 15
-        microovn_wait_ovndb_state "$container" sb connected 15
+        microovn_wait_ovndb_state "$container" nb connected 30
+        microovn_wait_ovndb_state "$container" sb connected 30
     done
 
     perform_manual_upgrade_steps $TEST_CONTAINERS

--- a/tests/test_helper/setup_teardown/tls_cluster.bash
+++ b/tests/test_helper/setup_teardown/tls_cluster.bash
@@ -12,6 +12,7 @@ setup_file() {
     export CENTRAL_CONTAINERS
     export CHASSIS_CONTAINERS
     launch_containers jammy $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
     install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
     bootstrap_cluster $TEST_CONTAINERS
 


### PR DESCRIPTION
TLS test suite setup was missing call to `wait_containers_ready` that other test suites utilize. It sometimes caused the tests to error out with:

error: too early for operation, device not yet seeded or device model not acknowledged

(cherry picked from commit bc8f87b1c69399c732a55e9bfb171839a96312ad)

Alongside the backport, we also increased timeout for OVN DB convergence after snap upgrade.