### PR TITLE
Allow MicroOVN init to take values from stdin.

### DIFF
--- a/microovn/cmd/microovn/init.go
+++ b/microovn/cmd/microovn/init.go
@@ -17,8 +17,111 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type InitValues struct {
+	Mode                  string   `yaml:"mode,omitempty"`
+	Name                  string   `yaml:"name,omitempty"`
+	Address               string   `yaml:"address,omitempty"`
+	Services              string   `yaml:"services,omitempty"`
+	Token                 string   `yaml:"token,omitempty"`
+	CustomEncapsulationIP string   `yaml:"custom_encapsulation_ip,omitempty"`
+	CustomCACert          string   `yaml:"custom_ca_cert,omitempty"`
+	CustomCAKey           string   `yaml:"custom_ca_key,omitempty"`
+	AdditionalServers     []string `yaml:"additional_servers,omitempty"`
+}
+
+func validateMode(mode string) error {
+	if mode != "bootstrap" && mode != "join" {
+		return fmt.Errorf("mode must be 'bootstrap' or 'join', got %q", mode)
+	}
+	return nil
+}
+
+func validateToken(mode, token string) error {
+	if mode == "join" && token == "" {
+		return fmt.Errorf("token is required for join mode")
+	}
+	if mode == "bootstrap" && token != "" {
+		return fmt.Errorf("token must not be set for bootstrap mode")
+	}
+	return nil
+}
+
+func validateServices(services string) error {
+	validServices := []string{"central", "chassis", "switch", "auto"}
+	for _, s := range strings.Split(services, ",") {
+		if !slices.Contains(validServices, s) {
+			return fmt.Errorf("invalid service selected: %s", s)
+		}
+		if s == "auto" && len(strings.Split(services, ",")) > 1 {
+			return fmt.Errorf("cannot select multiple services when using auto")
+		}
+	}
+	return nil
+}
+
+func validateCustomEncapsulationIP(ip string) error {
+	if ip == "" {
+		return nil
+	}
+	return validate.IsNetworkAddress(ip)
+}
+
+func validateCustomCACert(path string) error {
+	if path == "" {
+		return nil
+	}
+	return validate.IsNotEmpty(path)
+}
+
+func validateCustomCAKey(path string) error {
+	if path == "" {
+		return nil
+	}
+	return validate.IsNotEmpty(path)
+}
+
+func (iv *InitValues) validate() error {
+	if err := validateMode(iv.Mode); err != nil {
+		return err
+	}
+	if err := validateToken(iv.Mode, iv.Token); err != nil {
+		return err
+	}
+	if err := validateServices(iv.Services); err != nil {
+		return err
+	}
+	if err := validateCustomEncapsulationIP(iv.CustomEncapsulationIP); err != nil {
+		return err
+	}
+	if err := validateCustomCACert(iv.CustomCACert); err != nil {
+		return err
+	}
+	if err := validateCustomCAKey(iv.CustomCAKey); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (iv *InitValues) applyDefaults(flagAddress string) {
+	if iv.Name == "" {
+		iv.Name, _ = os.Hostname()
+	}
+
+	if iv.Address == "" && flagAddress != "" {
+		iv.Address = flagAddress
+	} else if iv.Address == "" {
+		iv.Address = util.NetworkInterfaceAddress()
+	}
+	iv.Address = util.CanonicalNetworkAddress(iv.Address, DefaultMicroClusterPort)
+
+	if iv.Services == "" {
+		iv.Services = "auto"
+	}
+}
+
 type cmdInit struct {
-	common *CmdControl
+	common      *CmdControl
+	flagAddress string
 }
 
 func (c *cmdInit) Command() *cobra.Command {
@@ -29,18 +132,24 @@ func (c *cmdInit) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
+	cmd.Flags().StringVar(&c.flagAddress, "address", "", "Address to listen on for cluster communication")
+
 	return cmd
 }
 
-func (c *cmdInit) wantsCustomEncapsulationIP() (string, string, error) {
-	wantsCustomEncapsulationIP, err := c.common.asker.AskBool("Would you like to define a custom encapsulation IP address for this member? (yes/no) [default=no]: ", "no")
+func (c *cmdInit) askCustomEncapsulationIP() (string, string, error) {
+	wants, err := c.common.asker.AskBool("Would you like to define a custom encapsulation IP address for this member? (yes/no) [default=no]: ", "no")
 	if err != nil {
 		return "", "", err
 	}
 
-	if wantsCustomEncapsulationIP {
-		encapIP, err := c.common.asker.AskString("Please enter the custom encapsulation IP address for this member: ", "", validate.Required(validate.IsNetworkAddress))
+	if wants {
+		encapIP, err := c.common.asker.AskString("Please enter the custom encapsulation IP address for this member: ", "", nil)
 		if err != nil {
+			return "", "", err
+		}
+
+		if err := validateCustomEncapsulationIP(encapIP); err != nil {
 			return "", "", err
 		}
 
@@ -49,160 +158,86 @@ func (c *cmdInit) wantsCustomEncapsulationIP() (string, string, error) {
 
 	return "", "", nil
 }
-func (c *cmdInit) wantsCustomCA() (string, string, error) {
-	wantsCustomCA, err := c.common.asker.AskBool("Would you like to provide your own CA certificate and private key for issuing OVN TLS certificates? (yes/no) [default=no]: ", "no")
+
+func (c *cmdInit) askCustomCA() (string, string, error) {
+	wants, err := c.common.asker.AskBool("Would you like to provide your own CA certificate and private key for issuing OVN TLS certificates? (yes/no) [default=no]: ", "no")
 	if err != nil {
 		return "", "", err
 	}
 
-	if wantsCustomCA {
-		certPath, err := c.common.asker.AskString("Please enter the path to the CA certificate file: ", "", validate.Required(validate.IsNotEmpty))
+	if wants {
+		certPath, err := c.common.asker.AskString("Please enter the path to the CA certificate file: ", "", nil)
 		if err != nil {
 			return "", "", err
 		}
 
-		keyPath, err := c.common.asker.AskString("Please enter the path to the CA private key file: ", "", validate.Required(validate.IsNotEmpty))
+		if err := validateCustomCACert(certPath); err != nil {
+			return "", "", err
+		}
+
+		keyPath, err := c.common.asker.AskString("Please enter the path to the CA private key file: ", "", nil)
 		if err != nil {
 			return "", "", err
 		}
+
+		if err := validateCustomCAKey(keyPath); err != nil {
+			return "", "", err
+		}
+
 		return certPath, keyPath, nil
 	}
 
 	return "", "", nil
 }
 
-func (c *cmdInit) selectServices() (string, error) {
-	validServices := []string{"central", "chassis", "switch", "auto"}
-	serviceList, err := c.common.asker.AskString("Please select comma-separated list services you would like to enable on this node (central/chassis/switch) or let MicroOVN automatically decide (auto) [default=auto]: ", "auto", validate.IsAny)
+func (c *cmdInit) askServices() (string, error) {
+	serviceList, err := c.common.asker.AskString("Please select comma-separated list services you would like to enable on this node (central/chassis/switch) or let MicroOVN automatically decide (auto) [default=auto]: ", "auto", nil)
 	if err != nil {
 		return "", err
 	}
-	selectedServices := strings.Split(serviceList, ",")
-	for _, service := range selectedServices {
-		if !slices.Contains(validServices, service) {
-			return "", fmt.Errorf("invalid service selected: %s", service)
-		}
-		if service == "auto" && len(selectedServices) > 1 {
-			return "", fmt.Errorf("cannot select multiple services when using auto")
-		}
+
+	if err := validateServices(serviceList); err != nil {
+		return "", err
 	}
-	return strings.Join(selectedServices, ","), nil
+
+	return serviceList, nil
 }
 
 func (c *cmdInit) Run(_ *cobra.Command, _ []string) error {
-	// Connect to the daemon.
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
 	if err != nil {
 		return err
 	}
 
-	// Check if already initialized.
 	_, err = m.GetClusterMembers(context.Background())
 	isUninitialized := err != nil && api.StatusErrorCheck(err, http.StatusServiceUnavailable)
 	if err != nil && !isUninitialized {
 		return err
 	}
 
-	// User interaction.
-	mode := "existing"
-	customEncapsulationIPSupported := slices.Contains(microovnAPI.Extensions(), "custom_encapsulation_ip")
-
-	if isUninitialized {
-		// Get system name.
-		hostName, err := os.Hostname()
-		if err != nil {
-			return fmt.Errorf("failed to retrieve system hostname: %w", err)
-		}
-
-		// Get system address.
-		address := util.NetworkInterfaceAddress()
-		address, err = c.common.asker.AskString(fmt.Sprintf("Please choose the address MicroOVN will be listening on [default=%s]: ", address), address, nil)
-		if err != nil {
-			return err
-		}
-		address = util.CanonicalNetworkAddress(
-			address, DefaultMicroClusterPort)
-
-		wantsBootstrap, err := c.common.asker.AskBool("Would you like to create a new MicroOVN cluster? (yes/no) [default=no]: ", "no")
-		if err != nil {
-			return err
-		}
-
-		optionalConfig := make(map[string]string)
-
-		selectedServices, err := c.selectServices()
-		if err != nil {
-			return err
-		}
-		optionalConfig["ovn-services"] = selectedServices
-
-		if wantsBootstrap {
-			mode = "bootstrap"
-
-			// Offer overriding the name.
-			hostName, err = c.common.asker.AskString(fmt.Sprintf("Please choose a name for this system [default=%s]: ", hostName), hostName, nil)
-			if err != nil {
-				return err
-			}
-
-			if customEncapsulationIPSupported {
-				key, encapIP, err := c.wantsCustomEncapsulationIP()
-				if err != nil {
-					return err
-				}
-
-				if key != "" && encapIP != "" {
-					optionalConfig[key] = encapIP
-				}
-			}
-
-			certPath, keyPath, err := c.wantsCustomCA()
-			if err != nil {
-				return err
-			}
-			if certPath != "" && keyPath != "" {
-				optionalConfig["ovn-ca-cert"] = certPath
-				optionalConfig["ovn-ca-key"] = keyPath
-			}
-
-			// Bootstrap the cluster.
-			err = m.NewCluster(context.Background(), hostName, address, optionalConfig)
-			if err != nil {
-				return err
-			}
-		} else {
-			mode = "join"
-
-			token, err := c.common.asker.AskString("Please enter your join token: ", "", nil)
-			if err != nil {
-				return err
-			}
-
-			if customEncapsulationIPSupported {
-				// Register a potential custom encapsulation IP for other systems,
-				// so that when they will join the cluster, their encapsulation IP
-				// for the Geneve tunnel will be automatically configured.
-				key, encapIP, err := c.wantsCustomEncapsulationIP()
-				if err != nil {
-					return err
-				}
-
-				if key != "" && encapIP != "" {
-					optionalConfig[key] = encapIP
-				}
-			}
-
-			err = m.JoinCluster(context.Background(), hostName, address, token, optionalConfig)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		fmt.Printf("MicroOVN has already been initialized.\n\n")
+	iv, err := readPreseedConfig()
+	if err != nil {
+		return err
 	}
 
-	// Add additional servers.
-	if mode != "join" {
+	fromPreseed := iv != nil
+	if !fromPreseed {
+		iv, err = c.populateInteractively()
+		if err != nil {
+			return err
+		}
+	}
+
+	iv.applyDefaults(c.flagAddress)
+	if err := iv.validate(); err != nil {
+		return err
+	}
+
+	if err := c.applyInitValues(m, isUninitialized, iv); err != nil {
+		return err
+	}
+
+	if !fromPreseed && iv.Mode != "join" {
 		wantsMachines, err := c.common.asker.AskBool("Would you like to add additional servers to the cluster? (yes/no) [default=no]: ", "no")
 		if err != nil {
 			return err
@@ -210,7 +245,7 @@ func (c *cmdInit) Run(_ *cobra.Command, _ []string) error {
 
 		if wantsMachines {
 			for {
-				tokenName, err := c.common.asker.AskString("What's the name of the new MicroOVN server? (empty to exit): ", "", func(_ string) error { return nil })
+				tokenName, err := c.common.asker.AskString("What's the name of the new MicroOVN server? (empty to exit): ", "", nil)
 				if err != nil {
 					return err
 				}
@@ -219,7 +254,6 @@ func (c *cmdInit) Run(_ *cobra.Command, _ []string) error {
 					break
 				}
 
-				// Issue the token.
 				token, err := m.NewJoinToken(context.Background(), tokenName, 3*time.Hour)
 				if err != nil {
 					return err
@@ -228,6 +262,126 @@ func (c *cmdInit) Run(_ *cobra.Command, _ []string) error {
 				fmt.Println(token)
 			}
 		}
+	}
+
+	return nil
+}
+
+func (c *cmdInit) populateInteractively() (*InitValues, error) {
+	customEncapsulationIPSupported := slices.Contains(microovnAPI.Extensions(), "custom_encapsulation_ip")
+
+	iv := &InitValues{}
+
+	address := util.NetworkInterfaceAddress()
+	a, err := c.common.asker.AskString(fmt.Sprintf("Please choose the address MicroOVN will be listening on [default=%s]: ", address), address, nil)
+	if err != nil {
+		return nil, err
+	}
+	address = a
+	iv.Address = util.CanonicalNetworkAddress(address, DefaultMicroClusterPort)
+
+	wantsBootstrap, err := c.common.asker.AskBool("Would you like to create a new MicroOVN cluster? (yes/no) [default=no]: ", "no")
+	if err != nil {
+		return nil, err
+	}
+
+	services, err := c.askServices()
+	if err != nil {
+		return nil, err
+	}
+	iv.Services = services
+
+	if wantsBootstrap {
+		iv.Mode = "bootstrap"
+
+		hostName, err := os.Hostname()
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve system hostname: %w", err)
+		}
+
+		iv.Name, err = c.common.asker.AskString(fmt.Sprintf("Please choose a name for this system [default=%s]: ", hostName), hostName, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if customEncapsulationIPSupported {
+			key, encapIP, err := c.askCustomEncapsulationIP()
+			if err != nil {
+				return nil, err
+			}
+			if key != "" && encapIP != "" {
+				iv.CustomEncapsulationIP = encapIP
+			}
+		}
+
+		certPath, keyPath, err := c.askCustomCA()
+		if err != nil {
+			return nil, err
+		}
+		if certPath != "" && keyPath != "" {
+			iv.CustomCACert = certPath
+			iv.CustomCAKey = keyPath
+		}
+	} else {
+		iv.Mode = "join"
+
+		token, err := c.common.asker.AskString("Please enter your join token: ", "", nil)
+		if err != nil {
+			return nil, err
+		}
+		iv.Token = token
+
+		if customEncapsulationIPSupported {
+			key, encapIP, err := c.askCustomEncapsulationIP()
+			if err != nil {
+				return nil, err
+			}
+			if key != "" && encapIP != "" {
+				iv.CustomEncapsulationIP = encapIP
+			}
+		}
+	}
+
+	return iv, nil
+}
+
+func (c *cmdInit) applyInitValues(m *microcluster.MicroCluster, isUninitialized bool, iv *InitValues) error {
+	customEncapsulationIPSupported := slices.Contains(microovnAPI.Extensions(), "custom_encapsulation_ip")
+
+	if isUninitialized {
+		optionalConfig := map[string]string{
+			"ovn-services": iv.Services,
+		}
+
+		if customEncapsulationIPSupported && iv.CustomEncapsulationIP != "" {
+			optionalConfig["ovn-encap-ip"] = iv.CustomEncapsulationIP
+		}
+
+		if iv.Mode == "bootstrap" {
+			if iv.CustomCACert != "" && iv.CustomCAKey != "" {
+				optionalConfig["ovn-ca-cert"] = iv.CustomCACert
+				optionalConfig["ovn-ca-key"] = iv.CustomCAKey
+			}
+
+			if err := m.NewCluster(context.Background(), iv.Name, iv.Address, optionalConfig); err != nil {
+				return err
+			}
+		} else {
+			if err := m.JoinCluster(context.Background(), iv.Name, iv.Address, iv.Token, optionalConfig); err != nil {
+				return err
+			}
+		}
+	} else {
+		fmt.Printf("MicroOVN has already been initialized.\n\n")
+	}
+
+	for _, tokenName := range iv.AdditionalServers {
+		token, err := m.NewJoinToken(context.Background(), tokenName, 3*time.Hour)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(token)
 	}
 
 	return nil

--- a/microovn/cmd/microovn/preseed.go
+++ b/microovn/cmd/microovn/preseed.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func readPreseedConfig() (*InitValues, error) {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat stdin: %w", err)
+	}
+
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		return nil, nil
+	}
+
+	var iv InitValues
+	decoder := yaml.NewDecoder(os.Stdin)
+	if err := decoder.Decode(&iv); err != nil {
+		return nil, fmt.Errorf("failed to parse preseed YAML from stdin: %w", err)
+	}
+
+	return &iv, nil
+}

--- a/tests/init_cluster_custom_encap_preseed.bats
+++ b/tests/init_cluster_custom_encap_preseed.bats
@@ -1,0 +1,1 @@
+init_cluster_custom_encap.bats

--- a/tests/init_cluster_preseed.bats
+++ b/tests/init_cluster_preseed.bats
@@ -1,0 +1,1 @@
+test_helper/bats/cluster.bats

--- a/tests/init_cluster_services_preseed.bats
+++ b/tests/init_cluster_services_preseed.bats
@@ -1,0 +1,1 @@
+test_helper/bats/init_cluster_services_preseed.bats

--- a/tests/init_cluster_user_ca_preseed.bats
+++ b/tests/init_cluster_user_ca_preseed.bats
@@ -1,0 +1,1 @@
+init_cluster_user_ca.bats

--- a/tests/test_helper/bats/init_cluster_services_preseed.bats
+++ b/tests/test_helper/bats/init_cluster_services_preseed.bats
@@ -1,0 +1,161 @@
+# This is a bash shell fragment -*- bash -*-
+
+load "test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+setup() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load test_helper/tls.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+    # Ensure TEST_CONTAINERS are populated, otherwise the tests below will
+    # provide false positive results.
+    assert [ -n "$TEST_CONTAINERS" ]
+
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+}
+
+teardown() {
+    print_diagnostics_on_failure $TEST_CONTAINERS
+    collect_coverage $TEST_CONTAINERS
+    delete_containers $TEST_CONTAINERS
+}
+
+init_cluster_services_register_test_functions() {
+    bats_test_function \
+        --description "Init MicroOVN in datapath mode (switch and chassis only)" \
+        -- init_cluster_with_services "switch,chassis" "switch,chassis" "switch,chassis" "switch,chassis"
+
+    bats_test_function \
+        --description "Init MicroOVN in control mode (central only)" \
+        -- init_cluster_with_services "central" "central" "central" "central"
+
+
+    bats_test_function \
+        --description "Init MicroOVN in 'auto' mode (default services)" \
+        -- init_cluster_auto
+}
+
+# init_cluster_with_services SERVICE_LIST [ SERVICE_LIST ...]
+#
+# This test runs bootstraps the MicroOVN cluster via 'microovn init' interactive
+# dialogue, enabling only services from SERVICE_LIST on each cluster member.
+# SERVICE_LIST is a comma separated string with valid service names. It should
+# be supplied as many times as there are nodes in TEST_CONTAINERS list.
+init_cluster_with_services() {
+    local services=$*
+
+    local service_list
+    read -r -a service_list <<< "$services"
+    local service_list_len="${#service_list[@]}"
+
+    local container_list
+    read -r -a container_list <<< "$TEST_CONTAINERS"
+    local container_list_len="${#container_list[@]}"
+
+    # Ensure that services were specified for every test container
+    assert_equal "$container_list_len" "$service_list_len"
+
+    # Init individual cluster members with specified services enabled
+    local leader
+    local i
+    for (( i=0; i<container_list_len; i++ )); do
+        local container="${container_list[$i]}"
+        local selected_services="${service_list[$i]}"
+        local addr
+        addr=$(container_get_default_ip "$container" \
+               "$(test_is_ipv6_test && echo inet6 || echo inet)")
+        assert [ -n "$addr" ]
+        if [ -z "$leader" ]; then
+            microovn_init_create_cluster_preseed "$container" "$addr" "" "" "" "$selected_services"
+            leader="$container"
+        else
+            local token
+            token=$(microovn_cluster_get_join_token "$leader" "$container")
+            microovn_init_join_cluster_preseed "$container" "$addr" "$token" "" "$selected_services"
+        fi
+    done
+
+    declare -A expected_snap_services
+    # Ensure that expected services are running on the node
+    for (( i=0; i<container_list_len; i++ )); do
+        local container="${container_list[$i]}"
+        local selected_services="${service_list[$i]}"
+
+        # Parse requested services into snap service names and the expected state
+        run grep -w "switch" <<< "$selected_services"
+        # shellcheck disable=SC2154 # Variable "$status" is exported from previous execution of 'run'
+        expected_snap_services["switch"]=$([ "$status" -eq 0 ] && echo "enabled" || echo "disabled")
+
+        run grep -w "chassis" <<< "$selected_services"
+        expected_snap_services["chassis"]=$([ "$status" -eq 0 ] && echo "enabled" || echo "disabled")
+
+        run grep -w "central" <<< "$selected_services"
+        expected_snap_services["ovn-northd"]=$([ "$status" -eq 0 ] && echo "enabled" || echo "disabled")
+        expected_snap_services["ovn-ovsdb-server-nb"]=$([ "$status" -eq 0 ] && echo "enabled" || echo "disabled")
+        expected_snap_services["ovn-ovsdb-server-sb"]=$([ "$status" -eq 0 ] && echo "enabled" || echo "disabled")
+
+        local service
+        for service in "${!expected_snap_services[@]}"; do
+            local expected_state="${expected_snap_services[$service]}"
+            echo "# ($container) Checking that microovn.$service is $expected_state" >&3
+            lxc_exec "$container" "snap services microovn.$service | grep $expected_state"
+        done
+    done
+}
+
+# init_cluster_auto
+#
+# This test bootstraps MicroOVN cluster via interactive 'init' dialogue,
+# selecting "auto" as a value for requested services. This causes MicroOVn
+# to fall back to the default behavior of enabling "chassis" and "switch" services
+# on every node, and enabling "central" on the first three nodes.
+init_cluster_auto() {
+    # Init individual cluster members in "auto" mode
+    local leader
+    local container
+    for container in $TEST_CONTAINERS; do
+        local addr
+        addr=$(container_get_default_ip "$container" \
+               "$(test_is_ipv6_test && echo inet6 || echo inet)")
+        assert [ -n "$addr" ]
+        if [ -z "$leader" ]; then
+            microovn_init_create_cluster_preseed "$container" "$addr" "" "" "" "auto"
+            leader="$container"
+        else
+            local token
+            token=$(microovn_cluster_get_join_token "$leader" "$container")
+            microovn_init_join_cluster_preseed "$container" "$addr" "$token" "" "auto"
+        fi
+    done
+
+    local i=1
+    for container in $TEST_CONTAINERS; do
+        # Chassis and switch services are always enabled in "auto" mode
+        echo "# ($container) Checking that microovn.switch is enabled" >&3
+        lxc_exec "$container" "snap services microovn.switch | grep enabled"
+
+        echo "# ($container) Checking that microovn.chassis is enabled" >&3
+        lxc_exec "$container" "snap services microovn.chassis | grep enabled"
+
+        # Central services should be enabled only on first three nodes in "auto" mode
+        local expected_central_state
+        expected_central_state=$([[ $i -le 3 ]] && echo "enabled" || echo "disabled")
+
+        echo "# ($container) Checking that microovn.ovn-northd is $expected_central_state" >&3
+        lxc_exec "$container" "snap services microovn.ovn-northd | grep $expected_central_state"
+
+        echo "# ($container) Checking that microovn.ovn-ovsdb-server-nb is $expected_central_state" >&3
+        lxc_exec "$container" "snap services microovn.ovn-ovsdb-server-nb | grep $expected_central_state"
+
+        echo "# ($container) Checking that microovn.ovn-ovsdb-server-sb is $expected_central_state" >&3
+        lxc_exec "$container" "snap services microovn.ovn-ovsdb-server-sb | grep $expected_central_state"
+        ((++i))
+    done
+}
+
+init_cluster_services_register_test_functions

--- a/tests/test_helper/microovn.bash
+++ b/tests/test_helper/microovn.bash
@@ -853,3 +853,101 @@ function setup_snap_aliases(){
         done
     done
 }
+
+# Build a YAML string for the preseed file from given parameters.
+# Arguments:
+#   $1 - name
+#   $2 - address
+#   $3 - custom_encapsulation_ip (optional)
+#   $4 - user_ca_crt (optional)
+#   $5 - user_ca_key (optional)
+#   $6 - services (optional)
+# Returns the YAML content to stdout.
+function microovn_preseed_bootstrap_yaml() {
+    local name=$1; shift
+    local address=$1; shift
+    local custom_encapsulation_ip=$1; shift
+    local user_ca_crt=$1; shift
+    local user_ca_key=$1; shift
+    local services=$1; shift
+
+    echo "mode: bootstrap"
+    echo "name: \"$name\""
+    if [ -n "$address" ]; then
+        echo "address: \"$address\""
+    fi
+    if [ -n "$services" ]; then
+        echo "services: \"$services\""
+    fi
+    if [ -n "$custom_encapsulation_ip" ]; then
+        echo "custom_encapsulation_ip: \"$custom_encapsulation_ip\""
+    fi
+    if [ -n "$user_ca_crt" ]; then
+        echo "custom_ca_cert: \"$user_ca_crt\""
+    fi
+    if [ -n "$user_ca_key" ]; then
+        echo "custom_ca_key: \"$user_ca_key\""
+    fi
+}
+
+# Build a YAML string for the preseed join configuration.
+# Arguments:
+#   $1 - address
+#   $2 - token
+#   $3 - custom_encapsulation_ip (optional)
+#   $4 - services (optional)
+# Returns the YAML content to stdout.
+function microovn_preseed_join_yaml() {
+    local address=$1; shift
+    local token=$1; shift
+    local custom_encapsulation_ip=$1; shift
+    local services=$1; shift
+
+    echo "mode: join"
+    echo "token: \"$token\""
+    if [ -n "$address" ]; then
+        echo "address: \"$address\""
+    fi
+    if [ -n "$services" ]; then
+        echo "services: \"$services\""
+    fi
+    if [ -n "$custom_encapsulation_ip" ]; then
+        echo "custom_encapsulation_ip: \"$custom_encapsulation_ip\""
+    fi
+}
+
+# Run 'microovn init' with a preseed YAML piped through stdin.
+# Arguments:
+#   $1       - container name
+#   stdin    - YAML preseed content
+function microovn_init_preseed() {
+    local container=$1; shift
+
+    lxc exec "$container" -- bash -c "sudo microovn init"
+}
+
+# microovn_init_create_cluster_preseed CONTAINER ADDRESS [CUSTOM_ENCAP_IP] [CA_CRT] [CA_KEY] [SERVICES]
+function microovn_init_create_cluster_preseed() {
+    local container=$1; shift
+    local address=$1; shift
+    local custom_encapsulation_ip=$1; shift
+    local user_ca_crt=$1; shift
+    local user_ca_key=$1; shift
+    local services=$1; shift
+
+    microovn_preseed_bootstrap_yaml "$container" "$address" \
+        "$custom_encapsulation_ip" "$user_ca_crt" "$user_ca_key" \
+        "$services" | microovn_init_preseed "$container"
+}
+
+# microovn_init_join_cluster_preseed CONTAINER ADDRESS TOKEN [CUSTOM_ENCAP_IP] [SERVICES]
+function microovn_init_join_cluster_preseed() {
+    local container=$1; shift
+    local address=$1; shift
+    local token=$1; shift
+    local custom_encapsulation_ip=$1; shift
+    local services=$1; shift
+
+    microovn_preseed_join_yaml "$address" "$token" \
+        "$custom_encapsulation_ip" "$services" | microovn_init_preseed "$container"
+}

--- a/tests/test_helper/setup_teardown/init_cluster_custom_encap_preseed.bash
+++ b/tests/test_helper/setup_teardown/init_cluster_custom_encap_preseed.bash
@@ -1,0 +1,50 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
+    export TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+
+    # Create a dedicated bridge for the east-west traffic
+    network_output=$(create_lxd_network "br-east-west")
+    ipv4_subnet=$(echo "$network_output" | cut -d'|' -f1)
+
+    # Give each container an IP address from the subnet
+    east_west_ips_to_containers=$(connect_containers_to_network_ipv4 "$TEST_CONTAINERS" "br-east-west" $ipv4_subnet)
+    IFS=',' read -ra east_west_addrs <<< "$east_west_ips_to_containers"
+    EAST_WEST_ADDRS=("${east_west_addrs[@]}")
+    printf '%s\n' "${EAST_WEST_ADDRS[@]}" > "$BATS_TMPDIR/east_west_addrs.txt"
+
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    local leader
+    for pair in "${EAST_WEST_ADDRS[@]}"; do
+        IFS='@' read -r container ip_east_west <<< "$pair"
+
+        local addr
+        addr=$(container_get_default_ip "$container" \
+               "$(test_is_ipv6_test && echo inet6 || echo inet)")
+        assert [ -n "$addr" ]
+        if [ -z "$leader" ]; then
+            microovn_init_create_cluster_preseed "$container" "$addr" "$ip_east_west" "" "" ""
+            leader="$container"
+        else
+            local token
+            token=$(microovn_cluster_get_join_token "$leader" "$container")
+            microovn_init_join_cluster_preseed "$container" "$addr" "$token" "$ip_east_west" ""
+        fi
+    done
+}
+
+teardown_file() {
+    print_diagnostics_on_failure $TEST_CONTAINERS
+    collect_coverage $TEST_CONTAINERS
+    delete_containers $TEST_CONTAINERS
+    delete_lxd_network "br-east-west"
+    rm -f "$BATS_TMPDIR/east_west_addrs.txt"
+}

--- a/tests/test_helper/setup_teardown/init_cluster_preseed.bash
+++ b/tests/test_helper/setup_teardown/init_cluster_preseed.bash
@@ -1,0 +1,35 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 3)
+    export TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    local leader
+    for container in $TEST_CONTAINERS; do
+        local addr
+        addr=$(container_get_default_ip "$container" \
+               "$(test_is_ipv6_test && echo inet6 || echo inet)")
+        assert [ -n "$addr" ]
+        if [ -z "$leader" ]; then
+            microovn_init_create_cluster_preseed "$container" "$addr" "" "" "" ""
+            leader="$container"
+        else
+            local token
+            token=$(microovn_cluster_get_join_token "$leader" "$container")
+            microovn_init_join_cluster_preseed "$container" "$addr" "$token" "" ""
+        fi
+    done
+}
+
+teardown_file() {
+    print_diagnostics_on_failure $TEST_CONTAINERS
+    collect_coverage $TEST_CONTAINERS
+    delete_containers $TEST_CONTAINERS
+}

--- a/tests/test_helper/setup_teardown/init_cluster_services_preseed.bash
+++ b/tests/test_helper/setup_teardown/init_cluster_services_preseed.bash
@@ -1,0 +1,15 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 4)
+    export TEST_CONTAINERS
+}
+
+teardown_file() {
+    print_diagnostics_on_failure $TEST_CONTAINERS
+}

--- a/tests/test_helper/setup_teardown/init_cluster_user_ca_preseed.bash
+++ b/tests/test_helper/setup_teardown/init_cluster_user_ca_preseed.bash
@@ -1,0 +1,55 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load test_helper/tls.bash
+    load ../.bats/bats-support/load.bash
+    load ../.bats/bats-assert/load.bash
+
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 4)
+    CENTRAL_CONTAINERS=""
+    CHASSIS_CONTAINERS=""
+
+    export TEST_CONTAINERS
+    export CENTRAL_CONTAINERS
+    export CHASSIS_CONTAINERS
+
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    export USER_CA_CRT="/var/snap/microovn/common/ca.crt"
+    export USER_CA_KEY="/var/snap/microovn/common/ca.key"
+    export LEADER
+    for container in $TEST_CONTAINERS; do
+        local addr
+        addr=$(container_get_default_ip "$container" "inet")
+        assert [ -n "$addr" ]
+        if [ -z "$LEADER" ]; then
+            generate_user_ca "$container" "ec" "$USER_CA_CRT" "$USER_CA_KEY"
+            microovn_init_create_cluster_preseed "$container" "$addr" "" "$USER_CA_CRT" "$USER_CA_KEY" ""
+            LEADER="$container"
+        else
+            local token
+            token=$(microovn_cluster_get_join_token "$LEADER" "$container")
+            microovn_init_join_cluster_preseed "$container" "$addr" "$token" "" ""
+        fi
+    done
+
+    # Categorize containers as "CENTRAL" and "CHASSIS" based on the services they run
+    for container in $TEST_CONTAINERS; do
+        container_services=$(microovn_get_cluster_services "$container")
+        if [[ "$container_services" == *"central"* ]]; then
+            CENTRAL_CONTAINERS+="$container "
+        else
+            CHASSIS_CONTAINERS+="$container "
+        fi
+    done
+}
+
+teardown_file() {
+    print_diagnostics_on_failure $TEST_CONTAINERS
+    collect_coverage $TEST_CONTAINERS
+    delete_containers $TEST_CONTAINERS
+}
+


### PR DESCRIPTION
The microovn init functionality is not very machine usable, which is a problem because we like machines and the operator charm could gain a lot of extra functionality through the init options.

The simple solution is to allow passing values though init as a yaml object.