### PR TITLE
daemon: Change default listening port

### DIFF
--- a/microovn/cmd/microovn/main.go
+++ b/microovn/cmd/microovn/main.go
@@ -15,7 +15,7 @@ import (
 
 // DefaultMicroClusterPort is the default port used for the MicroOVN
 // MicroCluster Daemon.
-const DefaultMicroClusterPort = 6443
+const DefaultMicroClusterPort = 6686
 
 // CmdControl has functions that are common to the microctl commands.
 // command line tools.


### PR DESCRIPTION
The old default port of MicroOVN daemon (6443) conflicts with the default port of Kubernetes API [0]. Therefore, we are picking a new default of 6686. Brief search did not turn up any application commonly using this port, and it is currently marked as 'Unassigned' in the IANA list [1].

Note this change affects only new installations. Any MicroOVN instances deployed from prior versions will retain the old port binding.

[0] https://kubernetes.io/docs/concepts/security/controlling-access/#transport-security
[1] https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt