### PR TITLE
[24.03] Fail nicely on Netlink connection failed.

### DIFF
--- a/microovn/ovn/dpu/dpu.go
+++ b/microovn/ovn/dpu/dpu.go
@@ -122,7 +122,14 @@ func DPUSetup(ctx context.Context, s state.State) error {
 			logger.Warn("lspci not found; skipping DPU setup")
 			return nil
 		}
-
+		if strings.Contains(err.Error(), "Failed to connect to devlink Netlink") {
+			logger.Warn(
+				"cannot connect to Netlink, check required kernel" +
+					"modules and snap interfaces are enabled;" +
+					" Skipping DPU setup",
+			)
+			return nil
+		}
 		// real failure
 		return err
 	}


### PR DESCRIPTION
On some releases the devlink kernel module is not enabled by default, it would be nice to handle this error nicely and let microovn continue working.

This only blocks DPU detection and not any integral functionality so in the scenario we cant use it, continuing isnt the end of the world.


(cherry picked from commit 0543ff031926a7b42e0bc8a3cabc9653305f04f5)