### PR TITLE
docs: Link to contribution guide.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,1 +1,1 @@
-docs/developers/contributing.rst
+docs/contributors/index.rst


### PR DESCRIPTION
CONTRIBUTING.rst link got broken when we reorganized the docs structure.