### PR TITLE
tests: Run tests from pre-built LXD image.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MICROOVN_SNAP: microovn.snap
+      MICROOVN_IMAGE: microovn-lxd-template.tar.gz
       MICROOVN_UNSQUASH_DST: ${{ github.workspace }}/microovn-squashfs
       # The `base_ref` will only be set for PR and contain the name of the
       # target branch.  The `ref_name` will be correct for the final push
@@ -92,18 +93,26 @@ jobs:
               --channel "${SNAPCRAFT_CHANNEL:-latest/stable}" \
               --classic
 
-      - name: Build snap
+      - name: Build snap and LXD image
         run: |
           # Build snap with coverage support
           sed -i 's/MICROOVN_COVERAGE=.*/MICROOVN_COVERAGE="yes"/g' microovn/build-aux/environment
-          make $MICROOVN_SNAP
+          make $MICROOVN_IMAGE
 
-      - name: Upload artifacts
+      - name: Upload Snap
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: snaps
           path: ${{ env.MICROOVN_SNAP }}
+          retention-days: 5
+
+      - name: Upload LXD image
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lxd-image
+          path: ${{ env.MICROOVN_IMAGE }}
           retention-days: 5
 
       - name: Extract unit test coverage
@@ -164,6 +173,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: snaps
+
+      - name: Download built image
+        uses: actions/download-artifact@v4
+        with:
+          name: lxd-image
 
       - name: Clear FORWARD firewall rules
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.snap
+# LXD image for testing
+microovn-lxd-template.tar.gz
 
 # collected coverage data
 .coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
+SHELL=/bin/bash
+# Paths to MicroOVN snap
 MICROOVN_SNAP=microovn.snap
 export MICROOVN_SNAP_PATH := $(CURDIR)/$(MICROOVN_SNAP)
+
+# Name of the LXD image with pre-installed MicroOVN that
+# will be used for testing
+export MICROOVN_CONTAINER_TEMPLATE := microovn-lxd-template
+
+# If set to "yes", tests will not use template image with pre-installed
+# microovn snap. Instead, they will use pristine image and install microovn
+# snap manually on each container.
+ifndef MICROOVN_TESTS_USE_SNAP
+export MICROOVN_TESTS_USE_SNAP := "no"
+endif
 
 .DEFAULT_GOAL := $(MICROOVN_SNAP)
 
@@ -23,7 +36,7 @@ check-lint: check-tabs
 		-not -name \*.conf\
 		| xargs shellcheck --severity=warning && echo Success!
 
-$(ALL_TESTS): $(MICROOVN_SNAP)
+$(ALL_TESTS): sync-image
 	echo "Running functional test $@";					\
 	$(CURDIR)/.bats/bats-core/bin/bats $@
 
@@ -37,4 +50,39 @@ clean:
 	rm -f $(MICROOVN_SNAP_PATH);						\
 	snapcraft clean
 
-.PHONY: $(ALL_TESTS) clean check-system check-lint check-tabs
+# Create LXD image with MicroOVN snap pre-installed.
+$(MICROOVN_CONTAINER_TEMPLATE).tar.gz: $(MICROOVN_SNAP)
+	@if [ "$$MICROOVN_TESTS_USE_SNAP" = "yes" ]; then \
+		echo "Skipping image build. MICROOVN_TESTS_USE_SNAP is set to 'yes'"; \
+	else \
+		set -e; \
+		source tests/test_helper/lxd.bash; \
+		source tests/test_helper/microovn.bash; \
+		source tests/test_helper/common.bash; \
+		exec 3>&1; \
+		base_image="$${MICROOVN_TEST_CONTAINER_IMAGE:-ubuntu:lts}"; \
+		echo "Building template image based on $$base_image"; \
+		lxc launch -q "$$base_image" $(MICROOVN_CONTAINER_TEMPLATE); \
+		wait_containers_ready $(MICROOVN_CONTAINER_TEMPLATE); \
+		MICROOVN_TESTS_USE_SNAP=yes install_microovn $(MICROOVN_SNAP_PATH) $(MICROOVN_CONTAINER_TEMPLATE); \
+		lxc publish $(MICROOVN_CONTAINER_TEMPLATE) --alias $(MICROOVN_CONTAINER_TEMPLATE) -f --reuse; \
+		lxc delete --force $(MICROOVN_CONTAINER_TEMPLATE); \
+		lxc image export $(MICROOVN_CONTAINER_TEMPLATE) $(MICROOVN_CONTAINER_TEMPLATE); \
+	fi
+
+# Ensure that LXD image used for testing is up to date
+sync-image: $(MICROOVN_CONTAINER_TEMPLATE).tar.gz
+	@if [ "$$MICROOVN_TESTS_USE_SNAP" = "yes" ]; then \
+		echo "Skipping image sync. MICROOVN_TESTS_USE_SNAP is set to 'yes'"; \
+	else \
+		file_sha=$$(sha256sum $(MICROOVN_CONTAINER_TEMPLATE).tar.gz | awk '{print $$1}' || echo "no file"); \
+		image_sha=$$(lxc image info $(MICROOVN_CONTAINER_TEMPLATE) | grep Fingerprint: | awk '{print $$2}' || echo "no image"); \
+		if [ "$$file_sha" = "$$image_sha" ]; then \
+			echo "MicroOVN image already up to date."; \
+		else \
+			echo "Uploading MicroOVN template image"; \
+			lxc image import $(MICROOVN_CONTAINER_TEMPLATE).tar.gz --alias $(MICROOVN_CONTAINER_TEMPLATE); \
+		fi \
+	fi
+
+.PHONY: $(ALL_TESTS) clean check-system check-lint check-tabs sync-image

--- a/docs/contributors/code.rst
+++ b/docs/contributors/code.rst
@@ -265,16 +265,45 @@ To run individual test suites you can execute:
 
    make tests/<name_of_the_test_suite>.bats
 
-By default, functional tests run in LXD containers based on ``ubuntu:lts``
-image. This can be changed by exporting environment variable
-``MICROOVN_TEST_CONTAINER_IMAGE`` and setting it to a valid LXD image name.
+.. tip::
 
-For example:
+   If your hardware can handle it, you can run test suites in parallel by
+   supplying ``make`` with ``-j`` argument (e.g. ``make check-system -j4``).
+   To avoid interleaving output from these parallel test suites, you can
+   specify the ``-O`` argument as well.
+
+Control test environment
+........................
+
+By default, functional tests will pre-build an LXD image with the MicroOVN
+snap already installed. This image is then used to spin up test containers,
+which significantly improves test times, because it avoids installing snap
+manually on each container. If you want to opt-out of this behaviour, and
+instead force tests to manually install MicroOVN snap, you can set
+``MICROOVN_TESTS_USE_SNAP=yes``. In that case, test containers will be based
+either on ``ubuntu:lts`` image, or whatever is specified in
+``MICROOVN_TEST_CONTAINER_IMAGE``. Below are few examples of how these
+environment variables can be combined.
 
 .. code-block:: none
 
-    export MICROOVN_TEST_CONTAINER_IMAGE="ubuntu:jammy"
-    make check-system
+   # Default behavior, using pre-built image based on 'ubuntu:lts'
+   make check-system
+
+   # Using pre-built image based on non-default base image
+   MICROOVN_TEST_CONTAINER_IMAGE="ubuntu:jammy" make check-system
+
+   # Using default base image, but forcing tests to install microovn
+   # snap on each container manually
+   MICROOVN_TESTS_USE_SNAP=yes make check-system
+
+   # Using custom base image and forcing tests to install microovn snap
+   # on each container manually
+   MICROOVN_TEST_CONTAINER_IMAGE="ubuntu:jammy" MICROOVN_TESTS_USE_SNAP=yes make check-system
+
+
+Run tests on remote LXD server
+..............................
 
 Making use of `LXD remotes`_ to spawn containers on a remote cluster or server
 is supported through the use of the ``LXC_REMOTE`` `LXD environment`_ variable.
@@ -283,13 +312,6 @@ is supported through the use of the ``LXC_REMOTE`` `LXD environment`_ variable.
 
    export LXC_REMOTE=microcloud
    make check-system
-
-.. tip::
-
-   If your hardware can handle it, you can run test suites in parallel by
-   supplying ``make`` with ``-j`` argument (e.g. ``make check-system -j4``).
-   To avoid interleaving output from these parallel test suites, you can
-   specify the ``-O`` argument as well.
 
 Test coverage information
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_helper/bats/init_cluster_services.bats
+++ b/tests/test_helper/bats/init_cluster_services.bats
@@ -14,15 +14,14 @@ setup() {
     # provide false positive results.
     assert [ -n "$TEST_CONTAINERS" ]
 
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
     install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
 }
 
 teardown() {
-    local container
-    for container in $TEST_CONTAINERS; do
-        lxc_exec "$container" "snap remove --purge microovn"
-        lxc file delete -q "$container/tmp/microovn.snap" >/dev/null 2>&1 || true
-    done
+    collect_coverage $TEST_CONTAINERS
+    delete_containers $TEST_CONTAINERS
 }
 
 init_cluster_services_register_test_functions() {

--- a/tests/test_helper/bats/lifecycle.bats
+++ b/tests/test_helper/bats/lifecycle.bats
@@ -5,6 +5,10 @@ setup_file() {
     load test_helper/lxd.bash
     load test_helper/microovn.bash
 
+    # This test suite overrides MICROOVN_TESTS_USE_SNAP env. variable
+    # because it needs to manually install MicroOVN snap as part of
+    # tests.
+    export MICROOVN_TESTS_USE_SNAP="yes"
 
     TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 1)
     export TEST_CONTAINERS

--- a/tests/test_helper/lxd.bash
+++ b/tests/test_helper/lxd.bash
@@ -2,7 +2,17 @@ function launch_containers_args() {
     local launch_args=$1; shift
     local containers=$*; shift
 
-    local image="${MICROOVN_TEST_CONTAINER_IMAGE:-ubuntu:lts}"
+    local image
+    if [ "$MICROOVN_TESTS_USE_SNAP" = "yes" ]; then
+        image="${MICROOVN_TEST_CONTAINER_IMAGE:-ubuntu:lts}"
+    else
+        image="$MICROOVN_CONTAINER_TEMPLATE"
+    fi
+
+    if [ -z "$image" ]; then
+        echo "# LXD image for test containers was not specified"
+        return 1
+    fi
 
     for container in $containers; do
         echo "# Launching '$image' container: $container" >&3

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -4,6 +4,11 @@ function install_microovn() {
     local snap_file=$1; shift
     local containers=$*
 
+    if [ "$MICROOVN_TESTS_USE_SNAP" != "yes" ]; then
+        echo "# Skipping snap installation. MicroOVN snap is expected to be present on test containers" >&3
+        return 0
+    fi
+
     local snap_base
     snap_base=$(snap_print_base $snap_file)
 

--- a/tests/test_helper/setup_teardown/init_cluster_services.bash
+++ b/tests/test_helper/setup_teardown/init_cluster_services.bash
@@ -8,12 +8,4 @@ setup_file() {
 
     TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 4)
     export TEST_CONTAINERS
-    launch_containers $TEST_CONTAINERS
-    wait_containers_ready $TEST_CONTAINERS
 }
-
-teardown_file() {
-    collect_coverage $TEST_CONTAINERS
-    delete_containers $TEST_CONTAINERS
-}
-

--- a/tests/test_helper/setup_teardown/tls_cluster.bash
+++ b/tests/test_helper/setup_teardown/tls_cluster.bash
@@ -11,6 +11,14 @@ setup_file() {
     export TEST_CONTAINERS
     export CENTRAL_CONTAINERS
     export CHASSIS_CONTAINERS
+
+    # This test suite overrides MICROOVN_TESTS_USE_SNAP env. variable
+    # because it uses LXD VMs instead of containers. This means that
+    # this suite can't run from container image with microovn snap
+    # pre-installed and each test VM needs to manually install
+    # microovn snap.
+    export MICROOVN_TESTS_USE_SNAP="yes"
+
     # Note(mkalcok): Tests for automatic renewal of expiring certificates need
     # to manipulate system time. This is not possible in an LXD container,
     # so we run these tests in the VM.

--- a/tests/test_helper/setup_teardown/upgrade.bash
+++ b/tests/test_helper/setup_teardown/upgrade.bash
@@ -9,6 +9,11 @@ setup_file() {
     ABS_TOP_TEST_DIRNAME="${BATS_TEST_DIRNAME}/"
     export ABS_TOP_TEST_DIRNAME
 
+    # This test suite overrides MICROOVN_TESTS_USE_SNAP env. variable
+    # because it needs to manually install MicroOVN snap as part of
+    # tests.
+    export MICROOVN_TESTS_USE_SNAP="yes"
+
     # Determine MicroOVN channel from which we are upgrading
     test_name=$(basename "$BATS_TEST_FILENAME")
     MICROOVN_SNAP_CHANNEL=$(get_upgrade_test_version "$test_name" "$TEST_NAME_PREFIX")


### PR DESCRIPTION
Current tests use clean ubuntu:lts LXD images in which they usually install microovn Snap during the test setup phase. This is a costly process and adds a significant amount of run time to the tests. We can improve this by pre-building an LXD image (based on ubuntu:lts) with the microovn snap already installed, which is then used to spin up containers by the tests. On a reasonably performant desktop PC, this improves test run time by roughly 50% for basic_cluster.bats which uses 3 containers. The time savings are even better for tests that use more containers.


This approach is a suitable replacement for most of the system tests. However, there are few that will keep the old workflow:
* lifecycle - The MicroOVN snap needs to be installed as part of the test and therefore can't be pre-installed on the image.
* ovsdb_schema_upgrade - This upgrade test needs to start with MicroOVN installed from the snap store.
* tls_cluster - This test uses VMs. It's debatable whether it's worth it to pre-build an LXD VM image just for this one test suite.
* upgrade - This upgrade test needs to start with MicroOVN installed from the  snap store.


As a consequence of using custom LXD image for testing, we no longer support specifying custom image through MICROOVN_TEST_CONTAINER_IMAGE env variable.
