### PR TITLE
Remove 'microovn.' prefix in OVN commands

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,14 @@ linkcheck_anchors_ignore_for_url = [
 ]
 linkcheck_anchors_ignore_for_url.extend(custom_linkcheck_anchors_ignore_for_url)
 
+# this cisa.gov pages are so heavily refrenced the github CI for linkchecks is
+# being seen as a DDos, this is causing our linkcheck tests to fail so we have
+# to ignore it.
+linkcheck_ignore = [r'.*cisa\.gov.*']
+
+linkcheck_timeout = 120
+linkcheck_retries = 3
+
 # Tags cannot be added directly in custom_conf.py, so add them here
 for tag in custom_tags:
     tags.add(tag)

--- a/docs/how-to/downscaling.rst
+++ b/docs/how-to/downscaling.rst
@@ -52,13 +52,13 @@ properly removed.
 .. code-block:: none
 
    # Check status of OVN SB cluster
-   microovn.ovn-appctl -t /var/snap/microovn/common/run/central/ovnsb_db.ctl cluster/status OVN_Southbound
+   ovn-appctl -t /var/snap/microovn/common/run/central/ovnsb_db.ctl cluster/status OVN_Southbound
 
    # Check status of OVN NB cluster
-   microovn.ovn-appctl -t /var/snap/microovn/common/run/central/ovnnb_db.ctl cluster/status OVN_Northbound
+   ovn-appctl -t /var/snap/microovn/common/run/central/ovnnb_db.ctl cluster/status OVN_Northbound
 
    # Check registered chassis
-   microovn.ovn-sbctl show
+   ovn-sbctl show
 
 Data preservation
 -----------------

--- a/docs/how-to/logs.rst
+++ b/docs/how-to/logs.rst
@@ -51,21 +51,21 @@ The Open vSwitch (OVS) and Open Virtual Network (OVN) daemons have a rich set
 of debug features, one of which is the ability to specify log levels for
 individual modules at run time.
 
-A list of modules can be acquired through the ``microovn.ovs-appctl`` and
-``microovn.ovn-appctl`` commands.
+A list of modules can be acquired through the ``ovs-appctl`` and
+``ovn-appctl`` commands.
 
 This is how to enable debug logging for the Open vSwitch ``vswitchd`` module:
 
 .. code-block:: none
 
-   microovn.ovs-appctl vlog/set vswitchd:file:dbg
+   ovs-appctl vlog/set vswitchd:file:dbg
 
 This is how to enable debug logging for the Open Virtual Network ``reconnect``
 module:
 
 .. code-block:: none
 
-   microovn.ovn-appctl vlog/set reconnect:file:dbg
+   ovn-appctl vlog/set reconnect:file:dbg
 
 For more details on how to configure logging, see `ovs-appctl manpage`_.
 

--- a/docs/how-to/major-upgrades.rst
+++ b/docs/how-to/major-upgrades.rst
@@ -76,10 +76,10 @@ To check current values, run following commands:
 .. code-block:: none
 
    # Get OVN Northbound cluster status
-   sudo microovn.ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound
+   sudo ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound
 
    # Get OVN Southbound cluster status
-   sudo microovn.ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound
+   sudo ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound
 
 Look for ``Election timer:`` in the output of these commands. Value of this
 field is expressed in milliseconds.
@@ -104,10 +104,10 @@ with:
 .. code-block:: none
 
    # Command example for Northbound election timer increase
-   microovn.ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnnb_db.ctl cluster/change-election-timer OVN_Northbound <new_value>
+   ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnnb_db.ctl cluster/change-election-timer OVN_Northbound <new_value>
 
    # Command example for Southbound election timer increase
-   microovn.ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnsb_db.ctl cluster/change-election-timer OVN_Southbound <new_value>
+   ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnsb_db.ctl cluster/change-election-timer OVN_Southbound <new_value>
 
 ``OVN`` wont let you increase the timer by more than twice its current
 value, so you will have to proceed gradually.

--- a/docs/how-to/ovn-underlay.rst
+++ b/docs/how-to/ovn-underlay.rst
@@ -54,12 +54,12 @@ To verify that the underlay network is correctly configured, you can check the I
 
 .. code-block:: none
 
-   root@micro1:~# microovn.ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
+   root@micro1:~# ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
    "10.0.1.2"
 
-   root@micro2:~# microovn.ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
+   root@micro2:~# ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
    "10.0.1.3"
 
-   root@micro3:~# microovn.ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
+   root@micro3:~# ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip
    "10.0.1.4"
 

--- a/docs/how-to/tls.rst
+++ b/docs/how-to/tls.rst
@@ -176,14 +176,14 @@ open with following variables exported:
 
 .. code-block:: none
 
-   microovn.ovn-appctl -t $CONTROL_SOCKET cluster/leave $DB
+   ovn-appctl -t $CONTROL_SOCKET cluster/leave $DB
 
 2. Make sure that member properly left the cluster by inspecting cluster status
 on nodes 2 and 3 and ensuring that node 1 is no longer part of the cluster:
 
 .. code-block:: none
 
-   microovn.ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound
+   ovn-appctl -t /var/snap/microovn/common/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound
 
 3. Clean up remaining DB files on node 1:
 
@@ -201,7 +201,7 @@ will get fixed automatically when other cluster members switch to ``ssl``:
 
 .. code-block:: none
 
-   microovn.ovsdb-tool join-cluster $DB_FILE $DB ssl:<local_ip>:$PORT tcp:<node_2_ip>:$PORT
+   ovsdb-tool join-cluster $DB_FILE $DB ssl:<local_ip>:$PORT tcp:<node_2_ip>:$PORT
    snap restart microovn.ovn-ovsdb-server-nb
    snap restart microovn.ovn-ovsdb-server-sb
    snap restart microovn.ovn-northd
@@ -212,17 +212,17 @@ command to monitor cluster until it indicates three members and field
 
 .. code-block:: none
 
-   microovn.ovn-appctl -t $CONTROL_SOCKET cluster/status $DB
+   ovn-appctl -t $CONTROL_SOCKET cluster/status $DB
 
 Now that node 1 successfully transitioned to TLS we can repeat the same steps
 on node 2 and then on node 3. The only difference is in **4. step** where we
 will use protocol ``ssl`` and IP of a node 1 as last arguments for
-``microovn.ovsdb-tool`` command. To save you some searching and replacing,
+``ovsdb-tool`` command. To save you some searching and replacing,
 here are the revised commands for the **4. step** to be used on node 2 and 3:
 
 .. code-block:: none
 
-   microovn.ovsdb-tool join-cluster $DB_FILE $DB ssl:<local_ip>:$PORT ssl:<node_1_ip>:$PORT
+   ovsdb-tool join-cluster $DB_FILE $DB ssl:<local_ip>:$PORT ssl:<node_1_ip>:$PORT
    snap restart microovn.ovn-ovsdb-server-nb
    snap restart microovn.ovn-ovsdb-server-sb
    snap restart microovn.ovn-northd
@@ -232,7 +232,7 @@ cluster status on any node:
 
 .. code-block:: none
 
-   microovn.ovn-appctl -t $CONTROL_SOCKET cluster/status $DB
+   ovn-appctl -t $CONTROL_SOCKET cluster/status $DB
 
 to verify that all three cluster members are using ``ssl`` as their connection
 protocol.
@@ -256,14 +256,14 @@ This section contains some well known or expected issues that you can encounter.
 I'm getting ``failed to load certificates`` error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you run commands like :command:`microovn.ovn-sbctl` and you get complaints
+If you run commands like :command:`ovn-sbctl` and you get complaints
 about missing certificates while the rest of the commands seem to work fine.
 
 Example:
 
 .. code-block:: none
 
-   microovn.ovn-sbctl show
+   ovn-sbctl show
 
 Example output:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,8 +59,7 @@ constructive feedback.
 * Contribute to the project on `GitHub`_ (documentation contributions go under
   the :file:`docs` directory)
 * GitHub is also used as our bug tracker
-* To speak with us, you can find us in our `MicroOVN Discourse`_ category. Use
-  the `Support`_ sub-category for technical assistance.
+* To speak with us, you can find us in our `MicroOVN Discourse`_ category.
 * Optionally enable `Ubuntu Pro`_ on your OVN nodes. This is a service that
   provides the `Livepatch Service`_ and the `Expanded Security Maintenance`_
   (ESM) program.
@@ -81,7 +80,6 @@ constructive feedback.
 .. _Code of conduct: https://ubuntu.com/community/ethos/code-of-conduct
 .. _GitHub: https://github.com/canonical/microovn
 .. _MicroOVN Discourse: https://discourse.ubuntu.com/c/microovn/160
-.. _Support: https://discourse.ubuntu.com/c/microovn/support/164
 .. _Ubuntu Pro: https://ubuntu.com/pro
 .. _Livepatch Service: https://ubuntu.com/security/livepatch
 .. _Expanded Security Maintenance: https://ubuntu.com/security/esm

--- a/docs/reference/aliasing.rst
+++ b/docs/reference/aliasing.rst
@@ -1,0 +1,37 @@
+=================
+Automatic Aliases
+=================
+
+MicroOVN is distributed by snap, which has automatic aliases for OVN and OVS
+binaries. You can view these with the snap aliases command:
+
+.. code-block:: none
+
+    snap aliases microovn
+
+.. code-block:: none
+
+	Command                Alias         Notes
+	microovn.ovn-appctl    ovn-appctl    -
+	microovn.ovn-nbctl     ovn-nbctl     -
+	microovn.ovn-sbctl     ovn-sbctl     -
+	microovn.ovn-trace     ovn-trace     -
+	microovn.ovs-appctl    ovs-appctl    -
+	microovn.ovs-dpctl     ovs-dpctl     -
+	microovn.ovs-ofctl     ovs-ofctl     -
+	microovn.ovs-vsctl     ovs-vsctl     -
+	microovn.ovsdb-client  ovsdb-client  -
+	microovn.ovsdb-tool    ovsdb-tool    -
+
+Further inspection can be done by inspecting the files themselves:
+
+.. code-block:: none
+
+	ls $(which ovn-nbctl) -l
+
+.. code-block:: none
+
+	lrwxrwxrwx 1 root root 18 Nov 28 15:25 /snap/bin/ovn-nbctl -> microovn.ovn-nbctl
+
+These aliases are not related to the MicroOVN snap version and are managed by
+the store. All installations, done through the snap store, should have access to these aliases. This does mean if you install a locally built version of MicroOVN, these aliases are not created for you.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,3 +11,4 @@ does not cover upstream OVN/OVS topics.
    cryptography
    security
    services
+   aliasing

--- a/docs/tutorial/multi-node.rst
+++ b/docs/tutorial/multi-node.rst
@@ -79,12 +79,11 @@ Now all three nodes are joined to the cluster.
 Manage the cluster
 ------------------
 
-You can interact with OVN using its native commands prefaced with the string
-``microovn.``. For example, to show the contents of the OVN Southbound
-database:
+You can interact with OVN using its native commands due to automatically created
+snap aliases, for example, to show the contents of the OVN Southbound database:
 
 .. code-block:: none
 
-   microovn.ovn-sbctl show
+   ovn-sbctl show
 
 The cluster can be managed from any of its nodes.

--- a/docs/tutorial/single-node.rst
+++ b/docs/tutorial/single-node.rst
@@ -27,10 +27,9 @@ Initialise the cluster
 Manage the cluster
 ------------------
 
-You can interact with OVN using its native commands prefaced with the string
-``microovn.``. For example, to show the contents of the OVN Southbound
-database:
+You can interact with OVN using its native commands due to automatically created
+snap aliases, for example, to show the contents of the OVN Southbound database:
 
 .. code-block:: none
 
-   microovn.ovn-sbctl show
+   ovn-sbctl show


### PR DESCRIPTION
Automatic aliases have been enabled in the MicroOVN snap [1], so documentation has been updated to drop this prefix and rewrite certain small sections talking about how to run OVN commands through MicroOVN.

[1]: https://forum.snapcraft.io/t/alias-request-for-various-microovn-binaries/43755/5