### PR TITLE
Revert "Use snapcraft from stable."

### DIFF
--- a/.github/workflows/build-microovn.yaml
+++ b/.github/workflows/build-microovn.yaml
@@ -46,7 +46,7 @@ jobs:
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           if [ "${POSSIBLE_TARGET_BRANCH}" = "main" ]; then
-            export SNAPCRAFT_CHANNEL=latest/stable # latest edge is currently broken, so we have to use stable for now
+            export SNAPCRAFT_CHANNEL=latest/candidate # latest edge is currently broken, so we have to use candidate for now
           fi
           sudo snap install snapcraft \
             --channel "${SNAPCRAFT_CHANNEL:-latest/stable}" \

--- a/.github/workflows/build-microovn.yaml
+++ b/.github/workflows/build-microovn.yaml
@@ -46,7 +46,7 @@ jobs:
           sudo snap set lxd daemon.group=adm
           sudo lxd init --auto
           if [ "${POSSIBLE_TARGET_BRANCH}" = "main" ]; then
-            export SNAPCRAFT_CHANNEL=latest/candidate # latest edge is currently broken, so we have to use candidate for now
+            export SNAPCRAFT_CHANNEL=latest/edge
           fi
           sudo snap install snapcraft \
             --channel "${SNAPCRAFT_CHANNEL:-latest/stable}" \


### PR DESCRIPTION
Snapcraft is fixed as of 9.0.0-post22

This reverts commit 2588af134eda375c53eeaba6694e8ef0127b40d6.