### PR TITLE
Use stable core26

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,6 @@
 name: microovn
 icon: microovn.png
 base: core26
-build-base: devel
-grade: devel
 assumes:
  - snapd2.73
 adopt-info: microovn


### PR DESCRIPTION
As core26 is stable and released, the devel statements are no longer needed