### PR TITLE
ci: Manually install LXD snap.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap refresh
+          sudo snap install lxd
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           test $POSSIBLE_TARGET_BRANCH = main && \
@@ -159,6 +160,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap refresh
+          sudo snap install lxd
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           snap list


### PR DESCRIPTION
It seems that the LXD snap is no longer installed by default on the ubuntu images in GH CI. Manual installation should fix that.

Note: This should be backported to all "live" branches.