### PR TITLE
CI: Make use of the new Canonical CLA service.

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -13,7 +13,7 @@ jobs:
     name: Canonical CLA signed
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@v2
 
   dco-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As laid out in [0], a Canonical has introduced a new CLA process.

As a consequence, all contributors much re-sign the CLA and all repositories protected by the CLA must move to the new service by end of March 2025.

0: https://discourse.ubuntu.com/t/new-canonical-cla-process/55853
Signed-off-by: Frode Nordahl <fnordahl@ubuntu.com>