### PR TITLE
[branch-24.03] ci: Manually install LXD snap.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap refresh
+          sudo snap install lxd
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           test $POSSIBLE_TARGET_BRANCH = main && \
@@ -159,6 +160,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap refresh
+          sudo snap install lxd
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           snap list

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,14 @@ linkcheck_anchors_ignore_for_url = [
 ]
 linkcheck_anchors_ignore_for_url.extend(custom_linkcheck_anchors_ignore_for_url)
 
+# this cisa.gov pages are so heavily refrenced the github CI for linkchecks is
+# being seen as a DDos, this is causing our linkcheck tests to fail so we have
+# to ignore it.
+linkcheck_ignore = [r'.*cisa\.gov.*']
+
+linkcheck_timeout = 120
+linkcheck_retries = 3
+
 # Tags cannot be added directly in custom_conf.py, so add them here
 for tag in custom_tags:
     tags.add(tag)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,8 +59,7 @@ constructive feedback.
 * Contribute to the project on `GitHub`_ (documentation contributions go under
   the :file:`docs` directory)
 * GitHub is also used as our bug tracker
-* To speak with us, you can find us in our `MicroOVN Discourse`_ category. Use
-  the `Support`_ sub-category for technical assistance.
+* To speak with us, you can find us in our `MicroOVN Discourse`_ category.
 * Optionally enable `Ubuntu Pro`_ on your OVN nodes. This is a service that
   provides the `Livepatch Service`_ and the `Expanded Security Maintenance`_
   (ESM) program.
@@ -81,7 +80,6 @@ constructive feedback.
 .. _Code of conduct: https://ubuntu.com/community/ethos/code-of-conduct
 .. _GitHub: https://github.com/canonical/microovn
 .. _MicroOVN Discourse: https://discourse.ubuntu.com/c/microovn/160
-.. _Support: https://discourse.ubuntu.com/c/microovn/support/164
 .. _Ubuntu Pro: https://ubuntu.com/pro
 .. _Livepatch Service: https://ubuntu.com/security/livepatch
 .. _Expanded Security Maintenance: https://ubuntu.com/security/esm


### PR DESCRIPTION
It seems that the LXD snap is no longer installed by default on the ubuntu images in GH CI. Manual installation should fix that.

Signed-off-by: Martin Kalcok <martin.kalcok@canonical.com>
(cherry picked from commit fbaab4d04a0feb7a7383b290f61c313413b30df1)