### PR TITLE
Adds a note about needed aliasing with netplan

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,3 +1,4 @@
+BGP
 Datapath
 ECDSA
 ECDH
@@ -16,6 +17,7 @@ Makefile
 MicroCluster
 MicroOVN
 MicroOVN's
+Netplan
 OVN
 OVN's
 OVS

--- a/docs/reference/aliasing.rst
+++ b/docs/reference/aliasing.rst
@@ -35,3 +35,10 @@ Further inspection can be done by inspecting the files themselves:
 
 These aliases are not related to the MicroOVN snap version and are managed by
 the store. All installations, done through the snap store, should have access to these aliases. This does mean if you install a locally built version of MicroOVN, these aliases are not created for you.
+
+.. note::
+
+   Netplan requires MicroOVN to have these aliases in order to consume OVS
+   through MicroOVN, which is essential for enabling and configuring BGP. So if
+   you are using a locally built MicroOVN, you must manually create at least the
+   alias for ``ovs-vsctl``.


### PR DESCRIPTION
Netplan requires at least the ovs-vsctl alias, this is currently undocumented, which is a problem. This adds a simple note in the aliasing section to explain this.