### PR TITLE
Revert "CI: Run TIOBE job only in Canonical repo"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,11 +248,12 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/microovn/
     needs:
       - generate-coverage
-    # TICS job runs on Canonical's self-hosted runner. Attempts
-    # to execute this job on a repository outside of Canonical org
-    # (typically a fork) cause timeout after long wait period because
-    # the repository doesn't have access to the runners.
-    if: ${{ github.repository == 'canonical/microovn' }}
+    # TICS execution requires access to an auth. token which is not available in the forks of this
+    # repository. We allow this job to run only if it has access to the token:
+    #  * On "push" action
+    #  * On scheduled action
+    #  * On pull request created from the main repository (not fork)
+    if: ${{ (github.event_name != 'pull_request') || (github.repository == github.event.pull_request.head.repo.full_name) }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This change caused PRs from forks to fail in CI. Apparently, PR from a fork satisfies the "github.repository == 'canonical/microovn'" condition.

Let's go back to the previous state until we figure out how to prevent forks from trying to run TIOBE job.

This reverts commit b1d3caa021b3398bcfade9fe53cca826b8fdb121.