### PR TITLE
Adds Microovn waitready command

### DIFF
--- a/microovn/cmd/microovn/main.go
+++ b/microovn/cmd/microovn/main.go
@@ -65,6 +65,9 @@ func main() {
 	var cmdEnable = cmdEnable{common: &commonCmd}
 	app.AddCommand(cmdEnable.Command())
 
+	var cmdWaitReady = cmdWaitReady{common: &commonCmd}
+	app.AddCommand(cmdWaitReady.Command())
+
 	// Nested.
 	var cmdCluster = cmdCluster{common: &commonCmd}
 	app.AddCommand(cmdCluster.Command())

--- a/microovn/cmd/microovn/waitready.go
+++ b/microovn/cmd/microovn/waitready.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/microcluster/v2/microcluster"
+	"github.com/spf13/cobra"
+)
+
+type cmdWaitReady struct {
+	common *CmdControl
+
+	flagTimeout int
+}
+
+func (c *cmdWaitReady) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "waitready",
+		Short: "Wait for the daemon to be ready to process requests",
+		RunE:  c.Run,
+		Args:  cobra.MatchAll(cobra.ExactArgs(0)),
+	}
+
+	cmd.Flags().IntVarP(&c.flagTimeout, "timeout", "t", 0,
+		"Number of seconds to wait before giving up")
+
+	return cmd
+}
+
+func (c *cmdWaitReady) Run(cmd *cobra.Command, _ []string) error {
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cmd.Context(), func() {}
+	if c.flagTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.flagTimeout)*time.Second)
+	}
+
+	defer cancel()
+
+	return m.Ready(ctx)
+}

--- a/tests/test_helper/bats/cli_ovsovn.bats
+++ b/tests/test_helper/bats/cli_ovsovn.bats
@@ -79,6 +79,9 @@ cli_ovsovn_register_test_functions() {
     bats_test_function \
         --description "Test invalid arguments return error code 1" \
         -- test_invalid_args_return_1
+    bats_test_function \
+        --description "Test waitready command"\
+        -- test_waitready
 }
 
 ovs-appctl_ovs-vswitchd() {
@@ -250,3 +253,16 @@ test_invalid_args_return_1() {
 }
 
 cli_ovsovn_register_test_functions
+
+test_waitready(){
+    for container in $TEST_CONTAINERS; do
+        run lxc_exec $container "snap stop microovn.daemon"
+        assert_success
+        run lxc_exec $container "microovn waitready -t 1"
+        assert_failure
+        run lxc_exec $container "snap start microovn.daemon"
+        assert_success
+        run lxc_exec $container "microovn waitready -t 10"
+        assert_success
+    done;
+}


### PR DESCRIPTION
This is a command to wait until the internal microcluster setup is ready for bootstrapping. This command has an optional flag to define the timeout.

Reported-at: https://bugs.launchpad.net/microovn/+bug/2098086