### PR TITLE
[branch-22.03] ci: Manually install LXD snap.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap refresh
+          sudo snap install lxd
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           sudo snap install snapcraft --classic
@@ -114,6 +115,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap refresh
+          sudo snap install lxd
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           snap list


### PR DESCRIPTION
It seems that the LXD snap is no longer installed by default on the ubuntu images in GH CI. Manual installation should fix that.

Signed-off-by: Martin Kalcok <martin.kalcok@canonical.com>
(cherry picked from commit fbaab4d04a0feb7a7383b290f61c313413b30df1)