### PR TITLE
[branch-24.03] Update golangci-lint to version v2.0.0.

### DIFF
--- a/microovn/.golangci.yml
+++ b/microovn/.golangci.yml
@@ -10,6 +10,14 @@ linters:
     - ineffassign
     - revive
     - staticcheck
+  settings:
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - [] # AllowList
+            - [] # DenyList
+            - - skip-package-name-checks: true # Extra parameter (upper-case-const|skip-package-name-checks)
   exclusions:
     generated: lax
     rules:

--- a/microovn/.golangci.yml
+++ b/microovn/.golangci.yml
@@ -1,25 +1,32 @@
+version: "2"
 run:
-  # The default of 1 minute is a pretty low number when taking into account the
-  # size of the project and its dependencies and the potential load of the
-  # various build environments this project is exposed to.
+  # The defualt timeout is now disabled but a timeout for 5m is good for the CI
   timeout: 5m
-issues:
-  # The default exclude rules disable the requirement for GoDoc comments in the
-  # revive linter, so we can't use them.
-  exclude-use-default: false
-  # Not using the default exclude rules re-introduces the below check,
-  # disabling for now as the fact that it is excluded by default and other
-  # people are re-adding it makes it probable that we don't need it either.
-  exclude-rules:
-    - linters: [errcheck]
-      text: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*printf?|os\\.(Un)?Setenv). is not checked"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gofmt
     - errcheck
-    - gosimple
     - govet
     - ineffassign
-    - staticcheck
     - revive
+    - staticcheck
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - errcheck
+        # disabling this check for now as the fact that it is excluded by default and other people are excluding it means its not needed.
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/microovn/api/certificates/issue.go
+++ b/microovn/api/certificates/issue.go
@@ -29,16 +29,16 @@ func issueCertificatesPut(s state.State, r *http.Request) response.Response {
 	// Get requested service name
 	requestedService, err := url.PathUnescape(mux.Vars(r)["service"])
 	if err != nil {
-		logger.Errorf("failed to parse service name from URL '%s'", r.URL)
-		return response.ErrorResponse(500, "Internal server error")
+		logger.Errorf("Failed to parse service name from URL '%s'", r.URL)
+		return response.ErrorResponse(500, "internal server error")
 	}
 	logger.Infof("Issuing new certificate for '%s' service.", requestedService)
 
 	// Get all enabled services and make sure that the requested service is among them.
 	eligibleServices, err := enabledOvnServices(r.Context(), s)
 	if err != nil {
-		logger.Errorf("failed to lookup local services eligible for certificate refresh: %s", err)
-		return response.ErrorResponse(500, "Internal server error.")
+		logger.Errorf("Failed to lookup local services eligible for certificate refresh: %s", err)
+		return response.ErrorResponse(500, "internal server error.")
 	}
 
 	isCertificateAllowed := false
@@ -52,7 +52,7 @@ func issueCertificatesPut(s state.State, r *http.Request) response.Response {
 	// Fail with 404 if requested service is not enabled
 	if !isCertificateAllowed {
 		missingMsg := fmt.Sprintf(
-			"Can't issue certificate for service '%s'. Service is not enabled on this member. Enabled services: %s",
+			"can't issue certificate for service '%s', service is not enabled on this member, enabled services: %s",
 			requestedService,
 			strings.Join(eligibleServices, ", "),
 		)
@@ -66,7 +66,7 @@ func issueCertificatesPut(s state.State, r *http.Request) response.Response {
 
 	if err != nil {
 		result.Failed = []string{requestedService}
-		logger.Errorf("failed to reissue certificate for '%s' service: %s", requestedService, err)
+		logger.Errorf("Failed to reissue certificate for '%s' service: %s", requestedService, err)
 		return response.SyncResponse(false, &result)
 	}
 

--- a/microovn/api/certificates/issue_all.go
+++ b/microovn/api/certificates/issue_all.go
@@ -21,8 +21,8 @@ func issueCertificatesAllPut(s state.State, r *http.Request) response.Response {
 	logger.Info("Re-issuing certificate for all enabled OVN services.")
 	responseData, err := reissueAllCertificates(r.Context(), s)
 	if err != nil {
-		logger.Errorf("failed to issue certificates for all services: %v", err)
-		return response.ErrorResponse(500, "Internal server error.")
+		logger.Errorf("Failed to issue certificates for all services: %v", err)
+		return response.ErrorResponse(500, "internal server error.")
 	}
 
 	return response.SyncResponse(true, responseData)

--- a/microovn/api/ovsdb/schema_version.go
+++ b/microovn/api/ovsdb/schema_version.go
@@ -59,8 +59,8 @@ func getExpectedSchemaVersion(s state.State, r *http.Request) response.Response 
 
 	expectedVersion, err := ovsdb.ExpectedOvsdbSchemaVersion(r.Context(), s, dbSpec)
 	if err != nil {
-		logger.Errorf("failed to get expected OVSDB schema version for '%s' database: %s", dbSpec.FriendlyName, err)
-		return response.ErrorResponse(500, "Internal Server Error")
+		logger.Errorf("Failed to get expected OVSDB schema version for '%s' database: %s", dbSpec.FriendlyName, err)
+		return response.ErrorResponse(500, "internal server error")
 	}
 
 	return response.SyncResponse(true, expectedVersion)
@@ -78,8 +78,8 @@ func getAllExpectedSchemaVersions(s state.State, r *http.Request) response.Respo
 	// Get local expected schema version and store it in the final result
 	localExpectedVersion, err := ovsdb.ExpectedOvsdbSchemaVersion(r.Context(), s, dbSpec)
 	if err != nil {
-		logger.Errorf("failed to get expected OVSDB schema version for '%s' database: %s", dbSpec.FriendlyName, err)
-		return response.ErrorResponse(500, "Internal Server Error")
+		logger.Errorf("Failed to get expected OVSDB schema version for '%s' database: %s", dbSpec.FriendlyName, err)
+		return response.ErrorResponse(500, "internal server error")
 	}
 
 	responseData := types.OvsdbSchemaReport{
@@ -94,7 +94,7 @@ func getAllExpectedSchemaVersions(s state.State, r *http.Request) response.Respo
 	clusterClient, err := s.Cluster(false)
 	if err != nil {
 		logger.Errorf("Failed to get a client for every cluster member: %s", err)
-		return response.ErrorResponse(500, "Internal Server Error")
+		return response.ErrorResponse(500, "internal server error")
 	}
 
 	// Fetch expected schema versions from each cluster member.
@@ -123,8 +123,8 @@ func getAllExpectedSchemaVersions(s state.State, r *http.Request) response.Respo
 func getActiveSchemaVersion(s state.State, r *http.Request) response.Response {
 	hasCentral, err := node.HasServiceActive(r.Context(), s, types.SrvCentral)
 	if err != nil {
-		logger.Errorf("failed to check if central is active on this node: %s", err)
-		return response.ErrorResponse(500, "Internal Server Error")
+		logger.Errorf("Failed to check if central is active on this node: %s", err)
+		return response.ErrorResponse(500, "internal server error")
 	}
 
 	dbSpec, errResponse := parseDbSpec(r)
@@ -141,8 +141,8 @@ func getActiveSchemaVersion(s state.State, r *http.Request) response.Response {
 
 	activeSchema, err := ovnCmd.OvsdbClient(r.Context(), s, dbSpec, 10, 30, "get-schema-version", dbSpec.SocketURL)
 	if err != nil {
-		logger.Errorf("failed to get active schema version for '%s' database: %s", dbSpec.FriendlyName, err)
-		return response.ErrorResponse(500, "Internal Server Error")
+		logger.Errorf("Failed to get active schema version for '%s' database: %s", dbSpec.FriendlyName, err)
+		return response.ErrorResponse(500, "internal server error")
 	}
 
 	return response.SyncResponse(true, strings.TrimSpace(activeSchema))
@@ -156,14 +156,14 @@ func getActiveSchemaVersion(s state.State, r *http.Request) response.Response {
 func forwardActiveSchemaVersion(s state.State, r *http.Request, dbSpec *ovnCmd.OvsdbSpec) response.Response {
 	centralNodes, err := node.FindService(r.Context(), s, "central")
 	if err != nil {
-		logger.Errorf("failed to find central node: %s", err)
-		return response.ErrorResponse(500, "Internal Server Error")
+		logger.Errorf("Failed to find central node: %s", err)
+		return response.ErrorResponse(500, "internal server error")
 	}
 
 	clusterClients, err := s.Cluster(false)
 	if err != nil {
-		logger.Errorf("failed to get cluster clients: %v", err)
-		return response.ErrorResponse(500, "Internal Server Error")
+		logger.Errorf("Failed to get cluster clients: %v", err)
+		return response.ErrorResponse(500, "internal server error")
 	}
 
 	for _, _client := range clusterClients {
@@ -192,7 +192,7 @@ func forwardActiveSchemaVersion(s state.State, r *http.Request, dbSpec *ovnCmd.O
 	}
 
 	logger.Error("None of the central nodes responded to the forwarded query")
-	return response.ErrorResponse(500, "Internal Server Error")
+	return response.ErrorResponse(500, "internal server error")
 }
 
 // parseDbSpec is a helper function that returns OvsdbSpec based on the database name
@@ -202,8 +202,8 @@ func forwardActiveSchemaVersion(s state.State, r *http.Request, dbSpec *ovnCmd.O
 func parseDbSpec(r *http.Request) (*ovnCmd.OvsdbSpec, response.Response) {
 	requestedDB, err := url.PathUnescape(mux.Vars(r)["db"])
 	if err != nil {
-		logger.Errorf("failed to parse requested DB name from url '%s'", r.URL)
-		return nil, response.ErrorResponse(500, "Internal Server Error")
+		logger.Errorf("Failed to parse requested DB name from url '%s'", r.URL)
+		return nil, response.ErrorResponse(500, "internal server error")
 	}
 	requestedDB = strings.ToLower(requestedDB)
 
@@ -216,7 +216,7 @@ func parseDbSpec(r *http.Request) (*ovnCmd.OvsdbSpec, response.Response) {
 	dbSpec, err := ovnCmd.NewOvsdbSpec(dbType)
 	if err != nil {
 		logger.Errorf("%s", err)
-		return nil, response.ErrorResponse(500, "Internal Server Error")
+		return nil, response.ErrorResponse(500, "internal server error")
 	}
 	return dbSpec, nil
 }

--- a/microovn/api/services/control.go
+++ b/microovn/api/services/control.go
@@ -31,10 +31,10 @@ func enableService(s state.State, r *http.Request) response.Response {
 	requestedService, err := url.PathUnescape(mux.Vars(r)["service"])
 	if err != nil {
 		logger.Errorf("Failed to get service: %s", err)
-		return response.ErrorResponse(500, "Internal server error")
+		return response.ErrorResponse(500, "internal server error")
 	}
 	if !types.CheckValidService(requestedService) {
-		return response.InternalError(errors.New("Service does not exist"))
+		return response.InternalError(errors.New("service does not exist"))
 	}
 
 	err = node.EnableService(r.Context(), s, requestedService)
@@ -46,7 +46,7 @@ func enableService(s state.State, r *http.Request) response.Response {
 	scr.Warnings, err = node.ServiceWarnings(r.Context(), s)
 	if err != nil {
 		logger.Errorf("Failed to generate warnings for service: %s: %s", requestedService, err)
-		return response.ErrorResponse(500, "Internal server error")
+		return response.ErrorResponse(500, "internal server error")
 	}
 	scr.Message = requestedService + " enabled"
 
@@ -62,10 +62,10 @@ func disableService(s state.State, r *http.Request) response.Response {
 	requestedService, err := url.PathUnescape(mux.Vars(r)["service"])
 	if err != nil {
 		logger.Errorf("Failed to get service: %s", err)
-		return response.ErrorResponse(500, "Internal server error")
+		return response.ErrorResponse(500, "internal server error")
 	}
 	if !types.CheckValidService(requestedService) {
-		return response.InternalError(errors.New("Service does not exist"))
+		return response.InternalError(errors.New("service does not exist"))
 	}
 	err = node.DisableService(r.Context(), s, requestedService)
 	if err != nil {
@@ -76,7 +76,7 @@ func disableService(s state.State, r *http.Request) response.Response {
 	scr.Warnings, err = node.ServiceWarnings(r.Context(), s)
 	if err != nil {
 		logger.Errorf("Failed to generate warnings for service: %s: %s", requestedService, err)
-		return response.ErrorResponse(500, "Internal server error")
+		return response.ErrorResponse(500, "internal server error")
 	}
 	scr.Message = requestedService + " disabled"
 

--- a/microovn/client/client.go
+++ b/microovn/client/client.go
@@ -24,7 +24,7 @@ func GetServices(ctx context.Context, c *client.Client) (types.Services, error) 
 
 	err := c.Query(queryCtx, "GET", types.APIVersion, api.NewURL().Path("services"), nil, &services)
 	if err != nil {
-		return nil, fmt.Errorf("Failed listing services: %w", err)
+		return nil, fmt.Errorf("failed listing services: %w", err)
 	}
 
 	return services, nil
@@ -141,7 +141,7 @@ func DisableService(ctx context.Context, c *client.Client, serviceName string) (
 	err := c.Query(queryCtx, "DELETE", types.APIVersion, api.NewURL().Path("service", serviceName), nil, &scr)
 
 	if err != nil {
-		return types.WarningSet{}, types.RegenerateEnvResponse{}, fmt.Errorf("Failed to disable service '%s': '%s'", serviceName, err)
+		return types.WarningSet{}, types.RegenerateEnvResponse{}, fmt.Errorf("failed to disable service '%s': '%s'", serviceName, err)
 	}
 
 	regenerateEnvResponse := types.RegenerateEnvResponse{}
@@ -163,7 +163,7 @@ func EnableService(ctx context.Context, c *client.Client, serviceName string) (t
 	scr := types.ServiceControlResponse{}
 	err := c.Query(queryCtx, "PUT", types.APIVersion, api.NewURL().Path("service", serviceName), nil, &scr)
 	if err != nil {
-		return types.WarningSet{}, types.RegenerateEnvResponse{}, fmt.Errorf("Failed to enable service '%s': '%s'", serviceName, err)
+		return types.WarningSet{}, types.RegenerateEnvResponse{}, fmt.Errorf("failed to enable service '%s': '%s'", serviceName, err)
 	}
 
 	regenerateEnvResponse := types.RegenerateEnvResponse{}
@@ -186,7 +186,7 @@ func RegenerateEnvironment(ctx context.Context, c *client.Client) (types.Regener
 	err := c.Query(queryCtx, "POST", types.APIVersion, api.NewURL().Path("env"), nil, &responseData)
 
 	if err != nil {
-		return types.RegenerateEnvResponse{}, fmt.Errorf("Failed to regenerate environment files: '%s'", err)
+		return types.RegenerateEnvResponse{}, fmt.Errorf("failed to regenerate environment files: '%s'", err)
 	}
 	return responseData, nil
 

--- a/microovn/cmd/microovn/cluster_add.go
+++ b/microovn/cmd/microovn/cluster_add.go
@@ -40,7 +40,7 @@ func (c *cmdClusterAdd) Run(cmd *cobra.Command, args []string) error {
 
 	token, err := m.NewJoinToken(context.Background(), args[0], time.Duration(c.flagTokenDuration*float64(time.Second)))
 	if err != nil {
-		return fmt.Errorf("Unable to add server to MicroCluster, name %q is taken:\n%w",
+		return fmt.Errorf("unable to add server to microcluster, name %q is taken:\n%w",
 			args[0],
 			err)
 	}

--- a/microovn/cmd/microovn/cluster_bootstrap.go
+++ b/microovn/cmd/microovn/cluster_bootstrap.go
@@ -32,13 +32,13 @@ func (c *cmdClusterBootstrap) Run(cmd *cobra.Command, args []string) error {
 
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
 	if err != nil {
-		return fmt.Errorf("Unable to configure MicroOVN: %w", err)
+		return fmt.Errorf("unable to configure microovn: %w", err)
 	}
 
 	// Get system hostname.
 	hostname, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve system hostname: %w", err)
+		return fmt.Errorf("failed to retrieve system hostname: %w", err)
 	}
 
 	// Get system address.

--- a/microovn/cmd/microovn/cluster_join.go
+++ b/microovn/cmd/microovn/cluster_join.go
@@ -32,13 +32,13 @@ func (c *cmdClusterJoin) Run(cmd *cobra.Command, args []string) error {
 
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
 	if err != nil {
-		return fmt.Errorf("Unable to configure MicroCluster: %w", err)
+		return fmt.Errorf("unable to configure microcluster: %w", err)
 	}
 
 	// Get system hostname.
 	hostname, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve system hostname: %w", err)
+		return fmt.Errorf("failed to retrieve system hostname: %w", err)
 	}
 
 	// Get system address.

--- a/microovn/cmd/microovn/cluster_sql.go
+++ b/microovn/cmd/microovn/cluster_sql.go
@@ -29,7 +29,7 @@ func (c *cmdClusterSQL) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		err := cmd.Help()
 		if err != nil {
-			return fmt.Errorf("Unable to load help: %w", err)
+			return fmt.Errorf("unable to load help: %w", err)
 		}
 
 		if len(args) == 0 {

--- a/microovn/cmd/microovn/init.go
+++ b/microovn/cmd/microovn/init.go
@@ -76,7 +76,7 @@ func (c *cmdInit) Run(_ *cobra.Command, _ []string) error {
 		// Get system name.
 		hostName, err := os.Hostname()
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve system hostname: %w", err)
+			return fmt.Errorf("failed to retrieve system hostname: %w", err)
 		}
 
 		// Get system address.

--- a/microovn/cmd/microovn/status.go
+++ b/microovn/cmd/microovn/status.go
@@ -141,11 +141,12 @@ func printOvsdbSchemaReport(cli *microClusterClient.Client, dbSpec *ovnCmd.Ovsdb
 			nodeName = node.Host
 		}
 		msg += fmt.Sprintf("\t%s: ", nodeName)
-		if node.Error == types.OvsdbSchemaFetchErrorGeneric {
+		switch node.Error {
+		case types.OvsdbSchemaFetchErrorGeneric:
 			msg += "Error. Failed to contact member\n"
-		} else if node.Error == types.OvsdbSchemaFetchErrorNotSupported {
+		case types.OvsdbSchemaFetchErrorNotSupported:
 			msg += "Missing API. MicroOVN needs upgrade\n"
-		} else {
+		default:
 			msg += fmt.Sprintf("%s\n", node.SchemaVersion)
 		}
 	}

--- a/microovn/database/schema.go
+++ b/microovn/database/schema.go
@@ -29,7 +29,7 @@ func getClusterTableName(ctx context.Context, tx *sql.Tx) (string, error) {
 	}
 
 	if len(tables) != 1 || tables[0] == "" {
-		return "", fmt.Errorf("No cluster members table found")
+		return "", fmt.Errorf("no cluster members table found")
 	}
 
 	return tables[0], nil

--- a/microovn/node/node.go
+++ b/microovn/node/node.go
@@ -33,7 +33,7 @@ func DisableService(ctx context.Context, s state.State, service types.SrvName) e
 		return err
 	}
 	if !exists {
-		return errors.New("This service is not enabled")
+		return errors.New("this service is not enabled")
 	}
 
 	// If going to disable central, check if possible, this is done before the
@@ -46,7 +46,7 @@ func DisableService(ctx context.Context, s state.State, service types.SrvName) e
 			return err
 		}
 		if len(centrals) == 1 {
-			return errors.New("You cannot delete the final enabled central service")
+			return errors.New("you cannot delete the final enabled central service")
 		}
 	}
 
@@ -58,14 +58,15 @@ func DisableService(ctx context.Context, s state.State, service types.SrvName) e
 		return err
 	}
 
-	if service == types.SrvCentral {
+	switch service {
+	case types.SrvCentral:
 		err = leaveCentral(ctx, s)
-	} else if service == types.SrvChassis {
+	case types.SrvChassis:
 		err = leaveChassis(ctx, s)
-	} else {
+	default:
 		err = snap.Stop(service, true)
 		if err != nil {
-			err = fmt.Errorf("Snapctl error, likely due to service not existing:\n %w", err)
+			err = fmt.Errorf("snapctl error, likely due to service not existing:\n %w", err)
 		}
 	}
 
@@ -84,11 +85,11 @@ func EnableService(ctx context.Context, s state.State, service types.SrvName) er
 		return err
 	}
 	if exists {
-		return errors.New("This Service is already enabled")
+		return errors.New("this service is already enabled")
 	}
 
 	if !types.CheckValidService(service) {
-		return errors.New("Service does not exist")
+		return errors.New("service does not exist")
 	}
 
 	err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
@@ -99,14 +100,15 @@ func EnableService(ctx context.Context, s state.State, service types.SrvName) er
 		return err
 	}
 
-	if service == types.SrvCentral {
+	switch service {
+	case types.SrvCentral:
 		err = joinCentral(ctx, s)
-	} else if service == types.SrvChassis {
+	case types.SrvChassis:
 		err = joinChassis(ctx, s)
-	} else {
+	default:
 		err = snap.Start(service, true)
 		if err != nil {
-			err = fmt.Errorf("Snapctl error, likely due to service not existing:\n%w", err)
+			err = fmt.Errorf("snapctl error, likely due to service not existing:\n%w", err)
 		}
 	}
 
@@ -121,7 +123,7 @@ func ListServices(ctx context.Context, s state.State) (types.Services, error) {
 	err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		records, err := database.GetServices(ctx, tx)
 		if err != nil {
-			return fmt.Errorf("Failed to fetch service: %w", err)
+			return fmt.Errorf("failed to fetch service: %w", err)
 		}
 
 		for _, service := range records {
@@ -235,17 +237,17 @@ func joinCentral(ctx context.Context, s state.State) error {
 
 	err = snap.Start("ovn-ovsdb-server-nb", true)
 	if err != nil {
-		return fmt.Errorf("Failed to start OVN NB: %w", err)
+		return fmt.Errorf("failed to start OVN NB: %w", err)
 	}
 
 	err = snap.Start("ovn-ovsdb-server-sb", true)
 	if err != nil {
-		return fmt.Errorf("Failed to start OVN SB: %w", err)
+		return fmt.Errorf("failed to start OVN SB: %w", err)
 	}
 
 	err = snap.Start("ovn-northd", true)
 	if err != nil {
-		return fmt.Errorf("Failed to start OVN northd: %w", err)
+		return fmt.Errorf("failed to start OVN northd: %w", err)
 	}
 	return nil
 }
@@ -339,7 +341,7 @@ func joinChassis(ctx context.Context, s state.State) error {
 	}
 	err = snap.Start("chassis", true)
 	if err != nil {
-		return fmt.Errorf("Failed to start OVN chassis: %w", err)
+		return fmt.Errorf("failed to start OVN chassis: %w", err)
 	}
 	return nil
 }

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -39,7 +39,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	// Generate the configuration.
 	err = generateEnvironment(ctx, s)
 	if err != nil {
-		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
+		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
 
 	// Generate client certificate for managing OVN Central services
@@ -55,31 +55,31 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 
 	err = node.EnableService(ctx, s, types.SrvSwitch)
 	if err != nil {
-		logger.Infof("failed to enable switch")
+		logger.Infof("Failed to enable switch")
 		return err
 	}
 
 	err = node.EnableService(ctx, s, types.SrvCentral)
 	if err != nil {
-		logger.Infof("failed to enable central")
+		logger.Infof("Failed to enable central")
 		return err
 	}
 
 	err = generateEnvironment(ctx, s)
 	if err != nil {
-		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
+		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
 
 	err = node.EnableService(ctx, s, types.SrvChassis)
 	if err != nil {
-		logger.Infof("failed to enable switch")
+		logger.Infof("Failed to enable switch")
 		return err
 	}
 
 	// Configure OVS to use OVN.
 	sbConnect, _, err := environmentString(ctx, s, 6642)
 	if err != nil {
-		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
+		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 	}
 
 	err = updateOvnListenConfig(ctx, s)
@@ -112,7 +112,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	)
 
 	if err != nil {
-		return fmt.Errorf("Error configuring OVS parameters: %s", err)
+		return fmt.Errorf("error configuring OVS parameters: %s", err)
 	}
 
 	return nil

--- a/microovn/ovn/certificates/certificates.go
+++ b/microovn/ovn/certificates/certificates.go
@@ -79,23 +79,24 @@ func issueCertificate(cn string, serviceName string, certType CertificateType, p
 	validFrom := time.Now().UTC()
 	serialNumber, err := rand.Int(rand.Reader, MaxSerialNumber)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to generate serial number: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
 	}
 
-	if certType == CertificateTypeCA {
+	switch certType {
+	case CertificateTypeCA:
 		isCa = true
 		keyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
 		validTo = validFrom.Add(CACertValidity)
-	} else if certType == CertificateTypeServer {
+	case CertificateTypeServer:
 		isCa = false
 		keyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageContentCommitment
 		validTo = validFrom.Add(ServiceCertValidity)
-	} else if certType == CertificateTypeClient {
+	case CertificateTypeClient:
 		isCa = false
 		keyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment | x509.KeyUsageKeyAgreement
 		validTo = validFrom.Add(ServiceCertValidity)
-	} else {
-		return nil, nil, fmt.Errorf("failed ot issue certificate: unknown certificate type")
+	default:
+		return nil, nil, fmt.Errorf("failed to issue certificate: unknown certificate type")
 	}
 
 	template := x509.Certificate{
@@ -346,7 +347,7 @@ func getServiceCertificatePaths(service string) (string, string, error) {
 	default:
 		certPath = ""
 		keyPath = ""
-		err = fmt.Errorf("unknown service '%s'. Can't generate certificate paths", service)
+		err = fmt.Errorf("unknown service '%s'. can't generate certificate paths", service)
 	}
 
 	return certPath, keyPath, err

--- a/microovn/ovn/cmd/commands.go
+++ b/microovn/ovn/cmd/commands.go
@@ -52,7 +52,8 @@ func NewOvsdbSpec(dbType OvsdbType) (*OvsdbSpec, error) {
 	var dbSpec *OvsdbSpec
 	var err error
 
-	if dbType == OvsdbTypeNBLocal {
+	switch dbType {
+	case OvsdbTypeNBLocal:
 		dbSpec = &OvsdbSpec{
 			SocketURL:    fmt.Sprintf("unix:%s", paths.OvnNBDatabaseSock()),
 			Schema:       paths.OvsdbNbSchema(),
@@ -61,7 +62,7 @@ func NewOvsdbSpec(dbType OvsdbType) (*OvsdbSpec, error) {
 			ShortName:    "nb",
 			IsCentral:    true,
 		}
-	} else if dbType == OvsdbTypeSBLocal {
+	case OvsdbTypeSBLocal:
 		dbSpec = &OvsdbSpec{
 			SocketURL:    fmt.Sprintf("unix:%s", paths.OvnSBDatabaseSock()),
 			Schema:       paths.OvsdbSbSchema(),
@@ -70,7 +71,7 @@ func NewOvsdbSpec(dbType OvsdbType) (*OvsdbSpec, error) {
 			ShortName:    "sb",
 			IsCentral:    true,
 		}
-	} else if dbType == OvsdbTypeSwitchLocal {
+	case OvsdbTypeSwitchLocal:
 		dbSpec = &OvsdbSpec{
 			SocketURL:    fmt.Sprintf("unix:%s", paths.OvsDatabaseSock()),
 			Schema:       paths.OvsdbSwitchSchema(),
@@ -79,7 +80,7 @@ func NewOvsdbSpec(dbType OvsdbType) (*OvsdbSpec, error) {
 			ShortName:    "switch",
 			IsCentral:    false,
 		}
-	} else {
+	default:
 		err = errors.New("unknown ovsdb type")
 	}
 
@@ -118,11 +119,12 @@ func WaitForDBState(ctx context.Context, _ state.State, db *OvsdbSpec, dbState s
 func ovnDBCtl(ctx context.Context, s state.State, dbType OvsdbType, timeout int, args ...string) (string, error) {
 	var baseCmd string
 
-	if dbType == OvsdbTypeNBLocal {
+	switch dbType {
+	case OvsdbTypeNBLocal:
 		baseCmd = "ovn-nbctl"
-	} else if dbType == OvsdbTypeSBLocal {
+	case OvsdbTypeSBLocal:
 		baseCmd = "ovn-sbctl"
-	} else {
+	default:
 		return "", errors.New("unknown DB type. OVN commands work only with NB or SB database")
 	}
 
@@ -136,7 +138,7 @@ func ovnDBCtl(ctx context.Context, s state.State, dbType OvsdbType, timeout int,
 		return "", err
 	}
 
-	if !(slices.Contains(args, "--timeout") || slices.Contains(args, "-t")) {
+	if !slices.Contains(args, "--timeout") && !slices.Contains(args, "-t") {
 		args = append([]string{"--timeout", "30"}, args...)
 	}
 
@@ -195,7 +197,7 @@ func VSCtl(ctx context.Context, s state.State, args ...string) (string, error) {
 		return "", err
 	}
 
-	if !(slices.Contains(args, "--timeout") || slices.Contains(args, "-t")) {
+	if !slices.Contains(args, "--timeout") && !slices.Contains(args, "-t") {
 		args = append([]string{"--timeout", "30"}, args...)
 	}
 

--- a/microovn/ovn/environment.go
+++ b/microovn/ovn/environment.go
@@ -113,7 +113,7 @@ func generateEnvironment(ctx context.Context, s state.State) error {
 	// Generate ovn.env.
 	fd, err := os.OpenFile(paths.OvnEnvFile(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
 	if err != nil {
-		return fmt.Errorf("Couldn't open ovn.env: %w", err)
+		return fmt.Errorf("couldn't open ovn.env: %w", err)
 	}
 	defer fd.Close()
 
@@ -146,7 +146,7 @@ func generateEnvironment(ctx context.Context, s state.State) error {
 		"sbConnect": sbConnect,
 	})
 	if err != nil {
-		return fmt.Errorf("Couldn't render ovn.env: %w", err)
+		return fmt.Errorf("couldn't render ovn.env: %w", err)
 	}
 
 	return nil
@@ -157,7 +157,7 @@ func createPaths() error {
 	for _, path := range paths.RequiredDirs() {
 		err := os.MkdirAll(path, 0700)
 		if err != nil {
-			return fmt.Errorf("Unable to create %q: %w", path, err)
+			return fmt.Errorf("unable to create %q: %w", path, err)
 		}
 	}
 
@@ -177,7 +177,7 @@ func cleanupPaths() error {
 		errs = append(
 			errs,
 			fmt.Errorf(
-				"failed to create backup directory '%s'. Refusing to continue with data removal: %s",
+				"failed to create backup directory '%s', refusing to continue with data removal: %s",
 				backupPath,
 				err,
 			),
@@ -199,7 +199,7 @@ func cleanupPaths() error {
 	if len(errs) > 0 {
 		errs = append(
 			errs,
-			fmt.Errorf("failures occured during backup. Refusing to continue with data removal"),
+			fmt.Errorf("failures occured during backup, refusing to continue with data removal"),
 		)
 		return errors.Join(errs...)
 	}

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -48,7 +48,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	// Generate the configuration.
 	err = generateEnvironment(ctx, s)
 	if err != nil {
-		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
+		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
 
 	// Generate client certificate for managing OVN Central services
@@ -69,33 +69,33 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	// Start all the required services, and central if needed
 	err = node.EnableService(ctx, s, types.SrvSwitch)
 	if err != nil {
-		logger.Infof("failed to enable switch")
+		logger.Infof("Failed to enable switch")
 		return err
 	}
 
 	if srvCentral < 3 {
 		err = node.EnableService(ctx, s, types.SrvCentral)
 		if err != nil {
-			logger.Infof("failed to enable central")
+			logger.Infof("Failed to enable central")
 			return err
 		}
 	}
 
 	err = generateEnvironment(ctx, s)
 	if err != nil {
-		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
+		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
 
 	err = node.EnableService(ctx, s, types.SrvChassis)
 	if err != nil {
-		logger.Infof("failed to enable switch")
+		logger.Infof("Failed to enable switch")
 		return err
 	}
 
 	// Enable OVN chassis.
 	sbConnect, _, err := environmentString(ctx, s, 6642)
 	if err != nil {
-		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
+		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 	}
 
 	// A custom encapsulation IP address can also be directly passed as an initConfig parameter.
@@ -124,7 +124,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	)
 
 	if err != nil {
-		return fmt.Errorf("Error configuring OVS parameters: %s", err)
+		return fmt.Errorf("error configuring OVS parameters: %s", err)
 	}
 
 	return nil

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -53,14 +53,14 @@ func refresh(ctx context.Context, s state.State) error {
 	// Generate the configuration.
 	err = generateEnvironment(ctx, s)
 	if err != nil {
-		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
+		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
 
 	// Restart OVN Northd service to account for NB/SB cluster changes.
 	if hasCentral {
 		err = snap.Restart("ovn-northd")
 		if err != nil {
-			return fmt.Errorf("Failed to restart OVN northd: %w", err)
+			return fmt.Errorf("failed to restart OVN northd: %w", err)
 		}
 	}
 
@@ -69,7 +69,7 @@ func refresh(ctx context.Context, s state.State) error {
 		// Reconfigure OVS to use OVN.
 		sbConnect, _, err := environmentString(ctx, s, 6642)
 		if err != nil {
-			return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
+			return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 		}
 
 		_, err = ovnCmd.VSCtl(
@@ -80,7 +80,7 @@ func refresh(ctx context.Context, s state.State) error {
 		)
 
 		if err != nil {
-			return fmt.Errorf("Failed to update OVS's 'ovn-remote' configuration")
+			return fmt.Errorf("failed to update OVS's 'ovn-remote' configuration")
 		}
 	}
 
@@ -90,11 +90,11 @@ func refresh(ctx context.Context, s state.State) error {
 func updateOvnListenConfig(ctx context.Context, s state.State) error {
 	nbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeNBLocal)
 	if err != nil {
-		return fmt.Errorf("Failed to get path to OVN NB database socket: %w", err)
+		return fmt.Errorf("failed to get path to OVN NB database socket: %w", err)
 	}
 	sbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeSBLocal)
 	if err != nil {
-		return fmt.Errorf("Failed to get path to OVN SB database socket: %w", err)
+		return fmt.Errorf("failed to get path to OVN SB database socket: %w", err)
 	}
 
 	protocol := networkProtocol(ctx, s)
@@ -107,7 +107,7 @@ func updateOvnListenConfig(ctx context.Context, s state.State) error {
 		fmt.Sprintf("p%s:6641:[::]", protocol),
 	)
 	if err != nil {
-		return errors.Errorf("Error setting ovn NB connection string: %s", err)
+		return errors.Errorf("error setting ovn NB connection string: %s", err)
 	}
 
 	_, err = ovnCmd.SBCtl(
@@ -119,7 +119,7 @@ func updateOvnListenConfig(ctx context.Context, s state.State) error {
 		fmt.Sprintf("p%s:6642:[::]", protocol),
 	)
 	if err != nil {
-		return errors.Errorf("Error setting ovn SB connection string: %s", err)
+		return errors.Errorf("error setting ovn SB connection string: %s", err)
 	}
 
 	return nil

--- a/microovn/ovn/start.go
+++ b/microovn/ovn/start.go
@@ -31,7 +31,7 @@ func Start(ctx context.Context, s state.State) error {
 	// Re-generate the configuration.
 	err = generateEnvironment(ctx, s)
 	if err != nil {
-		return fmt.Errorf("Failed to generate the daemon configuration: %w", err)
+		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
 
 	centralActive, err := node.HasServiceActive(ctx, s, "central")
@@ -48,7 +48,7 @@ func Start(ctx context.Context, s state.State) error {
 	// Reconfigure OVS to use OVN.
 	sbConnect, _, err := environmentString(ctx, s, 6642)
 	if err != nil {
-		return fmt.Errorf("Failed to get OVN SB connect string: %w", err)
+		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 	}
 
 	_, err = ovnCmd.VSCtl(
@@ -59,7 +59,7 @@ func Start(ctx context.Context, s state.State) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf("Failed to update OVS's 'ovn-remote' configuration")
+		return fmt.Errorf("failed to update OVS's 'ovn-remote' configuration")
 	}
 
 	// If "central" services are active on this node, start two goroutines that will check if OVN database schemas
@@ -72,14 +72,14 @@ func Start(ctx context.Context, s state.State) error {
 		go func() {
 			err := ovsdb.UpgradeCentralDB(ctx, s, ovnCmd.OvsdbTypeSBLocal)
 			if err != nil {
-				logger.Errorf("failed to perform OVN SB schema upgrade. '%s'", err)
+				logger.Errorf("Failed to perform OVN SB schema upgrade. '%s'", err)
 			}
 		}()
 
 		go func() {
 			err := ovsdb.UpgradeCentralDB(ctx, s, ovnCmd.OvsdbTypeNBLocal)
 			if err != nil {
-				logger.Errorf("failed to perform OVN NB schema upgrade. '%s'", err)
+				logger.Errorf("Failed to perform OVN NB schema upgrade. '%s'", err)
 			}
 		}()
 	}

--- a/tests/test_helper/bats/services.bats
+++ b/tests/test_helper/bats/services.bats
@@ -26,7 +26,7 @@ service_tests() {
     for container in $TEST_CONTAINERS; do
         # enable enabled service
         run lxc_exec "$container" "microovn enable switch"
-        assert_output "Error: Failed to enable service 'switch': 'This Service is already enabled'"
+        assert_output "Error: failed to enable service 'switch': 'this service is already enabled'"
 
         # enable non existing service
         run lxc_exec "$container" "microovn enable switchh"
@@ -38,7 +38,7 @@ service_tests() {
 
         # disable disabled service
         run lxc_exec "$container" "microovn disable switch"
-        assert_output "Error: Failed to disable service 'switch': 'This service is not enabled'"
+        assert_output "Error: failed to disable service 'switch': 'this service is not enabled'"
 
         run lxc_exec "$container" "microovn status | grep -ozE '${container}[^-]*' | grep switch"
         assert_output ""
@@ -64,7 +64,7 @@ service_warning_tests() {
     assert_output -p "[central] Warning: Cluster with less than 3 nodes can't tolerate any node failures."
 
     run lxc_exec "microovn-services-3" "microovn disable central"
-    assert_output "Error: Failed to disable service 'central': 'You cannot delete the final enabled central service'"
+    assert_output "Error: failed to disable service 'central': 'you cannot delete the final enabled central service'"
 
     # ensure central is actually still enabled
     assert [ -n "$(run lxc_exec "microovn-services-3" "microovn status | grep -ozE 'microovn-services-3[^-]*' | grep central")"]

--- a/tests/test_helper/bats/tls_cluster.bats
+++ b/tests/test_helper/bats/tls_cluster.bats
@@ -201,7 +201,7 @@ tls_cluster_chassis_reissue_certificates() {
 
         run reissue_certificate "$container" "$service"
         assert_failure
-        assert_output -p "Can't issue certificate for service '$service'. Service is not enabled on this member."
+        assert_output -p "can't issue certificate for service '$service', service is not enabled on this member,"
 
         run lxc_exec "$container" "ls $cert_path"
         assert_failure


### PR DESCRIPTION
These changes backport #227 and part of #245 to unblock `golangci-lint` when building the snap.