### PR TITLE
ci: run `apt update` before installing packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt update
           sudo apt install -yqq golang
           go install github.com/boumenot/gocover-cobertura@v1.2.0
 


### PR DESCRIPTION
We've seen some issues with 'coverage' job that failed to install 'go' package. This is possibly caused by outdated repository information in the CI image. Running `apt update` could fix it.