### PR TITLE
CI: Run TIOBE job only in Canonical repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,12 +248,11 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/microovn/
     needs:
       - generate-coverage
-    # TICS execution requires access to an auth. token which is not available in the forks of this
-    # repository. We allow this job to run only if it has access to the token:
-    #  * On "push" action
-    #  * On scheduled action
-    #  * On pull request created from the main repository (not fork)
-    if: ${{ (github.event_name != 'pull_request') || (github.repository == github.event.pull_request.head.repo.full_name) }}
+    # TICS job runs on Canonical's self-hosted runner. Attempts
+    # to execute this job on a repository outside of Canonical org
+    # (typically a fork) cause timeout after long wait period because
+    # the repository doesn't have access to the runners.
+    if: ${{ github.repository == 'canonical/microovn' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
With TIOBE job running on self-hosted runners,
the job never finishes on forks that are outside
the Canonical org. The whole pipeline is held-up
for 24h until the job times out while waiting for
the runner.