### PR TITLE
node: Fix incomplete remote addresses in northd

### DIFF
--- a/microovn/node/node.go
+++ b/microovn/node/node.go
@@ -17,6 +17,7 @@ import (
 	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCluster "github.com/canonical/microovn/microovn/ovn/cluster"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/ovn/environment"
 	"github.com/canonical/microovn/microovn/ovn/paths"
 	"github.com/canonical/microovn/microovn/snap"
 )
@@ -103,6 +104,11 @@ func EnableService(ctx context.Context, s state.State, service types.SrvName) er
 	})
 	if err != nil {
 		return err
+	}
+
+	err = environment.GenerateEnvironment(ctx, s)
+	if err != nil {
+		return fmt.Errorf("failed to regenerate environment file after enabling central service: %w", err)
 	}
 
 	switch service {

--- a/tests/test_helper/bats/cluster.bats
+++ b/tests/test_helper/bats/cluster.bats
@@ -24,6 +24,9 @@ cluster_register_test_functions() {
             -- cluster_test_db_connection_string "$db"
     done
     bats_test_function \
+        --description "Northd connection string" \
+        -- cluster_test_northd_connection_string
+    bats_test_function \
         --description "Expected MicroOVN cluster count" \
         -- cluster_expected_count
     bats_test_function \
@@ -207,6 +210,42 @@ cluster_test_db_connection_string() {
             # By using a fully qualified search string we can safely use
             # partial matching.
             assert_output -p "ssl:${expected_addr}:${expected_port}"
+        done
+    done
+}
+
+# cluster_test_northd_connection_string
+#
+# Test that northd service is connected to all expected NB and SB database
+# cluster members.
+cluster_test_northd_connection_string() {
+    local cluster_addresses=()
+    readarray \
+        -t cluster_addresses \
+        < <(microovn_get_member_cluster_address "central" $TEST_CONTAINERS)
+
+    local container
+    for container in $TEST_CONTAINERS; do
+        local container_services
+        container_services=$(microovn_get_cluster_services)
+        if [[ "$container_services" != *"central"* ]]; then
+            echo "Skip $container, no central services" >&3
+            continue
+        fi
+
+        local northd_pid
+        northd_pid=$(microovn_get_service_pid "$container" "ovn-northd" "ovn")
+        run lxc_exec \
+            "$container" \
+            "ps -ww -o cmd -p $northd_pid"
+
+        for addr in "${cluster_addresses[@]}"; do
+            local expected_addr
+            expected_addr=$(print_address $addr)
+            # By using a fully qualified search string we can safely use
+            # partial matching.
+            assert_output -p "ssl:${expected_addr}:6641"
+            assert_output -p "ssl:${expected_addr}:6642"
         done
     done
 }


### PR DESCRIPTION
MicroOVN used incomplete list of NB/SB cluster members when starting the ovn-northd service. When central service was enabled, local ovn.env file, containing list of IP addresses of NB/SB cluster members, was not updated before starting of the northd service. This caused northd service, on a node that just enabled the central service (or joined the cluster), to miss its own IP address.

This issue was partially hidden by the fact that all other northd services in the cluster had complete list of remote IPs. It was only the last joining member that was incomplete.
For the problem to manifest fully, the northd instance with the incomplete list of remote addresses would have to aquire lock, and the NB/SB database that was missing from its list would have to become the cluster leader.

A new test was added to ensure that all northd instances in the cluster have complete list of IPs of the NB/SB cluster members.

Fixes: ad657d813db24fad950171ddd454292f7b9d5966