### PR TITLE
Add defaults for initial and and connect addresses

### DIFF
--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -122,6 +122,22 @@ func generateEnvironment(ctx context.Context, s state.State) error {
 		localAddr = "[" + localAddr + "]"
 	}
 
+	//set northbound to be at the local address if there is no central db found
+	if nbInitial == "" {
+		nbInitial = localAddr
+	}
+	if nbConnect == "" {
+		nbConnect = "ssl:" + localAddr + ":6641"
+	}
+
+	//set southbound to be at the local address if there is no central db found
+	if sbInitial == "" {
+		sbInitial = localAddr
+	}
+	if sbConnect == "" {
+		sbConnect = "ssl:" + localAddr + ":6642"
+	}
+
 	err = ovnEnvTpl.Execute(fd, map[string]any{
 		"localAddr": localAddr,
 		"nbInitial": nbInitial,

--- a/tests/test_helper/bats/cluster.bats
+++ b/tests/test_helper/bats/cluster.bats
@@ -168,7 +168,7 @@ cluster_ovs_ovn_remote_addresses() {
     done
 }
 
-# _test_db_connection_string NBSB
+# cluster_test_db_connection_string NBSB
 #
 # Tests that database connection string for NBSB contains the expected
 # addresses.
@@ -211,7 +211,7 @@ cluster_test_db_connection_string() {
     done
 }
 
-# _test_southbound_propagation
+# cluster_test_southbound_propagation
 #
 # Tests that database connection between northbound and southbound databases
 # is properly functional.

--- a/tests/test_helper/bats/cluster.bats
+++ b/tests/test_helper/bats/cluster.bats
@@ -35,6 +35,9 @@ cluster_register_test_functions() {
     bats_test_function \
         --description "Open_vSwitch external_ids:ovn-remote addresses" \
         -- cluster_ovs_ovn_remote_addresses
+    bats_test_function \
+        --description "Ensure northd connectivity between NB and SB" \
+        -- cluster_test_southbound_propagation
 }
 
 cluster_expected_count() {
@@ -205,6 +208,25 @@ cluster_test_db_connection_string() {
             # partial matching.
             assert_output -p "ssl:${expected_addr}:${expected_port}"
         done
+    done
+}
+
+# _test_southbound_propagation
+#
+# Tests that database connection between northbound and southbound databases
+# is properly functional.
+#
+# The command tested is one which waits for the change to propagate to the
+# southbound database and was specficially picked as it was at one point
+# failing until pointed out by microcloud
+cluster_test_southbound_propagation() {
+    for container in $TEST_CONTAINERS; do
+        run lxc_exec "$container" \
+            "microovn.ovn-nbctl --timeout=10 --wait=sb ha-chassis-group-add testnet"
+        assert_success
+        run lxc_exec "$container" \
+            "microovn.ovn-nbctl --timeout=10 --wait=sb ha-chassis-group-del testnet"
+        assert_success
     done
 }
 


### PR DESCRIPTION

Previously if the enviroment file was generated before any central
services had been enabled, then the initial and connect fields would be
empty, stopping northd from connecting to south and north databases.

This fix gives these defaults, which will only be used in the case of a
no central being found, in which case a central will always be generated
on the local machine, so the default addresses will be accurate.
