### PR TITLE
Makes IPv4 optional for BGP external connections.

### DIFF
--- a/microovn/api/types/services.go
+++ b/microovn/api/types/services.go
@@ -4,7 +4,6 @@ package types
 import (
 	"fmt"
 	"log"
-	"net"
 	"strconv"
 	"strings"
 )
@@ -131,10 +130,6 @@ type ExtraBgpConfig struct {
 type BgpExternalConnection struct {
 	// Iface is a name of the physical interface that provides external connectivity
 	Iface string
-	// IPAddress is an IP that is assigned to the Logical Router Port connected to the external network
-	IPAddress net.IP
-	// IPMask is network mask assigned to the Logical Router Port connected to the external network
-	IPMask net.IPMask
 }
 
 // FromMap initializes ExtraBgpConfig structure from the provided map of string keys and string values.
@@ -192,19 +187,8 @@ func (bgpConf *ExtraBgpConfig) Validate() error {
 func (bgpConf *ExtraBgpConfig) ParseExternalConnection() ([]BgpExternalConnection, error) {
 	parsedConnections := make([]BgpExternalConnection, 0)
 	for _, extConn := range strings.Split(bgpConf.ExternalConnection, ",") {
-		ifaceName, cidr, found := strings.Cut(extConn, ":")
-		if !found {
-			return nil, fmt.Errorf("connection string requires format '<interface_name>:<ipv4_cidr>': %s", extConn)
-		}
-
-		ipAddr, ipNet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid IPv4 CIDR notation: %s", cidr)
-		}
 		parsedConnections = append(parsedConnections, BgpExternalConnection{
-			Iface:     ifaceName,
-			IPAddress: ipAddr,
-			IPMask:    ipNet.Mask,
+			Iface: extConn,
 		})
 	}
 

--- a/microovn/frr/bgp/persistance.go
+++ b/microovn/frr/bgp/persistance.go
@@ -35,13 +35,7 @@ func EnsureInterfacesInVrf(ctx context.Context, s state.State) error {
 		}
 		portVrf = strings.TrimSpace(portVrf)
 
-		portIP, err := ovnCmd.VSCtl(ctx, s, "get", "port", port, fmt.Sprintf("external-ids:%s", BgpIfaceIP))
-		if err != nil {
-			allErrors = errors.Join(allErrors, fmt.Errorf("failed to lookup IPv4 address of port '%s': %v", port, err))
-		}
-		portIP = strings.Trim(strings.TrimSpace(portIP), "\"")
-
-		err = moveInterfaceToVrf(ctx, port, portIP, portVrf)
+		err = moveInterfaceToVrf(ctx, port, portVrf)
 		if err != nil {
 			allErrors = errors.Join(allErrors, fmt.Errorf("failed to move interface '%s' to VRF '%s': %v", port, portVrf, err))
 		}

--- a/microovn/frr/bgp/service.go
+++ b/microovn/frr/bgp/service.go
@@ -70,7 +70,7 @@ func EnableService(ctx context.Context, s state.State, extraConfig *types.ExtraB
 	}
 
 	if extraConfig.Asn != "" {
-		err = startBgpUnnumbered(ctx, extConnections, extraConfig.Vrf, extraConfig.Asn)
+		err = startBgpUnnumbered(ctx, s, extConnections, extraConfig.Vrf, extraConfig.Asn)
 	}
 
 	return err

--- a/tests/test_helper/bats/bgp_control_plane.bats
+++ b/tests/test_helper/bats/bgp_control_plane.bats
@@ -52,7 +52,7 @@ teardown() {
     done
 }
 
-tls_cluster_register_test_functions() {
+bgp_control_plane_register_test_functions() {
     bats_test_function \
         --description "OVN with multiple BGP peers (Automatic BGP config)" \
         -- bgp_unnumbered_peering yes yes
@@ -110,8 +110,6 @@ bgp_unnumbered_peering() {
     local host_asn=4210000000
     local i=0
     for container in $TEST_CONTAINERS; do
-        local BGP_NET_1_IP="10.$i.10.1/24"
-        local BGP_NET_2_IP="10.$i.20.1/24"
         local vrf="$((i + 1))0"
         local bgp_iface_1="$OVN_CONTAINER_NET_1_IFACE-bgp"
         local bgp_iface_2="$OVN_CONTAINER_NET_2_IFACE-bgp"
@@ -120,9 +118,9 @@ bgp_unnumbered_peering() {
 
         # Set up external connection string, used to configure MicroOVN BGP, based on number of upstream
         # links
-        local external_connections="$OVN_CONTAINER_NET_1_IFACE:$BGP_NET_1_IP"
+        local external_connections="$OVN_CONTAINER_NET_1_IFACE"
         if [ "$multi_link" == "yes" ]; then
-            external_connections="$external_connections,$OVN_CONTAINER_NET_2_IFACE:$BGP_NET_2_IP"
+            external_connections="$external_connections,$OVN_CONTAINER_NET_2_IFACE"
         fi
 
         # Configure FRR on the OVN chassis either automatically (by supplying ASN) or manually
@@ -202,4 +200,4 @@ bgp_no_config() {
     # teardown method verifies that it can be properly disabled
 }
 
-tls_cluster_register_test_functions
+bgp_control_plane_register_test_functions

--- a/tests/test_helper/bats/bgp_data_plane.bats
+++ b/tests/test_helper/bats/bgp_data_plane.bats
@@ -32,10 +32,9 @@ function ping_ovn_int_network_over_bgp_router() {
 
     # Enable BGP redirection and start BGP daemon in OVN chassis
     local host_asn=4210000000
-    local BGP_NET_IP="172.16.10.1/24"
     local vrf="10"
     local vrf_device="ovnvrf$vrf"
-    local external_connections="$OVN_CONTAINER_INT_IFACE:$BGP_NET_IP"
+    local external_connections="$OVN_CONTAINER_INT_IFACE"
 
     echo "# Enabling MicroOVN BGP in $TEST_CONTAINER and configuring BGP (ASN $host_asn)" >&3
     lxc_exec "$TEST_CONTAINER" "microovn enable bgp \


### PR DESCRIPTION
Allows easier enabling of BGP via no longer needing IPv4. This is part of the attempt to get BGP unnumbered working within OVN. This configures the router-id which is generated based off a hash of the logical router port name.