### PR TITLE
24.03 fix northd listen

### DIFF
--- a/microovn/go.mod
+++ b/microovn/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/canonical/microcluster/v2 v2.0.5
 	github.com/gorilla/mux v1.8.1
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 )
 
@@ -35,6 +34,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/muhlemmer/gu v0.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.7 // indirect
 	github.com/pkg/xattr v0.4.10 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/microovn/node/node.go
+++ b/microovn/node/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/microovn/microovn/database"
 	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/ovn/environment"
 	"github.com/canonical/microovn/microovn/ovn/paths"
 	"github.com/canonical/microovn/microovn/snap"
 )
@@ -98,6 +99,11 @@ func EnableService(ctx context.Context, s state.State, service types.SrvName) er
 	})
 	if err != nil {
 		return err
+	}
+
+	err = environment.GenerateEnvironment(ctx, s)
+	if err != nil {
+		return fmt.Errorf("failed to regenerate environment file after enabling central service: %w", err)
 	}
 
 	switch service {

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/microovn/microovn/node"
 	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/ovn/environment"
 )
 
 // Bootstrap will initialize a new OVN deployment.
@@ -20,7 +21,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	defer muHook.Unlock()
 
 	// Create our storage.
-	err := createPaths()
+	err := environment.CreatePaths()
 	if err != nil {
 		return err
 	}
@@ -37,7 +38,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Generate the configuration.
-	err = generateEnvironment(ctx, s)
+	err = environment.GenerateEnvironment(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
@@ -65,7 +66,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 		return err
 	}
 
-	err = generateEnvironment(ctx, s)
+	err = environment.GenerateEnvironment(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
@@ -77,7 +78,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 	}
 
 	// Configure OVS to use OVN.
-	sbConnect, _, err := environmentString(ctx, s, 6642)
+	sbConnect, _, err := environment.ConnectionString(ctx, s, 6642)
 	if err != nil {
 		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 	}

--- a/microovn/ovn/bootstrap.go
+++ b/microovn/ovn/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
 	"github.com/canonical/microovn/microovn/ovn/certificates"
+	ovnCluster "github.com/canonical/microovn/microovn/ovn/cluster"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/ovn/environment"
 )
@@ -83,7 +84,7 @@ func Bootstrap(ctx context.Context, s state.State, initConfig map[string]string)
 		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 	}
 
-	err = updateOvnListenConfig(ctx, s)
+	err = ovnCluster.UpdateOvnListenConfig(ctx, s)
 	if err != nil {
 		return err
 	}

--- a/microovn/ovn/cluster/cluster.go
+++ b/microovn/ovn/cluster/cluster.go
@@ -1,0 +1,52 @@
+// Package cluster builds on top of microovn.ovn.cmd package and provides
+// functions for commonly used actions performed on the OVN cluster and related
+// services. It removes the necessity to manually build up ovn CLI commands.
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microcluster/v2/state"
+	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/ovn/environment"
+)
+
+// UpdateOvnListenConfig configures the OVN NB and SB databases to listen on the appropriate ports.
+func UpdateOvnListenConfig(ctx context.Context, s state.State) error {
+	nbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeNBLocal)
+	if err != nil {
+		return fmt.Errorf("failed to get path to OVN NB database socket: %w", err)
+	}
+	sbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeSBLocal)
+	if err != nil {
+		return fmt.Errorf("failed to get path to OVN SB database socket: %w", err)
+	}
+
+	protocol := environment.NetworkProtocol(ctx, s)
+	_, err = ovnCmd.NBCtl(
+		ctx,
+		s,
+		"--no-leader-only",
+		fmt.Sprintf("--db=%s", nbDB.SocketURL),
+		"set-connection",
+		fmt.Sprintf("p%s:6641:[::]", protocol),
+	)
+	if err != nil {
+		return fmt.Errorf("error setting ovn NB connection string: %s", err)
+	}
+
+	_, err = ovnCmd.SBCtl(
+		ctx,
+		s,
+		"--no-leader-only",
+		fmt.Sprintf("--db=%s", sbDB.SocketURL),
+		"set-connection",
+		fmt.Sprintf("p%s:6642:[::]", protocol),
+	)
+	if err != nil {
+		return fmt.Errorf("error setting ovn SB connection string: %s", err)
+	}
+
+	return nil
+}

--- a/microovn/ovn/environment/environment_test.go
+++ b/microovn/ovn/environment/environment_test.go
@@ -1,0 +1,82 @@
+package environment
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/microcluster/v2/state"
+)
+
+const localNodeIPv4 = "10.0.0.1"
+const remoteNodeIPv4 = "10.0.0.2"
+const localNodeIPv6 = "fe80::1"
+const remoteNodeIPv6 = "fe80::2"
+
+type MockState struct {
+	localNodeIP string
+	state.State
+}
+
+func (ms MockState) Address() *api.URL {
+	netURL := url.URL{
+		Scheme: "https",
+		Host:   ms.localNodeIP + ":6443",
+		Path:   "/1.0",
+	}
+	return &api.URL{
+		URL: netURL,
+	}
+}
+
+func TestUnexported_initialNbSbHost(t *testing.T) {
+	testCases := []struct {
+		hostIP     string
+		isIPv6     bool
+		centralIps []string
+		expected   string
+	}{
+		// IPv4 multi-node cluster: Expect initial to differ from local node
+		{
+			hostIP:     localNodeIPv4,
+			isIPv6:     false,
+			centralIps: []string{localNodeIPv4, remoteNodeIPv4},
+			expected:   remoteNodeIPv4,
+		},
+		// IPv4 single-node: Expect initial to match the local node
+		{
+			hostIP:     localNodeIPv4,
+			isIPv6:     false,
+			centralIps: []string{localNodeIPv4},
+			expected:   localNodeIPv4,
+		},
+		// IPv6 multi-node cluster: Expect initial to differ from local node
+		{
+			hostIP:     localNodeIPv6,
+			isIPv6:     true,
+			centralIps: []string{localNodeIPv6, remoteNodeIPv6},
+			expected:   remoteNodeIPv6,
+		},
+		// IPv4 single-node: Expect initial to match the local node
+		{
+			hostIP:     localNodeIPv6,
+			isIPv6:     true,
+			centralIps: []string{localNodeIPv6},
+			expected:   localNodeIPv6,
+		},
+	}
+
+	for _, tc := range testCases {
+		initialHost, err := initialNbSbHost(MockState{localNodeIP: tc.hostIP}, tc.centralIps)
+		if err != nil {
+			t.Errorf("Failed to get initial host: %s", err)
+		}
+		expectedIP := tc.expected
+		if tc.isIPv6 {
+			expectedIP = "[" + tc.expected + "]"
+		}
+		if initialHost != expectedIP {
+			t.Errorf("Expected initial host to be %s, got %s", expectedIP, initialHost)
+		}
+	}
+}

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/v2/state"
+	ovnCluster "github.com/canonical/microovn/microovn/ovn/cluster"
 
 	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/database"
@@ -94,11 +95,6 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	}
 
 	// Enable OVN chassis.
-	sbConnect, _, err := environment.ConnectionString(ctx, s, 6642)
-	if err != nil {
-		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
-	}
-
 	// A custom encapsulation IP address can also be directly passed as an initConfig parameter.
 	// This block is typically executed by a `microovn cluster init` or by an external project
 	// triggering this join hook.
@@ -119,13 +115,17 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 		s,
 		"set", "open_vswitch", ".",
 		fmt.Sprintf("external_ids:system-id=%s", s.Name()),
-		fmt.Sprintf("external_ids:ovn-remote=%s", sbConnect),
 		"external_ids:ovn-encap-type=geneve",
 		fmt.Sprintf("external_ids:ovn-encap-ip=%s", ovnEncapIP),
 	)
 
 	if err != nil {
 		return fmt.Errorf("error configuring OVS parameters: %s", err)
+	}
+
+	err = ovnCluster.UpdateOvnControllerRemoteConfig(ctx, s)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/microovn/ovn/join.go
+++ b/microovn/ovn/join.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/microovn/microovn/node"
 	"github.com/canonical/microovn/microovn/ovn/certificates"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/ovn/environment"
 )
 
 // Join will join an existing OVN deployment.
@@ -22,7 +23,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	defer muHook.Unlock()
 
 	// Create our storage.
-	err := createPaths()
+	err := environment.CreatePaths()
 	if err != nil {
 		return err
 	}
@@ -46,7 +47,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	}
 
 	// Generate the configuration.
-	err = generateEnvironment(ctx, s)
+	err = environment.GenerateEnvironment(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
@@ -81,7 +82,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 		}
 	}
 
-	err = generateEnvironment(ctx, s)
+	err = environment.GenerateEnvironment(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
@@ -93,7 +94,7 @@ func Join(ctx context.Context, s state.State, initConfig map[string]string) erro
 	}
 
 	// Enable OVN chassis.
-	sbConnect, _, err := environmentString(ctx, s, 6642)
+	sbConnect, _, err := environment.ConnectionString(ctx, s, 6642)
 	if err != nil {
 		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 	}

--- a/microovn/ovn/leave.go
+++ b/microovn/ovn/leave.go
@@ -7,6 +7,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/node"
+	"github.com/canonical/microovn/microovn/ovn/environment"
 )
 
 // Leave function gracefully departs from the OVN cluster before the member is removed from MicroOVN
@@ -26,7 +27,7 @@ func Leave(ctx context.Context, s state.State, _ bool) error {
 	}
 
 	logger.Info("Cleaning up runtime and data directories.")
-	err = cleanupPaths()
+	err = environment.CleanupPaths()
 	if err != nil {
 		logger.Warn(err.Error())
 	}

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
-	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	ovnCluster "github.com/canonical/microovn/microovn/ovn/cluster"
 	"github.com/canonical/microovn/microovn/ovn/environment"
 	"github.com/canonical/microovn/microovn/snap"
 )
@@ -66,20 +66,9 @@ func refresh(ctx context.Context, s state.State) error {
 	// Enable OVN chassis.
 	if hasSwitch {
 		// Reconfigure OVS to use OVN.
-		sbConnect, _, err := environment.ConnectionString(ctx, s, 6642)
+		err = ovnCluster.UpdateOvnControllerRemoteConfig(ctx, s)
 		if err != nil {
-			return fmt.Errorf("failed to get OVN SB connect string: %w", err)
-		}
-
-		_, err = ovnCmd.VSCtl(
-			ctx,
-			s,
-			"set", "open_vswitch", ".",
-			fmt.Sprintf("external_ids:ovn-remote=%s", sbConnect),
-		)
-
-		if err != nil {
-			return fmt.Errorf("failed to update OVS's 'ovn-remote' configuration")
+			return err
 		}
 	}
 

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/v2/state"
 
@@ -83,44 +81,6 @@ func refresh(ctx context.Context, s state.State) error {
 		if err != nil {
 			return fmt.Errorf("failed to update OVS's 'ovn-remote' configuration")
 		}
-	}
-
-	return nil
-}
-
-func updateOvnListenConfig(ctx context.Context, s state.State) error {
-	nbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeNBLocal)
-	if err != nil {
-		return fmt.Errorf("failed to get path to OVN NB database socket: %w", err)
-	}
-	sbDB, err := ovnCmd.NewOvsdbSpec(ovnCmd.OvsdbTypeSBLocal)
-	if err != nil {
-		return fmt.Errorf("failed to get path to OVN SB database socket: %w", err)
-	}
-
-	protocol := environment.NetworkProtocol(ctx, s)
-	_, err = ovnCmd.NBCtl(
-		ctx,
-		s,
-		"--no-leader-only",
-		fmt.Sprintf("--db=%s", nbDB.SocketURL),
-		"set-connection",
-		fmt.Sprintf("p%s:6641:[::]", protocol),
-	)
-	if err != nil {
-		return errors.Errorf("error setting ovn NB connection string: %s", err)
-	}
-
-	_, err = ovnCmd.SBCtl(
-		ctx,
-		s,
-		"--no-leader-only",
-		fmt.Sprintf("--db=%s", sbDB.SocketURL),
-		"set-connection",
-		fmt.Sprintf("p%s:6642:[::]", protocol),
-	)
-	if err != nil {
-		return errors.Errorf("error setting ovn SB connection string: %s", err)
 	}
 
 	return nil

--- a/microovn/ovn/refresh.go
+++ b/microovn/ovn/refresh.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/microovn/microovn/api/types"
 	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/ovn/environment"
 	"github.com/canonical/microovn/microovn/snap"
 )
 
@@ -34,7 +35,7 @@ func refresh(ctx context.Context, s state.State) error {
 	defer muHook.Unlock()
 
 	// Create our storage.
-	err := createPaths()
+	err := environment.CreatePaths()
 	if err != nil {
 		return err
 	}
@@ -51,7 +52,7 @@ func refresh(ctx context.Context, s state.State) error {
 	}
 
 	// Generate the configuration.
-	err = generateEnvironment(ctx, s)
+	err = environment.GenerateEnvironment(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
@@ -67,7 +68,7 @@ func refresh(ctx context.Context, s state.State) error {
 	// Enable OVN chassis.
 	if hasSwitch {
 		// Reconfigure OVS to use OVN.
-		sbConnect, _, err := environmentString(ctx, s, 6642)
+		sbConnect, _, err := environment.ConnectionString(ctx, s, 6642)
 		if err != nil {
 			return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 		}
@@ -97,7 +98,7 @@ func updateOvnListenConfig(ctx context.Context, s state.State) error {
 		return fmt.Errorf("failed to get path to OVN SB database socket: %w", err)
 	}
 
-	protocol := networkProtocol(ctx, s)
+	protocol := environment.NetworkProtocol(ctx, s)
 	_, err = ovnCmd.NBCtl(
 		ctx,
 		s,

--- a/microovn/ovn/start.go
+++ b/microovn/ovn/start.go
@@ -48,20 +48,9 @@ func Start(ctx context.Context, s state.State) error {
 		}
 	}
 	// Reconfigure OVS to use OVN.
-	sbConnect, _, err := environment.ConnectionString(ctx, s, 6642)
+	err = ovnCluster.UpdateOvnControllerRemoteConfig(ctx, s)
 	if err != nil {
-		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
-	}
-
-	_, err = ovnCmd.VSCtl(
-		ctx,
-		s,
-		"set", "open_vswitch", ".",
-		fmt.Sprintf("external_ids:ovn-remote=%s", sbConnect),
-	)
-
-	if err != nil {
-		return fmt.Errorf("failed to update OVS's 'ovn-remote' configuration")
+		return err
 	}
 
 	// If "central" services are active on this node, start two goroutines that will check if OVN database schemas

--- a/microovn/ovn/start.go
+++ b/microovn/ovn/start.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canonical/microovn/microovn/node"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
+	"github.com/canonical/microovn/microovn/ovn/environment"
 	"github.com/canonical/microovn/microovn/ovn/ovsdb"
 )
 
@@ -23,13 +24,13 @@ func Start(ctx context.Context, s state.State) error {
 	}
 
 	// Make sure the storage exists.
-	err = createPaths()
+	err = environment.CreatePaths()
 	if err != nil {
 		return err
 	}
 
 	// Re-generate the configuration.
-	err = generateEnvironment(ctx, s)
+	err = environment.GenerateEnvironment(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to generate the daemon configuration: %w", err)
 	}
@@ -46,7 +47,7 @@ func Start(ctx context.Context, s state.State) error {
 		}
 	}
 	// Reconfigure OVS to use OVN.
-	sbConnect, _, err := environmentString(ctx, s, 6642)
+	sbConnect, _, err := environment.ConnectionString(ctx, s, 6642)
 	if err != nil {
 		return fmt.Errorf("failed to get OVN SB connect string: %w", err)
 	}

--- a/microovn/ovn/start.go
+++ b/microovn/ovn/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microovn/microovn/node"
+	ovnCluster "github.com/canonical/microovn/microovn/ovn/cluster"
 	ovnCmd "github.com/canonical/microovn/microovn/ovn/cmd"
 	"github.com/canonical/microovn/microovn/ovn/environment"
 	"github.com/canonical/microovn/microovn/ovn/ovsdb"
@@ -41,7 +42,7 @@ func Start(ctx context.Context, s state.State) error {
 	}
 
 	if centralActive {
-		err = updateOvnListenConfig(ctx, s)
+		err = ovnCluster.UpdateOvnListenConfig(ctx, s)
 		if err != nil {
 			logger.Warnf("Failed to update OVN listening configs. There might be connectivity issues.")
 		}

--- a/snapcraft/commands/chassis.start
+++ b/snapcraft/commands/chassis.start
@@ -23,14 +23,6 @@ OVN_ARGS="--db-nb-addr="${OVN_LOCAL_IP}" \
 --ovn-controller-ssl-ca-cert="${CA_CERT}""
 
 
-if [ "${OVN_INITIAL_NB}" != "${OVN_LOCAL_IP}" ]; then
-    OVN_ARGS="${OVN_ARGS} --db-nb-cluster-remote-addr="${OVN_INITIAL_NB}""
-fi
-
-if [ "${OVN_INITIAL_SB}" != "${OVN_LOCAL_IP}" ]; then
-    OVN_ARGS="${OVN_ARGS} --db-sb-cluster-remote-addr="${OVN_INITIAL_SB}""
-fi
-
 # Start the OVN controller
 "${SNAP}/share/ovn/scripts/ovn-ctl" start_controller ${OVN_ARGS} \
     --ovn-manage-ovsdb=no \


### PR DESCRIPTION
Backport of #249

This backport contains also two refactoring patches from #247 
* https://github.com/canonical/microovn/pull/247/commits/f28a8e563ff02b435f16030b44b964eb18b44d59
* https://github.com/canonical/microovn/pull/247/commits/335479dee43af8694ab69d8991a9b4a854dacb9d

that help with cleaner cherry-picking.

There were few manual changes required compare to #249, mostly in the `environment.go`  due to `branch-24.03` not having a `ovn.central-ips` config option.

Hook handlers (join/start/bootstrap/refresh) were also updated to use `UpdateOvnControllerRemoteConfig` instead of manually setting `ovn-remote` option in the OVSDB. This brings them more in-line with the `main` implementation.