### PR TITLE
microovn: Use constant for MicroCluster port.

### DIFF
--- a/microovn/cmd/microovn/cluster_bootstrap.go
+++ b/microovn/cmd/microovn/cluster_bootstrap.go
@@ -43,7 +43,7 @@ func (c *cmdClusterBootstrap) Run(cmd *cobra.Command, args []string) error {
 
 	// Get system address.
 	address := util.NetworkInterfaceAddress()
-	address = util.CanonicalNetworkAddress(address, 6443)
+	address = util.CanonicalNetworkAddress(address, DefaultMicroClusterPort)
 
 	return m.NewCluster(context.Background(), hostname, address, nil)
 }

--- a/microovn/cmd/microovn/cluster_join.go
+++ b/microovn/cmd/microovn/cluster_join.go
@@ -43,7 +43,7 @@ func (c *cmdClusterJoin) Run(cmd *cobra.Command, args []string) error {
 
 	// Get system address.
 	address := util.NetworkInterfaceAddress()
-	address = util.CanonicalNetworkAddress(address, 6443)
+	address = util.CanonicalNetworkAddress(address, DefaultMicroClusterPort)
 
 	return m.JoinCluster(context.Background(), hostname, address, args[0], nil)
 }

--- a/microovn/cmd/microovn/init.go
+++ b/microovn/cmd/microovn/init.go
@@ -85,7 +85,8 @@ func (c *cmdInit) Run(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-		address = util.CanonicalNetworkAddress(address, 6443)
+		address = util.CanonicalNetworkAddress(
+			address, DefaultMicroClusterPort)
 
 		wantsBootstrap, err := c.common.asker.AskBool("Would you like to create a new MicroOVN cluster? (yes/no) [default=no]: ", "no")
 		if err != nil {

--- a/microovn/cmd/microovn/main.go
+++ b/microovn/cmd/microovn/main.go
@@ -13,6 +13,10 @@ import (
 	"github.com/canonical/microovn/microovn/version"
 )
 
+// DefaultMicroClusterPort is the default port used for the MicroOVN
+// MicroCluster Daemon.
+const DefaultMicroClusterPort = 6443
+
 // CmdControl has functions that are common to the microctl commands.
 // command line tools.
 type CmdControl struct {


### PR DESCRIPTION
The default port for use by the MicroCluster is repeated three places in the microovn client command.

Let's replace those with a constant instead.