### PR TITLE
Collect coverage after bgp tests

### DIFF
--- a/tests/test_helper/setup_teardown/bgp_control_plane.bash
+++ b/tests/test_helper/setup_teardown/bgp_control_plane.bash
@@ -113,6 +113,7 @@ setup_file() {
 }
 
 teardown_file() {
+    collect_coverage $TEST_CONTAINERS
     delete_containers $TEST_CONTAINERS
     delete_containers $BGP_PEERS
     local net

--- a/tests/test_helper/setup_teardown/bgp_data_plane.bash
+++ b/tests/test_helper/setup_teardown/bgp_data_plane.bash
@@ -73,6 +73,7 @@ setup_file() {
 
 
 teardown_file() {
+    collect_coverage $TEST_CONTAINERS
     delete_containers "$TEST_CONTAINER $BGP_PEER $EXT_HOST"
     delete_lxd_network "$BGP_INT_NET"
     delete_lxd_network "$BGP_EXT_NET"


### PR DESCRIPTION
BGP data plane and control plane tests were not collecting coverage data leading to a lower TQI score, this should fix this.