### PR TITLE
[branch-24.03] Backport docs vulnerability response process

### DIFF
--- a/SECURITY.rst
+++ b/SECURITY.rst
@@ -1,0 +1,1 @@
+docs/reference/security.rst

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,4 +1,5 @@
 CLI
+CVE
 ESM
 Geneve
 LTS
@@ -40,6 +41,7 @@ lifecycle
 linter
 linters
 manpage
+mitigations
 northd
 ovs
 ovsdb
@@ -50,6 +52,8 @@ readthedocs
 schemas
 submodules
 systemd
+ubuntu
 unencrypted
+uptime
 vSwitch
 yaml

--- a/docs/explanation/tracks-and-upgrades.rst
+++ b/docs/explanation/tracks-and-upgrades.rst
@@ -1,3 +1,5 @@
+.. _snap channels:
+
 ===================================
 MicroOVN snap channels and upgrades
 ===================================

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -8,5 +8,6 @@ does not cover upstream OVN/OVS topics.
 .. toctree::
    :maxdepth: 1
 
-   services
    cryptography
+   security
+   services

--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -1,0 +1,71 @@
+================
+Security process
+================
+
+What is a vulnerability?
+------------------------
+All vulnerabilities are bugs, but not every bug is a vulnerability.
+Vulnerabilities compromise one or more of:
+
+* Confidentiality (personal or corporate confidential data).
+* Integrity (trustworthiness and correctness).
+* Availability (uptime and service).
+
+If in doubt, please use the process for `reporting a vulnerability`_, and we
+will assess whether your report is in fact a security vulnerability, or if it
+should be `reported as a bug`_ using the normal bug process.
+
+Reporting a vulnerability
+-------------------------
+To report a security issue, please email `security@ubuntu.com`_ with a
+description of the issue, the steps you took to create the issue, affected
+versions, and, if known, mitigations for the issue.
+
+The `Ubuntu Security disclosure and embargo policy`_ contains more information
+about what you can expect when you contact us and what we expect from you.
+
+Product lifetime
+----------------
+The main components of MicroOVN, Open vSwitch (OVS) and Open Virtual Network
+(OVN), comes from the Ubuntu distribution.  Releases of MicroOVN in stable
+:ref:`snap channels` that align with Ubuntu Long Term Support (LTS) releases,
+receive the same level of support throughout the lifetime of the corresponding
+Ubuntu LTS release.  Please refer to the `Ubuntu lifecycle and release
+cadence`_ documentation for more information.
+
+Tracking vulnerabilities
+------------------------
+Vulnerabilities, their status, and the state of the analysis or response will
+all be tracked through the `Ubuntu CVE tracker`_.
+
+Responding to vulnerabilities
+-----------------------------
+Vulnerabilities are classified by `priority`_, and the MicroOVN project
+guarantees response to all High and Critical severity vulnerabilities, as well
+as any `Known Exploited Vulnerability`_.
+
+Security updates will be made available to consumers of stable :ref:`snap
+channels` that align with supported Ubuntu Long Term Support (LTS) releases.
+
+The MicroOVN snap is automatically rebuilt by Launchpad whenever there is an
+update to the underlying packages in the Ubuntu distribution.
+
+Updated versions of the snap will be put through the MicroOVN functional test
+suites before being promoted to stable :ref:`snap channels`.
+
+Information about new builds are made available through the `Snap store`_.
+
+Responsible disclosure
+----------------------
+We follow the `Ubuntu Security disclosure and embargo policy`_.  Please refer
+to the section on `reporting a vulnerability`_.
+
+.. LINKS
+.. _security@ubuntu.com: mailto:security@ubuntu.com
+.. _Ubuntu Security disclosure and embargo policy: https://ubuntu.com/security/disclosure-policy
+.. _reported as a bug: https://bugs.launchpad.net/microovn/+filebug
+.. _Ubuntu lifecycle and release cadence: https://ubuntu.com/about/release-cycle
+.. _Ubuntu CVE tracker: https://ubuntu.com/security/cves
+.. _priority: https://ubuntu.com/security/cves/about#priority
+.. _Known Exploited Vulnerability: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+.. _Snap store: https://snapcraft.io/store


### PR DESCRIPTION
This PR backports https://github.com/canonical/microovn/pull/206 into `branch-24.03`.

The combined docs build for MicroCloud uses one of the references on the `explanation/tracks-and-upgrades.rst` page for its stable docs build which requires this change to be backported.