### PR TITLE
MicroOVN paths command

### DIFF
--- a/microovn/cmd/microovn/main.go
+++ b/microovn/cmd/microovn/main.go
@@ -68,6 +68,9 @@ func main() {
 	var cmdWaitReady = cmdWaitReady{common: &commonCmd}
 	app.AddCommand(cmdWaitReady.Command())
 
+	var cmdPath = cmdPath{common: &commonCmd}
+	app.AddCommand(cmdPath.Command())
+
 	// Nested.
 	var cmdCluster = cmdCluster{common: &commonCmd}
 	app.AddCommand(cmdCluster.Command())

--- a/microovn/cmd/microovn/paths.go
+++ b/microovn/cmd/microovn/paths.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microovn/microovn/ovn/paths"
+)
+
+type cmdPath struct {
+	common *CmdControl
+}
+
+func (c *cmdPath) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "path <NAME>",
+		Short: "Retrieve the path for the given name.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.Run,
+	}
+	return cmd
+}
+
+func (c *cmdPath) Run(_ *cobra.Command, args []string) error {
+	name := args[0]
+	path := paths.GetPath(name)
+	if path == nil {
+		return fmt.Errorf("unknown path name: %s", name)
+	}
+	fmt.Println(path)
+	return nil
+}

--- a/microovn/ovn/paths/paths.go
+++ b/microovn/ovn/paths/paths.go
@@ -181,3 +181,58 @@ func BackupDirs() []string {
 		LogsDir(),
 	}
 }
+
+// GetPath returns the corresponding path for a given name. If the name is not
+// recognized, it returns nil.
+func GetPath(name string) interface{} {
+	switch name {
+	case "Root":
+		return Root()
+	case "LogsDir":
+		return LogsDir()
+	case "OvnRuntimeDir":
+		return OvnRuntimeDir()
+	case "CentralDBDir":
+		return CentralDBDir()
+	case "CentralDBNBPath":
+		return CentralDBNBPath()
+	case "CentralDBSBPath":
+		return CentralDBSBPath()
+	case "CentralDBSBBackupPath":
+		return CentralDBSBBackupPath()
+	case "CentralDBNBBackupPath":
+		return CentralDBNBBackupPath()
+	case "SwitchDBDir":
+		return SwitchDBDir()
+	case "SwitchRuntimeDir":
+		return SwitchRuntimeDir()
+	case "SwitchDataDir":
+		return SwitchDataDir()
+	case "OvnEnvFile":
+		return OvnEnvFile()
+	case "OvnNBDatabaseSock":
+		return OvnNBDatabaseSock()
+	case "OvnSBDatabaseSock":
+		return OvnSBDatabaseSock()
+	case "OvnNBControlSock":
+		return OvnNBControlSock()
+	case "OvnSBControlSock":
+		return OvnSBControlSock()
+	case "OvsDatabaseSock":
+		return OvsDatabaseSock()
+	case "PkiDir":
+		return PkiDir()
+	case "EnvDir":
+		return EnvDir()
+	case "PkiCaCertFile":
+		return PkiCaCertFile()
+	case "OvsdbSbSchema":
+		return OvsdbSbSchema()
+	case "OvsdbNbSchema":
+		return OvsdbNbSchema()
+	case "OvsdbSwitchSchema":
+		return OvsdbSwitchSchema()
+	default:
+		return nil
+	}
+}

--- a/tests/test_helper/bats/cli_ovsovn.bats
+++ b/tests/test_helper/bats/cli_ovsovn.bats
@@ -82,6 +82,9 @@ cli_ovsovn_register_test_functions() {
     bats_test_function \
         --description "Test waitready command"\
         -- test_waitready
+    bats_test_function \
+        --description "Test paths command"\
+        -- test_paths
 }
 
 ovs-appctl_ovs-vswitchd() {
@@ -238,6 +241,7 @@ test_invalid_args_return_1() {
         "microovn certificates reissue"
         "microovn enable"
         "microovn disable"
+        "microovn path"
     )
 
     for container in $TEST_CONTAINERS; do
@@ -262,6 +266,21 @@ test_waitready(){
         assert_success
         run lxc_exec $container "microovn waitready -t 10"
         assert_success
+    done;
+}
+
+test_paths(){
+    for container in $TEST_CONTAINERS; do
+        run lxc_exec $container "microovn path Root"
+        assert_output '/var/snap/microovn/common'
+        run lxc_exec $container "microovn path SwitchDataDir"
+        assert_output '/var/snap/microovn/common/data/switch/openvswitch'
+        run lxc_exec $container "microovn path EnvDir"
+        assert_output '/var/snap/microovn/common/data/env'
+        run lxc_exec $container "microovn path CentralDBNBPath"
+        assert_output '/var/snap/microovn/common/data/central/db/ovnnb_db.db'
+        run lxc_exec $container "microovn path thisisnotapath"
+        assert_failure
     done;
 }
 

--- a/tests/test_helper/bats/cli_ovsovn.bats
+++ b/tests/test_helper/bats/cli_ovsovn.bats
@@ -252,8 +252,6 @@ test_invalid_args_return_1() {
 
 }
 
-cli_ovsovn_register_test_functions
-
 test_waitready(){
     for container in $TEST_CONTAINERS; do
         run lxc_exec $container "snap stop microovn.daemon"
@@ -266,3 +264,5 @@ test_waitready(){
         assert_success
     done;
 }
+
+cli_ovsovn_register_test_functions


### PR DESCRIPTION
Simple command takes the name of a function in ovn/paths and outputs the
corresponding path. Useful for maintaining a single point of truth