### PR TITLE
Doubles the vm wait timeout.

### DIFF
--- a/tests/test_helper/lxd.bash
+++ b/tests/test_helper/lxd.bash
@@ -186,7 +186,7 @@ function wait_vms_ready() {
     local vms=$*
     local vm
     for vm in $vms; do
-        wait_until "lxd_agent_ready $vm"
+        WAIT_TIMEOUT=60 wait_until "lxd_agent_ready $vm"
         _wait_instance_ready "$vm"
     done
 }


### PR DESCRIPTION
Previously this was 30, which was causing the tls_cluster test to be quite inconsistent.