### PR TITLE
Mark BGP as experimental.

### DIFF
--- a/.github/workflows/build-microovn.yaml
+++ b/.github/workflows/build-microovn.yaml
@@ -46,7 +46,7 @@ jobs:
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           if [ "${POSSIBLE_TARGET_BRANCH}" = "main" ]; then
-            export SNAPCRAFT_CHANNEL=latest/candidate # latest edge is currently broken, so we have to use candidate for now
+            export SNAPCRAFT_CHANNEL=latest/stable # latest edge is currently broken, so we have to use stable for now
           fi
           sudo snap install snapcraft \
             --channel "${SNAPCRAFT_CHANNEL:-latest/stable}" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
       MICROOVN_SNAP_PATH: ${{ github.workspace }}/microovn.snap
       MICROOVN_SNAP_CHANNEL: 22.03/stable
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.metadata.outputs.matrix) }}
     steps:
       - name: Checkout code

--- a/docs/explanation/bgp-redirect.rst
+++ b/docs/explanation/bgp-redirect.rst
@@ -2,10 +2,10 @@
 OVN integration with BGP
 ========================
 
-OVN fully enabled support for integration with BGP in version ``25.03``. The
-support includes the ability to redirect BGP control-plane traffic to a
-specific ``Logical Switch Port`` and the ability of the ``ovn-controller`` to
-advertise and learn routes via a `Linux VRF`_.
+OVN fully enabled experimental support for integration with BGP in version
+``25.03``. The support includes the ability to redirect BGP control-plane traffic
+to a specific ``Logical Switch Port`` and the ability of the ``ovn-controller``
+to advertise and learn routes via a `Linux VRF`_.
 
 BGP control plane
 -----------------
@@ -40,6 +40,14 @@ peers, it inserts them to the VRF, from which they are picked up by the
 
 What MicroOVN sets up
 ---------------------
+
+.. note::
+
+   This is experimental and the network architecture this sets up is likely to
+   change in future versions. This use case will not be the long term solution,
+   and nor will deployments using MicroOVN BGP in its current state be fully
+   supported going forward.
+
 
 MicroOVN can simplify the BGP integration setup described in the previous
 sections. For more information on how to do it, see:

--- a/docs/how-to/bgp.rst
+++ b/docs/how-to/bgp.rst
@@ -6,6 +6,14 @@ Configuration of the OVN integration with BGP is a single-command process in
 the MicroOVN, for more information about what's happening under the hood, see:
 :doc:`Explanation: OVN integration with BGP </explanation/bgp-redirect>`.
 
+.. note::
+
+   This is experimental and the network architecture this sets up is likely to
+   change in future versions. This use case will not be the long term solution,
+   and nor will deployments using MicroOVN BGP in its current state be fully
+   supported going forward.
+
+
 Enable BGP integration
 ----------------------
 

--- a/microovn/cmd/microovn/service_control.go
+++ b/microovn/cmd/microovn/service_control.go
@@ -118,6 +118,11 @@ func (c *cmdEnable) Run(_ *cobra.Command, args []string) error {
 	}
 
 	targetService := args[0]
+
+	if targetService == types.SrvBgp {
+		fmt.Printf("Please note, BGP functionality is currently experimental and likely to change.")
+	}
+
 	extraConfig, err := c.parseExtraConfig(targetService)
 	if err != nil {
 		return err

--- a/tests/test_helper/bats/bgp_control_plane.bats
+++ b/tests/test_helper/bats/bgp_control_plane.bats
@@ -264,7 +264,7 @@ function bgp_bad_netplan(){
         --config vrf=$vrf \
         --config asn=$host_asn"
     assert_failure
-    assert_output "Error: failed to enable service 'bgp': 'failed to apply netplan config: installed netplan does not support using ovs-vsctl from microovn'"
+    assert_output "Please note, BGP functionality is currently experimental and likely to change.Error: failed to enable service 'bgp': 'failed to apply netplan config: installed netplan does not support using ovs-vsctl from microovn'"
 
     run lxc_exec "$MICROOVN_BGP_CONTAINER" "microovn.ovs-vsctl find bridge name!=br-int"
     assert_success
@@ -303,7 +303,7 @@ function bgp_no_vrf(){
         --config vrf=$vrf \
         --config asn=$host_asn"
     assert_failure
-    assert_output "Error: failed to enable service 'bgp': 'failed to create vrf for LR 'lr-$TEST_VM_NO_VRF-microovn': vrf kernel module missing or not loaded'"
+    assert_output "Please note, BGP functionality is currently experimental and likely to change.Error: failed to enable service 'bgp': 'failed to create vrf for LR 'lr-microovn-no-vrf-microovn': vrf kernel module missing or not loaded'"
 }
 
 bgp_control_plane_register_test_functions

--- a/tests/test_helper/common.bash
+++ b/tests/test_helper/common.bash
@@ -374,6 +374,10 @@ function container_can_ping() {
 
 # print_diagnostics_on_failure CONTAINERS
 function print_diagnostics_on_failure() {
+    if [ -z "${ACTIONS_RUNNER_DEBUG:-}" ]; then
+        return
+    fi
+
     local containers=$*
     local container
 


### PR DESCRIPTION
Updates the documentation to ensure the user is aware that this feature is not finalized and is heavily subject to change, and therefore deployments using MicroOVN BGP in its current state will not be supported.

Also adds a note when you enable the bgp service that you are using experimental functionality.