### PR TITLE
tests: Fix BGP peering failures

### DIFF
--- a/microovn/bgp/redirect.go
+++ b/microovn/bgp/redirect.go
@@ -446,8 +446,11 @@ func generateVeth(ctx context.Context, s state.State, extConnections []types.Bgp
 		mac := generateLrpMac(getLrpName(s, extConnection.Iface))
 
 		// Add to virtual ethernet
-		np.AddVeth(bgpInterface, brgInterface, mac, false)
-		np.AddVeth(brgInterface, bgpInterface, "", false)
+		// The BGP-side veth needs link-local: [ipv6] so that networkd
+		// brings the interface UP and assigns an IPv6 LLA, which is
+		// required for unnumbered BGP peering.
+		np.AddVeth(bgpInterface, brgInterface, mac, false, []string{"ipv6"})
+		np.AddVeth(brgInterface, bgpInterface, "", false, nil)
 		brIntInterfaces = append(brIntInterfaces, brgInterface)
 		vrfInterfaces = append(vrfInterfaces, bgpInterface)
 
@@ -475,7 +478,28 @@ func generateVeth(ctx context.Context, s state.State, extConnections []types.Bgp
 		return err
 	}
 
-	return netplan.Apply(ctx)
+	err = netplan.Apply(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Netplan creates the veth pair, VRF, and bridge, but on some
+	// distributions networkd may not fully configure the interfaces:
+	// - The BGP-side veths may remain DOWN
+	// - VRF binding may not be applied
+	for _, iface := range vrfInterfaces {
+		// Ensure interface is bound to the VRF
+		_, err = shared.RunCommandContext(ctx, "ip", "link", "set", "dev", iface, "master", vrfName)
+		if err != nil {
+			return fmt.Errorf("failed to bind interface '%s' to VRF '%s': %v", iface, vrfName, err)
+		}
+		_, err = shared.RunCommandContext(ctx, "ip", "link", "set", "dev", iface, "up")
+		if err != nil {
+			return fmt.Errorf("failed to bring up interface '%s': %v", iface, err)
+		}
+	}
+
+	return nil
 }
 
 // redirectBgp creates a port in OVS, moves it to the VRF specified by "tableID" and configures OVN to redirect

--- a/microovn/netplan/netplan.go
+++ b/microovn/netplan/netplan.go
@@ -32,9 +32,10 @@ type network struct {
 
 // VirtualEthernet is a struct for defining virtual ethernets
 type virtualEthernet struct {
-	Peer       string `yaml:"peer"`
-	MacAddress string `yaml:"macaddress,omitempty"`
-	AcceptRa   bool   `yaml:"accept-ra"`
+	Peer       string   `yaml:"peer"`
+	MacAddress string   `yaml:"macaddress,omitempty"`
+	AcceptRa   bool     `yaml:"accept-ra"`
+	LinkLocal  []string `yaml:"link-local,omitempty"`
 }
 
 // VRF defines vrf entires in the netplan config
@@ -69,11 +70,12 @@ func NewConfig() *Config {
 }
 
 // AddVeth adds a veth pair to the config.
-func (c *Config) AddVeth(iface string, peer string, mac string, acceptRa bool) {
+func (c *Config) AddVeth(iface string, peer string, mac string, acceptRa bool, linkLocal []string) {
 	c.Network.VirtualEthernets[iface] = virtualEthernet{
 		Peer:       peer,
 		MacAddress: mac,
 		AcceptRa:   acceptRa,
+		LinkLocal:  linkLocal,
 	}
 }
 

--- a/microovn/netplan/netplan_test.go
+++ b/microovn/netplan/netplan_test.go
@@ -23,7 +23,7 @@ func TestAddMethods(t *testing.T) {
 	if _, ok := cfg.Network.VirtualEthernets["veth413"]; ok {
 		t.Errorf("unexpected veth1 in config")
 	}
-	cfg.AddVeth("veth413", "veth612", "a1:b2:c3:d4:e5:f6", false)
+	cfg.AddVeth("veth413", "veth612", "a1:b2:c3:d4:e5:f6", false, []string{"ipv6"})
 	if _, ok := cfg.Network.VirtualEthernets["veth413"]; !ok {
 		t.Errorf("expected veth413 in config")
 	}
@@ -38,7 +38,7 @@ func TestAddMethods(t *testing.T) {
 		t.Errorf("acceptRa is true when false expected")
 	}
 
-	cfg.AddVeth("veth612", "veth413", "", true)
+	cfg.AddVeth("veth612", "veth413", "", true, nil)
 	if _, ok := cfg.Network.VirtualEthernets["veth612"]; !ok {
 		t.Errorf("expected veth612 in config")
 	}

--- a/tests/test_helper/bats/bgp_data_plane.bats
+++ b/tests/test_helper/bats/bgp_data_plane.bats
@@ -55,6 +55,8 @@ network:
             peer: veth1-brg
             macaddress: 02:90:b1:a2:e6:28
             accept-ra: false
+            link-local:
+                - ipv6
         veth1-brg:
             peer: veth1-bgp
             accept-ra: false

--- a/tests/test_helper/bgp_utils.bash
+++ b/tests/test_helper/bgp_utils.bash
@@ -12,6 +12,10 @@ function install_frr_bgp() {
         lxc_exec "$container" "sed -i 's/bgpd=no/bgpd=yes/g' /etc/frr/daemons"
         # Relax burst restart limit as tests tend to restart the service often
         lxc_exec "$container" "sed -i 's/StartLimitBurst=.*/StartLimitBurst=100/g' /usr/lib/systemd/system/frr.service"
+        # Disable AppArmor profiles for FRR daemons. The bgpd profile in
+        # LXD containers causes EACCES on socket read() for BGP connections
+        # that traverse OVS/OVN virtual network paths.
+        lxc_exec "$container" "mkdir -p /etc/apparmor.d/disable && for f in bgpd bfdd zebra staticd; do [ -f /etc/apparmor.d/\$f ] && ln -sf /etc/apparmor.d/\$f /etc/apparmor.d/disable/ && apparmor_parser -R /etc/apparmor.d/\$f 2>/dev/null; done; true"
         lxc_exec "$container" "systemctl daemon-reload"
         lxc_exec "$container" "systemctl restart frr"
     done


### PR DESCRIPTION
Fix regressions that prevent BGP sessions from establishing in the MicroOVN BGP redirect feature:

1. netplan: Add link-local configuration for BGP veth interfaces

   On newer systemd-networkd, veth interfaces require explicit
   link-local: [ipv6] configuration to receive an IPv6 link-local
   address, which is required for unnumbered BGP peering.

2. bgp/redirect: Work around networkd not fully configuring interfaces

   After netplan apply, explicitly ensure BGP-side veths are:
   - Bound to the VRF (networkd may not apply this)
   - Brought UP (networkd may leave them DOWN)

3. tests: Disable FRR AppArmor profiles in test containers

   Newer FRR package versions ships AppArmor profiles that confine
   bgpd in enforce mode. The bgpd profile causes EACCES on socket
   read() for BGP connections that traverse OVS/OVN virtual network
   paths (veth -> OVS bridge -> patch port -> OVN LRP -> veth in VRF).
   Disable these profiles after FRR installation in test containers.