### PR TITLE
[branch-24.03] github: Add workflow_dispatch.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: '14 3 * * 1'
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
This enables manually triggering CI jobs.



(cherry picked from commit 9eda9c42ffab820ff5565d012908283970aa31b9)