### PR TITLE
docs: add annotations to microcloud integration only

### DIFF
--- a/docs/tutorial/multi-node.rst
+++ b/docs/tutorial/multi-node.rst
@@ -2,6 +2,12 @@
 Multi-node
 ===========
 
+.. only:: integrated
+
+   .. note::
+
+      MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles MicroOVN installation.
+
 This tutorial shows how to install a 3-node MicroOVN cluster.
 
 One big advantage of a multi-node cluster is that it provides redundancy

--- a/docs/tutorial/single-node.rst
+++ b/docs/tutorial/single-node.rst
@@ -2,6 +2,12 @@
 Single-node
 ===========
 
+.. only:: integrated
+
+   .. note::
+
+      MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles MicroOVN installation.
+
 This tutorial shows how to install MicroOVN in the simplest way possible.
 
 .. caution::


### PR DESCRIPTION
The MicroOVN is pulled in as part of the [MicroCloud integrated docs set](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microceph/), which allows the user to switch between the MicroCloud, LXD, MicroCeph, and MicroOVN products from a header menu.

For MicroCloud users, some pages of the other docs sets are not relevant (such as installation docs, which MicroCloud handles). This PR adds a `note`-type annotation to such pages advising users of this, which uses the `only` Sphinx directive to _only_ show those notes when the page is viewed as part of the MicroCloud integrated docs set. It has no effect on the standalone doc set.