### PR TITLE
Allows set-ca to use stdin

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -69,3 +69,4 @@ unencrypted
 uptime
 vSwitch
 yaml
+stdin

--- a/docs/how-to/tls.rst
+++ b/docs/how-to/tls.rst
@@ -136,21 +136,30 @@ Alternative to the automatic self-signed CA certificate is for the user to
 provide their own CA certificate and private key. This can be done when
 initialising a cluster via :command:`init`, or anytime afterwards via
 :command:`certificates set-ca`. The certificate and the key are provided as a
-path to a file on disk. MicroOVN stores the contents of these files in its
-database, so it's safe to remove the files afterwards.
+path to a file on disk. The certificate and private key can be passed via stdin
+when using :command:`certificates set-ca --combined`. MicroOVN stores the
+contents of these files in its database, so it's safe to remove the files
+afterwards.
 
 .. note::
 
    With MicroOVN being a confined snap, it has limited accessibility
    to the host filesystem. The most reliable way to provide the certificate
    and the key file, is to put them into `/var/snap/microovn/common` and let
-   the MicroOVN to read it from there.
+   the MicroOVN to read it from there, or by piping them in using the --combined
+   option.
 
 Example of replacing current CA:
 
 .. code-block:: none
 
    microovn certificates set-ca --cert /var/snap/microovn/common/ca.crt --key /var/snap/microovn/common/ca.key
+
+Or via stdin:
+
+.. code-block:: none
+
+   cat /var/snap/microovn/common/ca.crt /var/snap/microovn/common/ca.key | microovn certificates set-ca --combined
 
 Similar to the :command:`certificates regenerate-ca`, this triggers reissue of
 all service and client certificates on the OVN cluster. The command's output

--- a/microovn/cmd/microovn/certificates_set_ca.go
+++ b/microovn/cmd/microovn/certificates_set_ca.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/pem"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/canonical/microcluster/v2/microcluster"
@@ -16,6 +20,7 @@ type cmdCertificatesSetCA struct {
 	certificates *cmdCertificates
 	certPath     string
 	keyPath      string
+	combined     bool
 }
 
 // Command method returns definition for "microovn certificates set-ca" subcommand
@@ -26,26 +31,91 @@ func (c *cmdCertificatesSetCA) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().StringVar(&c.certPath, "cert", "", "Path to the CA certificate file (required)")
-	cmd.Flags().StringVar(&c.keyPath, "key", "", "Path to the CA private key file (required)")
-	_ = cmd.MarkFlagRequired("cert")
-	_ = cmd.MarkFlagRequired("key")
+	cmd.Flags().StringVar(&c.certPath, "cert", "", "Path to the CA certificate file")
+	cmd.Flags().StringVar(&c.keyPath, "key", "", "Path to the CA private key file")
+	cmd.Flags().BoolVar(&c.combined, "combined", false, "CA certificate and CA private key are being fed in via stdin")
 
 	return cmd
+}
+
+func extractCertsAndKey(data []byte) ([]byte, []byte, error) {
+	var certsBuf bytes.Buffer
+	var keyBuf bytes.Buffer
+
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+
+		switch block.Type {
+		case "CERTIFICATE":
+			err := pem.Encode(&certsBuf, block)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to encode certificate block: %w", err)
+			}
+		case "RSA PRIVATE KEY", "PRIVATE KEY", "EC PRIVATE KEY":
+			// Only keep the first private key
+			if keyBuf.Len() == 0 {
+				err := pem.Encode(&keyBuf, block)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to encode key block: %w", err)
+				}
+			}
+		default:
+			// Ignore other block types
+		}
+	}
+
+	if certsBuf.Len() == 0 {
+		return nil, nil, fmt.Errorf("no certificates found")
+	}
+	if keyBuf.Len() == 0 {
+		return nil, nil, fmt.Errorf("no private key found")
+	}
+
+	return certsBuf.Bytes(), keyBuf.Bytes(), nil
 }
 
 // Run method implements the functionality of "microovn certificates set-ca" command. It reads the provided
 // certificate and key files, then requests local MicroOVN service to use them as CA and to reissue all service
 // certificates on every node.
 func (c *cmdCertificatesSetCA) Run(_ *cobra.Command, _ []string) error {
-	certData, err := os.ReadFile(c.certPath)
-	if err != nil {
-		return fmt.Errorf("failed to read certificate file: %w", err)
+	var certData []byte
+	var keyData []byte
+	var err error
+
+	certPathExists := c.certPath != ""
+	keyPathExists := c.keyPath != ""
+	if c.combined == (keyPathExists || certPathExists) {
+		return errors.New("you must use --combined xor (--key and --cert)")
 	}
 
-	keyData, err := os.ReadFile(c.keyPath)
-	if err != nil {
-		return fmt.Errorf("failed to read private key file: %w", err)
+	if keyPathExists != certPathExists {
+		return errors.New("you must use either both or none of --key and --cert")
+	}
+
+	if c.combined {
+		stdinData, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("failed to read stdin: %w", err)
+		}
+		certData, keyData, err = extractCertsAndKey(stdinData)
+
+		if err != nil {
+			return fmt.Errorf("failed to parse certificates and keys from stdin: %w", err)
+		}
+	} else {
+		certData, err = os.ReadFile(c.certPath)
+		if err != nil {
+			return fmt.Errorf("failed to read certificate file: %w", err)
+		}
+
+		keyData, err = os.ReadFile(c.keyPath)
+		if err != nil {
+			return fmt.Errorf("failed to read private key file: %w", err)
+		}
 	}
 
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})

--- a/tests/test_helper/bats/init_cluster_user_ca.bats
+++ b/tests/test_helper/bats/init_cluster_user_ca.bats
@@ -19,12 +19,60 @@ init_cluster_user_ca_register_test_functions() {
     bats_test_function \
         --description "MicroOVN was bootstrapped with user-supplied CA" \
         -- cluster_bootstrapped_with_user_ca
+    bats_test_function \
+        --description "MicroOVN cluster supplied with new CA" \
+        -- ca_changed_with_set_ca
+    bats_test_function \
+        --description "Test set ca command failures" \
+        -- set_ca_failures
 }
 
 cluster_bootstrapped_with_user_ca() {
     local container
     local uploaded_ca_hash
     local microovn_ca_hash
+
+    uploaded_ca_hash=$(get_cert_fingerprint "$LEADER" "$USER_CA_CRT")
+    assert [ -n "$uploaded_ca_hash" ]
+
+    # Ensure that CA cert used by MicroOVN matches the one uploaded by the user
+    for container in $TEST_CONTAINERS; do
+        microovn_ca_hash=$(get_cert_fingerprint "$container" "$CA_CERT_PATH")
+        assert [ -n "$microovn_ca_hash" ]
+        assert_equal "$uploaded_ca_hash" "$microovn_ca_hash"
+    done
+
+    # Ensure that OVN Central nodes have certificates signed by the user-supplied CA
+    for container in $CENTRAL_CONTAINERS; do
+        verify_central_cert_files "$container"
+    done
+
+    # Ensure that OVN Chassis nodes have certificates signed by the user-supplied CA
+    for container in $CENTRAL_CONTAINERS; do
+        verify_chassis_cert_files "$container"
+    done
+
+}
+
+set_ca_failures() {
+    run lxc_exec "$LEADER" "microovn certificates set-ca --combined --cert"
+    assert_failure
+    run lxc_exec "$LEADER" "microovn certificates set-ca --combined --cert --key"
+    assert_failure
+    run lxc_exec "$LEADER" "microovn certificates set-ca --key"
+    assert_failure
+    run lxc_exec "$LEADER" "microovn certificates set-ca"
+    assert_failure
+}
+
+ca_changed_with_set_ca() {
+    local container
+    local uploaded_ca_hash
+    local microovn_ca_hash
+
+    generate_user_ca "$LEADER" "ec" "$USER_CA_CRT" "$USER_CA_KEY"
+    run lxc_exec "$LEADER" "cat $CA_CERT_PATH $USER_CA_KEY | microovn certificates set-ca --combined"
+    assert_success
 
     uploaded_ca_hash=$(get_cert_fingerprint "$LEADER" "$USER_CA_CRT")
     assert [ -n "$uploaded_ca_hash" ]


### PR DESCRIPTION
This allows certificates set-ca to take certificates and keys from stdin, this is very useful for ongoing charm work and general consumption of this feature.