### PR TITLE
lint: Skip package name check.

### DIFF
--- a/microovn/.golangci.yml
+++ b/microovn/.golangci.yml
@@ -10,6 +10,14 @@ linters:
     - ineffassign
     - revive
     - staticcheck
+  settings:
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - [] # AllowList
+            - [] # DenyList
+            - - skip-package-name-checks: true # Extra parameter (upper-case-const|skip-package-name-checks)
   exclusions:
     generated: lax
     rules:


### PR DESCRIPTION
'revive' started to warn against "meaningless package names"[0] and it gets triggered by our "types" package.
I don't presume to know more about good practices than Go developers, but I struggle to come up with a good alternative to our "types" package. I believe that in the context of the project structure, package 'microovn.api.types' makes sense.

[0] https://go.dev/blog/package-names#bad-package-names