### PR TITLE
Minor dpu reworks.

### DIFF
--- a/.github/workflows/build-microovn.yaml
+++ b/.github/workflows/build-microovn.yaml
@@ -46,7 +46,7 @@ jobs:
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           if [ "${POSSIBLE_TARGET_BRANCH}" = "main" ]; then
-            export SNAPCRAFT_CHANNEL=latest/edge
+            export SNAPCRAFT_CHANNEL=latest/candidate # latest edge is currently broken, so we have to use candidate for now
           fi
           sudo snap install snapcraft \
             --channel "${SNAPCRAFT_CHANNEL:-latest/stable}" \

--- a/microovn/ovn/dpu/dpu.go
+++ b/microovn/ovn/dpu/dpu.go
@@ -96,10 +96,13 @@ func setOVNDPUSerial(ctx context.Context, s state.State, serial string) error {
 	if err != nil && !strings.Contains(fmt.Sprintf("%v", err), "ovs-vsctl: no key") {
 		return err
 	}
-	externalIDs := strings.Join([]string{
-		out,
-		fmt.Sprintf("ovn-cms-options=card-serial-number=%s", serial),
-	}, ",")
+	externalIDs := fmt.Sprintf("ovn-cms-options=card-serial-number=%s", serial)
+	if out != "" {
+		externalIDs = strings.Join([]string{
+			out,
+			externalIDs,
+		}, ",")
+	}
 	_, err = ovnCmd.VSCtl(
 		ctx,
 		s,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -439,7 +439,8 @@ parts:
       - commands/*
       - ./*.env
       - bin/jq
+      - bin/lspci
       - sbin/devlink
       - lib/*/libjq.so*
       - lib/*/libonig.so*
-      - lib/*/lspci.so*
+      - lib/*/libpci.so*

--- a/tests/test_helper/common.bash
+++ b/tests/test_helper/common.bash
@@ -132,11 +132,7 @@ function snap_print_base() {
 # Returns 0 if base snap has stable channel, 1 otherwise
 function test_snap_is_stable_base() {
     local base_snap=$1; shift
-
-    local version_info
-    version_info=$(snap info "$base_snap" | awk '/\/stable/{print$2}')
-
-    [ "$version_info" != "--" ]
+    snap info "$base_snap" | awk '/\/stable/{print$2}' | grep -vq -- --
 }
 
 # get_upgrade_test_version TEST_FILE_NAME TEST_PREFIX

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -13,12 +13,15 @@ function install_microovn() {
     snap_base=$(snap_print_base $snap_file)
 
     for container in $containers; do
+        lxc_exec "$container" "apt update && apt install -y snapd"
         if ! test_snap_is_stable_base "$snap_base"; then
+            # if using unstable base use unstable snapd
+            lxc_exec "$container" "snap install snapd --channel latest/edge"
+            lxc_exec "$container" "snap refresh snapd --channel latest/edge"
             echo "# !!NOTE!! Installing $snap_base \
                   from edge channel for $snap_file" >&3
             lxc_exec "$container" "snap install --edge $snap_base"
         fi
-        lxc_exec "$container" "apt update && apt install -y snapd"
         echo "# Deploying MicroOVN to $container" >&3
         lxc_file_push "$snap_file" "$container/tmp/microovn.snap"
         echo "# Installing MicroOVN in container $container" >&3


### PR DESCRIPTION
- lspci is inaccessable by the snap outside of --dangerous, so we fix this
- we need a slight rework to the externalIDs logic when nothing else exists there.