### PR TITLE
 Allow microovn.switch to start before bootstrap

### DIFF
--- a/snapcraft/commands/switch.start
+++ b/snapcraft/commands/switch.start
@@ -11,6 +11,8 @@ export OVS_PKGDATADIR="${SNAP}/share/openvswitch"
 export OVS_BINDIR="${SNAP}/bin"
 export OVS_SBINDIR="${SNAP}/bin"
 
+mkdir -p ${OVS_RUNDIR} ${OVS_LOGDIR} ${OVS_DBDIR}
+
 # Start vswitchd
 "${SNAP}/share/openvswitch/scripts/ovs-ctl" \
     start \

--- a/snapcraft/ovn.env
+++ b/snapcraft/ovn.env
@@ -4,14 +4,14 @@
 runtime_env="${SNAP_COMMON}/data/env/ovn.env"
 if [ -r "$runtime_env" ]; then
     . "$runtime_env"
+	export OVN_NB_DB="${OVN_NB_CONNECT}"
+	export OVN_SB_DB="${OVN_SB_CONNECT}"
 fi
 
 export OVN_PKI_DIR="${SNAP_COMMON}/data/pki"
 export CA_CERT="${OVN_PKI_DIR}/cacert.pem"
 
 export OVN_RUNDIR="${SNAP_COMMON}/run/ovn/"
-export OVN_NB_DB="${OVN_NB_CONNECT}"
-export OVN_SB_DB="${OVN_SB_CONNECT}"
 
 export OVS_RUNDIR="${SNAP_COMMON}/run/switch/"
 

--- a/tests/switchstart.bats
+++ b/tests/switchstart.bats
@@ -1,0 +1,1 @@
+test_helper/bats/switchstart.bats

--- a/tests/test_helper/bats/switchstart.bats
+++ b/tests/test_helper/bats/switchstart.bats
@@ -1,0 +1,40 @@
+
+load "${ABS_TOP_TEST_DIRNAME}test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+setup() {
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/common.bash
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/lxd.bash
+    load ${ABS_TOP_TEST_DIRNAME}test_helper/microovn.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-support/load.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS is populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+}
+
+switchstart_register_test_functions() {
+    bats_test_function \
+        --description "Testing of starting switch before bootstrap" \
+        -- start_switch_first_tests
+}
+
+start_switch_first_tests() {
+    for container in $TEST_CONTAINERS; do
+        run lxc_exec "$container" "microovn status"
+        assert_failure
+
+        run lxc_exec "$container" "snap start microovn.switch"
+        assert_success
+
+        run lxc_exec "$container" "snap services microovn.switch |
+                                   grep -q inactive"
+        assert_failure
+
+        run lxc_exec "$container" "microovn.ovs-vsctl show"
+        assert_success
+    done
+}
+
+
+switchstart_register_test_functions

--- a/tests/test_helper/setup_teardown/switchstart.bash
+++ b/tests/test_helper/setup_teardown/switchstart.bash
@@ -1,0 +1,17 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 1)
+    export TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+}
+
+teardown_file() {
+    collect_coverage $TEST_CONTAINERS
+    delete_containers $TEST_CONTAINERS
+}


### PR DESCRIPTION
Allows the snap service MicroOVN.switch to be enabled before the
MicroOVN cluster has been bootstrapped, this is useful if you need to
use OVS to setup networking before you start MicroOVN.

Reported-at: https://bugs.launchpad.net/microovn/+bug/2045490

Based on PR #227 