### PR TITLE
Makefile: remove image template on 'clean'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ $(MICROOVN_SNAP): $(MICROOVN_SOURCES) $(SNAP_SOURCES) $(COMMAND_WRAPPERS)
 
 clean:
 	rm -f $(MICROOVN_SNAP_PATH);						\
+	rm -f $(MICROOVN_CONTAINER_TEMPLATE).tar.gz;				\
 	snapcraft clean
 
 # Create LXD image with MicroOVN snap pre-installed.


### PR DESCRIPTION
Commit a6c89879 introduced reusable LXD images for faster system tests. However, we forgot to add them to the list of files to remove on `make clean`.