### PR TITLE
feat: `microovn inspect` command 

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -8,6 +8,7 @@ BGP
 BIRD's
 cms
 Datapath
+DHCP
 DPU
 DPUs
 devlink

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -11,6 +11,7 @@ a basic understanding of OVN.
 
    Security <tls>
    downscaling
+   inspect
    logs
    major-upgrades
    ovn-underlay

--- a/docs/how-to/inspect.rst
+++ b/docs/how-to/inspect.rst
@@ -1,0 +1,122 @@
+=============================
+Inspect a MicroOVN deployment
+=============================
+
+The ``microovn inspect`` command checks the health of a MicroOVN deployment.
+It compares the configured services with their runtime state, checks the OVN
+databases, and looks for differences in the generated OVN environment across
+cluster members.
+
+The command is read-only. It does not change services, files, OVN database
+records, or cluster membership. Remediation shown in the output is guidance
+for the operator and is never run automatically.
+
+Run an inspection
+-----------------
+
+Run the command with elevated privileges on any MicroOVN cluster member:
+
+.. code-block:: none
+
+   sudo microovn inspect
+
+The default output identifies the node and inspection scope, describes the
+Northbound and Southbound databases, and lists findings which need attention.
+Passing checks are omitted. This is equivalent to ``--format=text`` (or
+``-f text``).
+
+Use ``--verbose`` (or ``-v``) to include passing checks, node-level details,
+collection errors, and remediation guidance:
+
+.. code-block:: none
+
+   sudo microovn inspect --verbose
+
+Use JSON output when the report will be consumed by another program:
+
+.. code-block:: none
+
+   sudo microovn inspect --format=json
+
+JSON reports always contain the complete result set, so ``--verbose`` cannot
+be combined with ``--format=json``. The ``schema_version`` field identifies
+the report format. Consumers should allow additional optional fields within a
+schema version.
+
+An inspection has an overall 30-second time limit. Collection from an
+individual remote member is limited to five seconds. Database probing has its
+own bounded convergence window within the overall limit.
+
+Understand the result
+---------------------
+
+Each check has one of four statuses:
+
+``PASS``
+   The available evidence satisfies the check.
+
+``WARNING``
+   MicroOVN is operating, but a known condition is degraded or carries risk.
+
+``FAIL``
+   The available evidence proves that a condition is unhealthy.
+
+``UNKNOWN``
+   MicroOVN could not collect enough evidence to determine health.
+
+The summary counts every status. Its overall status uses this precedence:
+``FAIL``, ``UNKNOWN``, ``WARNING``, then ``PASS``. This keeps an incomplete
+inspection visible even when other checks have passed.
+
+The command uses these exit codes:
+
+``0``
+   Every check passed.
+
+``1``
+   At least one check returned ``WARNING``, ``FAIL``, or ``UNKNOWN``.
+
+   ``2``
+   The arguments were invalid, or inspection failed before it could produce a
+   report. This includes running the command on a member which has not joined
+   or set up a MicroOVN cluster.
+
+An unavailable cluster member is reported as ``UNKNOWN``. Results collected
+from other members are still included in the report.
+
+Choose a cluster member
+-----------------------
+
+Run the command on a voting member for an authoritative cluster-wide report.
+A standby or spare member can provide local evidence, but it cannot establish
+the state of the whole cluster. Its report contains an authority warning and
+``UNKNOWN`` results for checks which require cluster-wide state, so it exits
+with code ``1``.
+
+The central topology check also reports a warning when the deployment has one
+or two central members, or an even non-zero number of central members. A
+deployment with no managed central service is not warned because its central
+databases may be managed externally.
+
+Checks performed
+----------------
+
+The inspection covers these areas:
+
+* Central topology - checks the number of members configured with the
+  ``central`` service.
+* Service runtime - compares configured services with the snap daemons running
+  on each member. A configured service which is inactive or disabled is a
+  failure. An active or enabled daemon without a corresponding configured
+  service is a warning.
+* OVN databases - checks Northbound and Southbound schema agreement,
+  connectivity, and ``nb_cfg`` convergence.
+* DHCP metadata routes - checks that logical switch ports with DHCP options
+   have a classless static route to the instance metadata service.
+* Environment convergence - compares the generated ``ovn.env`` entries across
+  reachable members.
+
+Environment values are hashed on the member where they are collected. Raw
+values are not returned or printed. The hashes prevent accidental disclosure,
+but they are not a substitute for secret storage: a guessed low-entropy value
+can be confirmed offline by hashing it and comparing the result.

--- a/microovn/api/endpoints.go
+++ b/microovn/api/endpoints.go
@@ -23,6 +23,9 @@ var Server = map[string]rest.Server{
 				Endpoints: []rest.Endpoint{
 					services.ListCmd,
 					services.ServiceControlCmd,
+					InspectionSnapshotEndpoint,
+					InspectionDatabaseEndpoint,
+					InspectionNetworkEndpoint,
 					RegenerateEnvEndpoint,
 					certificates.IssueCertificatesEndpoint,
 					certificates.IssueCertificatesAllEndpoint,

--- a/microovn/api/inspect.go
+++ b/microovn/api/inspect.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/canonical/microcluster/v3/microcluster/rest"
+	"github.com/canonical/microcluster/v3/microcluster/rest/response"
+	"github.com/canonical/microcluster/v3/state"
+	"github.com/canonical/microovn/microovn/api/types"
+	"github.com/canonical/microovn/microovn/inspect/facts"
+	"github.com/canonical/microovn/microovn/ovn/environment"
+	"github.com/canonical/microovn/microovn/snap"
+)
+
+var InspectionSnapshotEndpoint = rest.Endpoint{
+	Path: "inspect/snapshot",
+	Get: rest.EndpointAction{
+		Handler:        inspectionSnapshotGet,
+		AllowUntrusted: false,
+		ProxyTarget:    false,
+	},
+}
+
+var InspectionDatabaseEndpoint = rest.Endpoint{
+	Path: "inspect/database",
+	Get: rest.EndpointAction{
+		Handler:        inspectionDatabaseGet,
+		AllowUntrusted: false,
+		ProxyTarget:    false,
+	},
+}
+
+var InspectionNetworkEndpoint = rest.Endpoint{
+	Path: "inspect/network",
+	Get: rest.EndpointAction{
+		Handler:        inspectionNetworkGet,
+		AllowUntrusted: false,
+		ProxyTarget:    false,
+	},
+}
+
+func inspectionSnapshotGet(s state.State, r *http.Request) response.Response {
+	snapshot := facts.CollectNodeSnapshot(
+		r.Context(),
+		s.Name(),
+		s.Address().Hostname(),
+		snap.Services,
+		environment.ReadEnvironment,
+	)
+	return response.SyncResponse(true, snapshot)
+}
+
+func inspectionDatabaseGet(s state.State, r *http.Request) response.Response {
+	scope := r.URL.Query().Get("scope")
+	if scope == "" {
+		return response.BadRequest(fmt.Errorf("missing required query parameter: scope"))
+	}
+	if scope != string(types.InspectionScopeCluster) && scope != string(types.InspectionScopeLocal) {
+		return response.BadRequest(fmt.Errorf("invalid scope: %s", scope))
+	}
+	probe, err := facts.CollectDatabaseProbe(
+		r.Context(),
+		s,
+		types.InspectionScope(scope),
+	)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	return response.SyncResponse(true, probe)
+}
+
+func inspectionNetworkGet(s state.State, r *http.Request) response.Response {
+	probe := facts.CollectNetworkProbe(
+		r.Context(),
+		s,
+	)
+	return response.SyncResponse(true, probe)
+}

--- a/microovn/api/inspect_test.go
+++ b/microovn/api/inspect_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInspectionSnapshotEndpointContract(t *testing.T) {
+	if InspectionSnapshotEndpoint.Path != "inspect/snapshot" {
+		t.Fatalf("endpoint path = %q, want %q", InspectionSnapshotEndpoint.Path, "inspect/snapshot")
+	}
+	if InspectionSnapshotEndpoint.Get.Handler == nil {
+		t.Fatal("snapshot endpoint has no GET handler")
+	}
+	if InspectionSnapshotEndpoint.Get.AllowUntrusted {
+		t.Fatal("snapshot endpoint allows untrusted requests")
+	}
+	if InspectionSnapshotEndpoint.Get.ProxyTarget {
+		t.Fatal("snapshot endpoint proxies requests")
+	}
+
+	registered := false
+	for _, resource := range Server["microovn"].Resources {
+		for _, endpoint := range resource.Endpoints {
+			if endpoint.Path == InspectionSnapshotEndpoint.Path {
+				registered = true
+				break
+			}
+		}
+	}
+	if !registered {
+		t.Fatal("snapshot endpoint is not registered")
+	}
+}
+
+func TestInspectionDatabaseEndpointContract(t *testing.T) {
+	if InspectionDatabaseEndpoint.Path != "inspect/database" {
+		t.Fatalf("endpoint path = %q, want %q", InspectionDatabaseEndpoint.Path, "inspect/database")
+	}
+	if InspectionDatabaseEndpoint.Get.Handler == nil {
+		t.Fatal("database endpoint has no GET handler")
+	}
+	if InspectionDatabaseEndpoint.Get.AllowUntrusted {
+		t.Fatal("database endpoint allows untrusted requests")
+	}
+	if InspectionDatabaseEndpoint.Get.ProxyTarget {
+		t.Fatal("database endpoint proxies requests")
+	}
+
+	registered := false
+	for _, resource := range Server["microovn"].Resources {
+		for _, endpoint := range resource.Endpoints {
+			if endpoint.Path == InspectionDatabaseEndpoint.Path {
+				registered = true
+				break
+			}
+		}
+	}
+	if !registered {
+		t.Fatal("database endpoint is not registered")
+	}
+}
+
+func TestInspectionNetworkEndpointContract(t *testing.T) {
+	if InspectionNetworkEndpoint.Path != "inspect/network" {
+		t.Fatalf("endpoint path = %q, want %q", InspectionNetworkEndpoint.Path, "inspect/network")
+	}
+	if InspectionNetworkEndpoint.Get.Handler == nil {
+		t.Fatal("network endpoint has no GET handler")
+	}
+	if InspectionNetworkEndpoint.Get.AllowUntrusted {
+		t.Fatal("network endpoint allows untrusted requests")
+	}
+	if InspectionNetworkEndpoint.Get.ProxyTarget {
+		t.Fatal("network endpoint proxies requests")
+	}
+
+	registered := false
+	for _, resource := range Server["microovn"].Resources {
+		for _, endpoint := range resource.Endpoints {
+			if endpoint.Path == InspectionNetworkEndpoint.Path {
+				registered = true
+				break
+			}
+		}
+	}
+	if !registered {
+		t.Fatal("network endpoint is not registered")
+	}
+}
+
+func TestInspectionDatabaseGetRejectsInvalidScope(t *testing.T) {
+	for _, target := range []string{
+		"/1.0/inspect/database",
+		"/1.0/inspect/database?scope=invalid",
+	} {
+		t.Run(target, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, target, nil)
+			recorder := httptest.NewRecorder()
+
+			response := inspectionDatabaseGet(nil, request)
+			if err := response.Render(recorder, request); err != nil {
+				t.Fatalf("failed to render response: %v", err)
+			}
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}

--- a/microovn/api/types/inspect.go
+++ b/microovn/api/types/inspect.go
@@ -1,0 +1,168 @@
+package types
+
+import "time"
+
+const (
+	InspectionSchemaVersion = 1
+)
+
+type InspectionScope string
+
+const (
+	InspectionScopeCluster InspectionScope = "cluster"
+	InspectionScopeLocal   InspectionScope = "local"
+)
+
+type InspectionMemberRole string
+
+const (
+	InspectionMemberRoleVoter   InspectionMemberRole = "voter"
+	InspectionMemberRoleStandby InspectionMemberRole = "standby"
+	InspectionMemberRoleSpare   InspectionMemberRole = "spare"
+)
+
+type InspectionReport struct {
+	SchemaVersion    int                        `json:"schema_version" yaml:"schema_version"`
+	Timestamp        time.Time                  `json:"timestamp" yaml:"timestamp"`
+	ExecutionContext InspectionExecutionContext `json:"execution_context" yaml:"execution_context"`
+	Summary          InspectionSummary          `json:"summary" yaml:"summary"`
+	DatabaseSummary  InspectionDatabaseSummary  `json:"database_summary" yaml:"database_summary"`
+	Results          []InspectionResult         `json:"results" yaml:"results"`
+}
+
+type InspectionStatus string
+
+const (
+	InspectionStatusPass    InspectionStatus = "PASS"
+	InspectionStatusWarning InspectionStatus = "WARNING"
+	InspectionStatusFail    InspectionStatus = "FAIL"
+	InspectionStatusUnknown InspectionStatus = "UNKNOWN"
+)
+
+type InspectionExecutionContext struct {
+	LocalNode     string               `json:"local_node" yaml:"local_node"`
+	MemberRole    InspectionMemberRole `json:"member_role" yaml:"member_role"`
+	Authoritative bool                 `json:"authoritative" yaml:"authoritative"`
+	Scope         InspectionScope      `json:"scope" yaml:"scope"`
+}
+
+type InspectionSummary struct {
+	Status InspectionStatus `json:"status" yaml:"status"`
+	Counts InspectionCounts `json:"counts" yaml:"counts"`
+}
+
+type InspectionCounts struct {
+	Pass    int `json:"pass" yaml:"pass"`
+	Warning int `json:"warning" yaml:"warning"`
+	Fail    int `json:"fail" yaml:"fail"`
+	Unknown int `json:"unknown" yaml:"unknown"`
+}
+
+type InspectionDatabaseSummary struct {
+	Northbound    InspectionDatabaseStatus       `json:"northbound" yaml:"northbound"`
+	Southbound    InspectionDatabaseStatus       `json:"southbound" yaml:"southbound"`
+	Communication InspectionCommunicationSummary `json:"communication" yaml:"communication"`
+}
+
+type InspectionDatabaseStatus struct {
+	Status              InspectionStatus `json:"status" yaml:"status"`
+	ActiveSchemaVersion string           `json:"active_schema_version,omitempty" yaml:"active_schema_version,omitempty"`
+	ExpectedMembers     int              `json:"expected_members" yaml:"expected_members"`
+	RespondingMembers   int              `json:"responding_members" yaml:"responding_members"`
+	Message             string           `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+type InspectionSchemaEvidence struct {
+	Database      string                           `json:"database" yaml:"database"`
+	ActiveVersion string                           `json:"active_version,omitempty" yaml:"active_version,omitempty"`
+	ActiveError   string                           `json:"active_error,omitempty" yaml:"active_error,omitempty"`
+	Members       []InspectionSchemaMemberEvidence `json:"members" yaml:"members"`
+}
+
+type InspectionSchemaMemberEvidence struct {
+	Node        string `json:"node" yaml:"node"`
+	Version     string `json:"version,omitempty" yaml:"version,omitempty"`
+	Unsupported bool   `json:"unsupported,omitempty" yaml:"unsupported,omitempty"`
+	Error       string `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+type InspectionCommunicationSummary struct {
+	Status  InspectionStatus `json:"status" yaml:"status"`
+	NBCfg   *int64           `json:"nb_cfg,omitempty" yaml:"nb_cfg,omitempty"`
+	SBCfg   *int64           `json:"sb_cfg,omitempty" yaml:"sb_cfg,omitempty"`
+	Message string           `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+type InspectionCommunicationEvidence struct {
+	NBCfg           *int64 `json:"nb_cfg,omitempty" yaml:"nb_cfg,omitempty"`
+	SBCfg           *int64 `json:"sb_cfg,omitempty" yaml:"sb_cfg,omitempty"`
+	NBReachable     *bool  `json:"nb_reachable,omitempty" yaml:"nb_reachable,omitempty"`
+	SBReachable     *bool  `json:"sb_reachable,omitempty" yaml:"sb_reachable,omitempty"`
+	Converged       *bool  `json:"converged,omitempty" yaml:"converged,omitempty"`
+	CollectionError string `json:"collection_error,omitempty" yaml:"collection_error,omitempty"`
+}
+
+type InspectionResult struct {
+	ID              string             `json:"id" yaml:"id"`
+	Category        string             `json:"category" yaml:"category"`
+	Status          InspectionStatus   `json:"status" yaml:"status"`
+	Summary         string             `json:"summary" yaml:"summary"`
+	Details         []InspectionDetail `json:"details,omitempty" yaml:"details,omitempty"`
+	Remediation     string             `json:"remediation,omitempty" yaml:"remediation,omitempty"`
+	CollectionError string             `json:"collection_error,omitempty" yaml:"collection_error,omitempty"`
+}
+
+type InspectionDetail struct {
+	Node    string            `json:"node,omitempty" yaml:"node,omitempty"`
+	ID      string            `json:"id" yaml:"id"`
+	Status  InspectionStatus  `json:"status,omitempty" yaml:"status,omitempty"`
+	Summary string            `json:"summary" yaml:"summary"`
+	Data    map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+}
+
+type InspectionNodeSnapshot struct {
+	NodeName    string                      `json:"node_name" yaml:"node_name"`
+	Address     string                      `json:"address" yaml:"address"`
+	Daemons     []InspectionDaemonState     `json:"daemons" yaml:"daemons"`
+	Environment []InspectionEnvironment     `json:"environment" yaml:"environment"`
+	Errors      []InspectionCollectionError `json:"errors,omitempty" yaml:"errors,omitempty"`
+}
+
+type InspectionDaemonState struct {
+	Name    string `json:"name" yaml:"name"`
+	Active  bool   `json:"active" yaml:"active"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+}
+
+type InspectionEnvironment struct {
+	Name string `json:"name" yaml:"name"`
+	Hash string `json:"hash" yaml:"hash"`
+}
+
+type InspectionCollectionError struct {
+	Node      string `json:"node,omitempty" yaml:"node,omitempty"`
+	FactGroup string `json:"fact_group" yaml:"fact_group"`
+	Source    string `json:"source,omitempty" yaml:"source,omitempty"`
+	Message   string `json:"message" yaml:"message"`
+}
+
+type InspectionDatabaseProbe struct {
+	Scope            InspectionScope                 `json:"scope" yaml:"scope"`
+	Schemas          []InspectionSchemaEvidence      `json:"schemas,omitempty" yaml:"schemas,omitempty"`
+	Communication    InspectionCommunicationEvidence `json:"communication" yaml:"communication"`
+	CollectionErrors []InspectionCollectionError     `json:"collection_errors,omitempty" yaml:"collection_errors,omitempty"`
+}
+
+type InspectionDHCPOptionEvidence struct {
+	UUID                 string            `json:"uuid" yaml:"uuid"`
+	CIDR                 string            `json:"cidr" yaml:"cidr"`
+	ExternalIDs          map[string]string `json:"external_ids,omitempty" yaml:"external_ids,omitempty"`
+	Ports                []string          `json:"ports" yaml:"ports"`
+	ClasslessStaticRoute []string          `json:"classless_static_route,omitempty" yaml:"classless_static_route,omitempty"`
+}
+
+type InspectionNetworkProbe struct {
+	Scope            InspectionScope                `json:"scope" yaml:"scope"`
+	DHCPOptions      []InspectionDHCPOptionEvidence `json:"dhcp_options" yaml:"dhcp_options"`
+	CollectionErrors []InspectionCollectionError    `json:"collection_errors,omitempty" yaml:"collection_errors,omitempty"`
+}

--- a/microovn/api/types/inspect_test.go
+++ b/microovn/api/types/inspect_test.go
@@ -1,0 +1,103 @@
+package types
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestInspectionJSONContract(t *testing.T) {
+	timestamp := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	report := InspectionReport{
+		SchemaVersion: InspectionSchemaVersion,
+		Timestamp:     timestamp,
+		ExecutionContext: InspectionExecutionContext{
+			LocalNode:     "node1",
+			MemberRole:    InspectionMemberRoleVoter,
+			Authoritative: true,
+			Scope:         InspectionScopeCluster,
+		},
+		Summary: InspectionSummary{
+			Status: InspectionStatusWarning,
+			Counts: InspectionCounts{Pass: 1, Warning: 1},
+		},
+		DatabaseSummary: InspectionDatabaseSummary{
+			Northbound: InspectionDatabaseStatus{Status: InspectionStatusPass},
+			Southbound: InspectionDatabaseStatus{Status: InspectionStatusWarning},
+			Communication: InspectionCommunicationSummary{
+				Status: InspectionStatusPass,
+			},
+		},
+		Results: []InspectionResult{
+			{ID: "first", Category: "cluster", Status: InspectionStatusPass, Summary: "first result"},
+			{ID: "second", Category: "database", Status: InspectionStatusWarning, Summary: "second result"},
+		},
+	}
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("failed to marshal inspection report: %v", err)
+	}
+
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("failed to decode inspection report: %v", err)
+	}
+	for _, key := range []string{"schema_version", "timestamp", "execution_context", "summary", "database_summary", "results"} {
+		if _, ok := wire[key]; !ok {
+			t.Errorf("inspection report is missing JSON field %q", key)
+		}
+	}
+	if len(wire) != 6 {
+		t.Errorf("inspection report has %d top-level fields, want 6", len(wire))
+	}
+
+	var encodedTimestamp string
+	if err := json.Unmarshal(wire["timestamp"], &encodedTimestamp); err != nil {
+		t.Fatalf("failed to decode timestamp: %v", err)
+	}
+	if encodedTimestamp != "2026-01-02T03:04:05Z" {
+		t.Errorf("timestamp is %q, want UTC RFC3339 encoding", encodedTimestamp)
+	}
+
+	var results []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(wire["results"], &results); err != nil {
+		t.Fatalf("failed to decode results: %v", err)
+	}
+	if len(results) != 2 || results[0].ID != "first" || results[1].ID != "second" {
+		t.Errorf("result order changed: %#v", results)
+	}
+
+	rawValue := "ssl:private-fixture-value"
+	hash := sha256.Sum256([]byte(rawValue))
+	snapshot := InspectionNodeSnapshot{
+		NodeName: "node1",
+		Environment: []InspectionEnvironment{{
+			Name: "OVN_KEY",
+			Hash: fmt.Sprintf("%x", hash),
+		}},
+		Errors: []InspectionCollectionError{{
+			FactGroup: "environment",
+			Message:   "unavailable",
+		}},
+	}
+
+	snapshotData, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("failed to marshal inspection snapshot: %v", err)
+	}
+	if bytes.Contains(snapshotData, []byte(rawValue)) {
+		t.Fatal("serialized snapshot contains a raw environment value")
+	}
+	if bytes.Contains(snapshotData, []byte(`"value"`)) {
+		t.Fatal("serialized snapshot exposes an environment value field")
+	}
+	if bytes.Contains(snapshotData, []byte(`"node"`)) {
+		t.Fatal("snapshot-local collection error includes an empty node field")
+	}
+}

--- a/microovn/bgp/redirect.go
+++ b/microovn/bgp/redirect.go
@@ -361,6 +361,7 @@ func createExternalNetworks(ctx context.Context, s state.State, bridges []types.
 	lrName := getLrName(s)
 	_, err := ovnCmd.NBCtlCluster(ctx,
 		s,
+		ovnCmd.DefaultDBStateWait,
 		"--",
 		"lr-add", lrName,
 		"--",
@@ -384,6 +385,7 @@ func createExternalNetworks(ctx context.Context, s state.State, bridges []types.
 
 		_, err = ovnCmd.NBCtlCluster(ctx,
 			s,
+			ovnCmd.DefaultDBStateWait,
 			"--",
 			// Create Logical Router Port
 			"lrp-add", lrName, lrpName, lrpMac,
@@ -432,6 +434,7 @@ func createVrf(ctx context.Context, s state.State, bridges []types.BgpBridge, ta
 
 	_, err := ovnCmd.NBCtlCluster(ctx,
 		s,
+		ovnCmd.DefaultDBStateWait,
 		"set", "Logical_Router", lrName,
 		"options:dynamic-routing=true",
 		fmt.Sprintf("options:dynamic-routing-vrf-id=%s", tableID),
@@ -444,6 +447,7 @@ func createVrf(ctx context.Context, s state.State, bridges []types.BgpBridge, ta
 		lrpName := getLrpName(s, brg.Bridge)
 		_, err = ovnCmd.NBCtlCluster(ctx,
 			s,
+			ovnCmd.DefaultDBStateWait,
 			"lrp-set-options", lrpName,
 			"dynamic-routing-maintain-vrf=true",
 			"dynamic-routing-redistribute=nat,lb",
@@ -553,6 +557,7 @@ func redirectBgp(ctx context.Context, s state.State, bridges []types.BgpBridge, 
 		// Create Logical Switch Port to which the BGP+BFD traffic will be redirected
 		_, err := ovnCmd.NBCtlCluster(ctx,
 			s,
+			ovnCmd.DefaultDBStateWait,
 			"--",
 			"lsp-add", lsName, bgpLsp,
 			"--",
@@ -604,7 +609,7 @@ func teardownAll(ctx context.Context, s state.State) error {
 	var allErrors error
 	// Find and remove Logical Router used for BGP redirect
 	logicalRouter := getLrName(s)
-	_, err := ovnCmd.NBCtlCluster(ctx, s, "lr-del", logicalRouter)
+	_, err := ovnCmd.NBCtlCluster(ctx, s, ovnCmd.DefaultDBStateWait, "lr-del", logicalRouter)
 	if err != nil {
 		allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete Logical Router '%s': %v", logicalRouter, err))
 	}
@@ -615,7 +620,7 @@ func teardownAll(ctx context.Context, s state.State) error {
 	}
 
 	// Find and remove Logical Switches used to connect to external networks on the local chassis
-	logicalSwitches, err := ovnCmd.NBCtlCluster(ctx, s, "--bare", "--columns", "name",
+	logicalSwitches, err := ovnCmd.NBCtlCluster(ctx, s, ovnCmd.DefaultDBStateWait, "--bare", "--columns", "name",
 		"find", "logical_switch", fmt.Sprintf("external-ids:%s=true", BgpManagedTag),
 	)
 	if err != nil {
@@ -627,7 +632,7 @@ func teardownAll(ctx context.Context, s state.State) error {
 			if !strings.HasPrefix(logicalSwitch, chassisSwitchNamePrefix) {
 				continue
 			}
-			_, err = ovnCmd.NBCtlCluster(ctx, s, "ls-del", logicalSwitch)
+			_, err = ovnCmd.NBCtlCluster(ctx, s, ovnCmd.DefaultDBStateWait, "ls-del", logicalSwitch)
 			if err != nil {
 				allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete Logical Switch '%s': %v", logicalSwitch, err))
 			}

--- a/microovn/client/client.go
+++ b/microovn/client/client.go
@@ -31,6 +31,52 @@ func GetServices(ctx context.Context, c microTypes.Client) (types.Services, erro
 	return services, nil
 }
 
+// GetNodeSnapshot returns inspection facts collected on the target node.
+func GetNodeSnapshot(ctx context.Context, c microTypes.Client) (types.InspectionNodeSnapshot, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	snapshot := types.InspectionNodeSnapshot{}
+	err := c.Query(queryCtx, "GET", types.APIVersion, &url.URL{Path: "inspect/snapshot"}, nil, &snapshot)
+	if err != nil {
+		return snapshot, fmt.Errorf("failed to get node inspection snapshot: %w", err)
+	}
+
+	return snapshot, nil
+}
+
+// GetDatabaseProbe returns inspection facts collected about cluster database
+func GetDatabaseProbe(ctx context.Context, c microTypes.Client, scope types.InspectionScope) (types.InspectionDatabaseProbe, error) {
+	if scope != types.InspectionScopeCluster && scope != types.InspectionScopeLocal {
+		return types.InspectionDatabaseProbe{}, fmt.Errorf("invalid inspection scope: %s", scope)
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	probe := types.InspectionDatabaseProbe{}
+	err := c.Query(queryCtx, "GET", types.APIVersion, &url.URL{Path: "inspect/database", RawQuery: "scope=" + string(scope)}, nil, &probe)
+	if err != nil {
+		return probe, fmt.Errorf("failed to get database inspection probe: %w", err)
+	}
+
+	return probe, nil
+}
+
+// GetNetworkProbe returns cluster-wide network inspection evidence.
+func GetNetworkProbe(ctx context.Context, c microTypes.Client) (types.InspectionNetworkProbe, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	probe := types.InspectionNetworkProbe{}
+	err := c.Query(queryCtx, "GET", types.APIVersion, &url.URL{Path: "inspect/network"}, nil, &probe)
+	if err != nil {
+		return probe, fmt.Errorf("failed to get network inspection probe: %w", err)
+	}
+
+	return probe, nil
+}
+
 // ReissueCertificate sends request to local MicroOVN cluster member to re-issue new certificate for
 // selected service.
 func ReissueCertificate(ctx context.Context, c microTypes.Client, serviceName string) (types.IssueCertificateResponse, error) {

--- a/microovn/client/client_test.go
+++ b/microovn/client/client_test.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func TestGetDatabaseProbeRejectsInvalidScope(t *testing.T) {
+	_, err := GetDatabaseProbe(context.Background(), nil, types.InspectionScope("invalid"))
+	if err == nil {
+		t.Fatal("GetDatabaseProbe returned nil error for invalid scope")
+	}
+}

--- a/microovn/cmd/microovn/inspect.go
+++ b/microovn/cmd/microovn/inspect.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/canonical/lxd/shared/i18n"
+	"github.com/canonical/microcluster/v3/microcluster"
+	"github.com/canonical/microovn/microovn/inspect"
+	"github.com/spf13/cobra"
+)
+
+type outputFormat string
+
+const (
+	formatText outputFormat = "text"
+	formatJSON outputFormat = "json"
+)
+
+type cmdInspect struct {
+	common           *CmdControl
+	flagVerbose      bool
+	flagOutputFormat outputFormat
+}
+
+func (f outputFormat) String() string {
+	return string(f)
+}
+
+func (f *outputFormat) Set(v string) error {
+	switch outputFormat(v) {
+	case formatJSON, formatText:
+		*f = outputFormat(v)
+		return nil
+	default:
+		return fmt.Errorf(i18n.G("Invalid format %q"), v)
+	}
+}
+
+func (f *outputFormat) Type() string {
+	return "string"
+}
+
+func (c *cmdInspect) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect the MicroOVN deployment",
+		RunE:  c.Run,
+	}
+
+	c.flagOutputFormat = formatText
+
+	cmd.Flags().BoolVarP(&c.flagVerbose, "verbose", "v", false, "Show full inspection results")
+	cmd.Flags().VarP(&c.flagOutputFormat, "format", "f", i18n.G("Format (text|json)"))
+	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		c.common.ExitCode = 2
+		return err
+	})
+
+	return cmd
+}
+
+func (c *cmdInspect) Run(cmd *cobra.Command, args []string) error {
+	c.common.ExitCode = 2
+
+	if len(args) != 0 {
+		return errors.New(i18n.G("inspect accepts no positional arguments"))
+	}
+	if c.flagVerbose && c.flagOutputFormat == formatJSON {
+		return errors.New(i18n.G("--verbose and --format=json cannot be used together"))
+	}
+
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	report, err := inspect.Orchestrate(cmd.Context(), inspect.Dependencies{
+		Cluster: m,
+		Client:  cli,
+		Checks:  inspect.DefaultChecks(),
+	})
+	if err != nil {
+		return err
+	}
+
+	if c.flagOutputFormat == formatJSON {
+		err = inspect.RenderJSON(cmd.OutOrStdout(), report)
+	} else {
+		err = inspect.RenderText(cmd.OutOrStdout(), report, c.flagVerbose)
+	}
+	if err != nil {
+		return err
+	}
+
+	c.common.ExitCode = inspect.ExitCode(report)
+	return nil
+}

--- a/microovn/cmd/microovn/inspect_test.go
+++ b/microovn/cmd/microovn/inspect_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestInspectRejectsInvalidInvocation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "positional argument", args: []string{"node1"}},
+		{name: "verbose JSON", args: []string{"--verbose", "--format=json"}},
+		{name: "invalid format", args: []string{"--format=yaml"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			common := &CmdControl{}
+			command := (&cmdInspect{common: common}).Command()
+			command.SetArgs(test.args)
+			command.SilenceErrors = true
+			command.SilenceUsage = true
+
+			err := command.Execute()
+			if err == nil {
+				t.Fatal("inspect accepted an invalid invocation")
+			}
+
+			if common.ExitCode != 2 {
+				t.Fatalf("inspect exit code is %d, want 2", common.ExitCode)
+			}
+			if got := commandExitCode(err, common.ExitCode); got != 2 {
+				t.Fatalf("commandExitCode returned %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestCommandExitCode(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		reportExitCode int
+		want           int
+	}{
+		{name: "healthy report", reportExitCode: 0, want: 0},
+		{name: "report finding", reportExitCode: 1, want: 1},
+		{name: "other command error", err: errors.New("failed"), want: 1},
+		{name: "configured command error", err: errors.New("failed"), reportExitCode: 2, want: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := commandExitCode(test.err, test.reportExitCode); got != test.want {
+				t.Fatalf("commandExitCode returned %d, want %d", got, test.want)
+			}
+		})
+	}
+}

--- a/microovn/cmd/microovn/main.go
+++ b/microovn/cmd/microovn/main.go
@@ -25,6 +25,7 @@ type CmdControl struct {
 	FlagLogDebug   bool
 	FlagLogVerbose bool
 	FlagStateDir   string
+	ExitCode       int
 
 	asker cli.Asker
 }
@@ -68,6 +69,9 @@ func main() {
 	var cmdWaitReady = cmdWaitReady{common: &commonCmd}
 	app.AddCommand(cmdWaitReady.Command())
 
+	var cmdInspect = cmdInspect{common: &commonCmd}
+	app.AddCommand(cmdInspect.Command())
+
 	// Nested.
 	var cmdCluster = cmdCluster{common: &commonCmd}
 	app.AddCommand(cmdCluster.Command())
@@ -83,8 +87,19 @@ func main() {
 
 	app.InitDefaultHelpCmd()
 
-	err := app.Execute()
-	if err != nil {
-		os.Exit(1)
+	exitCode := commandExitCode(app.Execute(), commonCmd.ExitCode)
+	if exitCode != 0 {
+		os.Exit(exitCode)
 	}
+}
+
+func commandExitCode(err error, configuredExitCode int) int {
+	if configuredExitCode != 0 {
+		return configuredExitCode
+	}
+	if err != nil {
+		return 1
+	}
+
+	return 0
 }

--- a/microovn/go.mod
+++ b/microovn/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/canonical/lxd v0.0.0-20251211093832-ac7a1edf4d94
 	github.com/canonical/microcluster/v3 v3.0.0-20260121114850-ead5e49aa73b
 	github.com/gorilla/mux v1.8.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.10.2
 	github.com/zitadel/logging v0.6.2
@@ -28,7 +29,6 @@ require (
 	github.com/google/renameio v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gosexy/gettext v0.0.0-20160830220431-74466a0a0c4a // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/microovn/inspect/checks.go
+++ b/microovn/inspect/checks.go
@@ -1,0 +1,73 @@
+package inspect
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+type memberSnapshotError struct {
+	node          string
+	snapshotFound bool
+	err           string
+}
+
+func forEachMemberSnapshot(
+	input Input,
+	factGroup string,
+	callback func(string, types.InspectionNodeSnapshot),
+) []memberSnapshotError {
+	var unavailable []memberSnapshotError
+	for _, node := range getSortedMemberNames(input) {
+		snapshot, found := input.Snapshots[node]
+		if !found {
+			unavailable = append(unavailable, memberSnapshotError{
+				node: node,
+				err:  snapshotCollectionError(input, node),
+			})
+			continue
+		}
+
+		var errors []string
+		for _, collectionError := range snapshot.Errors {
+			if collectionError.FactGroup == factGroup {
+				errors = append(errors, collectionError.Message)
+			}
+		}
+		if len(errors) > 0 {
+			slices.Sort(errors)
+			unavailable = append(unavailable, memberSnapshotError{
+				node:          node,
+				snapshotFound: true,
+				err:           strings.Join(errors, "; "),
+			})
+			continue
+		}
+
+		callback(node, snapshot)
+	}
+
+	return unavailable
+}
+
+func snapshotCollectionError(input Input, node string) string {
+	var errors []string
+	for _, collectionError := range input.CollectionErrors {
+		if collectionError.Node == node &&
+			(collectionError.FactGroup == "member" || collectionError.FactGroup == "snapshot") {
+			errors = append(errors, collectionError.Message)
+		}
+	}
+	slices.Sort(errors)
+	return strings.Join(errors, "; ")
+}
+
+func getSortedMemberNames(input Input) []string {
+	memberNames := make([]string, 0, len(input.Members))
+	for _, member := range input.Members {
+		memberNames = append(memberNames, member.Name)
+	}
+	slices.Sort(memberNames)
+	return memberNames
+}

--- a/microovn/inspect/collect.go
+++ b/microovn/inspect/collect.go
@@ -1,0 +1,422 @@
+package inspect
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/netip"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/canonical/microcluster/v3/microcluster"
+	microTypes "github.com/canonical/microcluster/v3/microcluster/types"
+	"github.com/canonical/microovn/microovn/api/types"
+	"github.com/canonical/microovn/microovn/client"
+	"github.com/canonical/microovn/microovn/ovn/cmd"
+)
+
+func collectInput(ctx context.Context, cluster *microcluster.MicroCluster, local microTypes.Client) (Input, error) {
+	input := Input{
+		Snapshots: make(map[string]types.InspectionNodeSnapshot),
+		Schemas:   make(map[string]types.InspectionSchemaEvidence),
+	}
+
+	execution, err := collectExecutionContext(ctx, cluster)
+	if err != nil {
+		return Input{}, err
+	}
+	input.ExecutionContext = execution
+
+	snapshot, err := client.GetNodeSnapshot(ctx, local)
+	if err != nil {
+		input.CollectionErrors = append(input.CollectionErrors, types.InspectionCollectionError{
+			Node:      input.ExecutionContext.LocalNode,
+			FactGroup: "snapshot",
+			Message:   fmt.Sprintf("failed to get local node snapshot: %v", err),
+		})
+	} else {
+		snapshot.NodeName = input.ExecutionContext.LocalNode
+		input.Snapshots[snapshot.NodeName] = snapshot
+	}
+
+	if input.ExecutionContext.Authoritative {
+		members, err := cluster.GetClusterMembers(ctx)
+		if err != nil {
+			input.CollectionErrors = append(input.CollectionErrors, types.InspectionCollectionError{
+				Node:      input.ExecutionContext.LocalNode,
+				FactGroup: "member",
+				Message:   fmt.Sprintf("failed to get cluster members: %v", err),
+			})
+			return input, nil
+		}
+		slices.SortFunc(
+			members,
+			func(a, b microTypes.ClusterMember) int {
+				return cmp.Compare(a.Name, b.Name)
+			},
+		)
+		input.Members = members
+		collectClusterEvidence(ctx, cluster, local, &input)
+	} else {
+		collectLocalEvidence(ctx, local, &input)
+	}
+
+	slices.SortFunc(
+		input.CollectionErrors,
+		func(a, b types.InspectionCollectionError) int {
+			if result := cmp.Compare(a.Node, b.Node); result != 0 {
+				return result
+			}
+			if result := cmp.Compare(a.FactGroup, b.FactGroup); result != 0 {
+				return result
+			}
+			return cmp.Compare(a.Message, b.Message)
+		},
+	)
+
+	return input, nil
+}
+
+func collectExecutionContext(ctx context.Context, cluster *microcluster.MicroCluster) (types.InspectionExecutionContext, error) {
+	status, err := cluster.Status(ctx)
+	if err != nil {
+		return types.InspectionExecutionContext{}, fmt.Errorf("failed to get local member status: %w", err)
+	}
+
+	members, err := cluster.GetDqliteClusterMembers()
+	if err != nil {
+		return types.InspectionExecutionContext{}, dqliteMembersError(err)
+	}
+
+	return resolveExecutionContext(status, members)
+}
+
+func dqliteMembersError(err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return errors.New("MicroOVN is not initialized")
+	}
+
+	return fmt.Errorf("failed to get local dqlite members: %w", err)
+}
+
+func resolveExecutionContext(status *microTypes.Server, members []microTypes.DqliteMember) (types.InspectionExecutionContext, error) {
+
+	var matches []microTypes.DqliteMember
+	for _, member := range members {
+		if member.Name == status.Name {
+			matches = append(matches, member)
+		}
+	}
+
+	if len(matches) == 0 {
+		for _, member := range members {
+			if sameMemberAddress(member.Address, status.Address) {
+				matches = append(matches, member)
+			}
+		}
+	}
+
+	if len(matches) != 1 {
+		return types.InspectionExecutionContext{}, fmt.Errorf(
+			"expected one local dqlite member, found %d",
+			len(matches),
+		)
+	}
+
+	role := matches[0].Role
+	name := matches[0].Name
+	execution := types.InspectionExecutionContext{
+		LocalNode: name,
+	}
+
+	switch role {
+	case string(types.InspectionMemberRoleVoter):
+		execution.Authoritative = true
+		execution.Scope = types.InspectionScopeCluster
+		execution.MemberRole = types.InspectionMemberRoleVoter
+	case string(types.InspectionMemberRoleSpare):
+		execution.Scope = types.InspectionScopeLocal
+		execution.MemberRole = types.InspectionMemberRoleSpare
+	case "stand-by", string(types.InspectionMemberRoleStandby):
+		// Normalize dqlite role to a canonical member role used in the inspection context
+		execution.Scope = types.InspectionScopeLocal
+		execution.MemberRole = types.InspectionMemberRoleStandby
+	default:
+		return types.InspectionExecutionContext{}, fmt.Errorf("unsupported local member role %q", role)
+	}
+
+	return execution, nil
+}
+
+func sameMemberAddress(memberAddress string, statusAddress microTypes.AddrPort) bool {
+	if memberAddress == statusAddress.String() {
+		return true
+	}
+
+	parsed, err := netip.ParseAddrPort(memberAddress)
+	return err == nil && parsed.Addr() == statusAddress.Addr()
+}
+
+func collectLocalEvidence(ctx context.Context, local microTypes.Client, input *Input) {
+	probe, err := client.GetDatabaseProbe(ctx, local, types.InspectionScopeLocal)
+	if err != nil {
+		input.CollectionErrors = append(input.CollectionErrors, types.InspectionCollectionError{
+			Node:      input.ExecutionContext.LocalNode,
+			FactGroup: "database",
+			Message:   fmt.Sprintf("failed to get local database probe: %v", err),
+		})
+	}
+	input.Communication = probe.Communication
+	for _, schema := range probe.Schemas {
+		input.Schemas[schema.Database] = schema
+	}
+
+	input.DesiredStateAvailable = false
+}
+
+func collectClusterEvidence(ctx context.Context, cluster *microcluster.MicroCluster, local microTypes.Client, input *Input) {
+	input.DesiredStateAvailable = true
+
+	// Services
+	services, err := client.GetServices(ctx, local)
+	if err != nil {
+		input.CollectionErrors = append(input.CollectionErrors, types.InspectionCollectionError{
+			Node:      input.ExecutionContext.LocalNode,
+			FactGroup: "services",
+			Message:   fmt.Sprintf("failed to get services: %v", err),
+		})
+		input.DesiredStateAvailable = false
+	}
+	input.Services = services
+
+	// Database probe
+	dbProbe, err := client.GetDatabaseProbe(ctx, local, types.InspectionScopeCluster)
+	if err != nil {
+		input.CollectionErrors = append(input.CollectionErrors, types.InspectionCollectionError{
+			Node:      input.ExecutionContext.LocalNode,
+			FactGroup: "database",
+			Message:   fmt.Sprintf("failed to get local database probe: %v", err),
+		})
+	}
+	input.Communication = dbProbe.Communication
+	for _, schema := range dbProbe.Schemas {
+		input.Schemas[schema.Database] = schema
+	}
+
+	// Schema
+	for _, dbType := range []cmd.OvsdbType{
+		cmd.OvsdbTypeNBLocal,
+		cmd.OvsdbTypeSBLocal,
+	} {
+		evidence, errs := collectClusterSchema(ctx, local, dbType, input.Members)
+		if evidence.Database != "" {
+			input.Schemas[evidence.Database] = evidence
+		}
+		input.CollectionErrors = append(input.CollectionErrors, errs...)
+	}
+
+	// Cluster network probe
+	netProbe, err := client.GetNetworkProbe(ctx, local)
+	if err != nil {
+		input.CollectionErrors = append(input.CollectionErrors, types.InspectionCollectionError{
+			Node:      input.ExecutionContext.LocalNode,
+			FactGroup: "network",
+			Message:   fmt.Sprintf("failed to get network probe: %v", err),
+		})
+	}
+	input.Network = netProbe
+
+	// Remote snapshots
+	var memberClients []memberClient
+	for _, member := range input.Members {
+		if member.Name == input.ExecutionContext.LocalNode {
+			continue
+		}
+		mClient, err := cluster.RemoteClient(member.Address.String())
+		if err != nil {
+			input.CollectionErrors = append(input.CollectionErrors, types.InspectionCollectionError{
+				Node:      member.Name,
+				FactGroup: "member",
+				Message:   fmt.Sprintf("failed to get member client: %v", err),
+			})
+			continue
+		}
+		memberClients = append(memberClients, memberClient{member: member, client: mClient})
+	}
+
+	snapshots, errs := getMemberNodeSnapshots(ctx, memberClients)
+	input.CollectionErrors = append(input.CollectionErrors, errs...)
+	for _, snapshot := range snapshots {
+		input.Snapshots[snapshot.NodeName] = snapshot
+	}
+}
+
+func collectClusterSchema(
+	ctx context.Context,
+	local microTypes.Client,
+	dbType cmd.OvsdbType,
+	members []microTypes.ClusterMember,
+) (types.InspectionSchemaEvidence, []types.InspectionCollectionError) {
+	spec, err := cmd.NewOvsdbSpec(dbType)
+	if err != nil {
+		return types.InspectionSchemaEvidence{}, []types.InspectionCollectionError{{
+			FactGroup: "database",
+			Message:   err.Error(),
+		}}
+	}
+
+	evidence := types.InspectionSchemaEvidence{
+		Database: spec.ShortName,
+		Members:  make([]types.InspectionSchemaMemberEvidence, len(members)),
+	}
+
+	memberByAddress := make(map[string]int, len(members))
+	for index, member := range members {
+		evidence.Members[index] = types.InspectionSchemaMemberEvidence{
+			Node:  member.Name,
+			Error: "schema response missing",
+		}
+		memberByAddress[member.Address.Addr().String()] = index
+	}
+
+	active, activeResult := client.GetActiveOvsdbSchemaVersion(ctx, local, spec)
+	switch activeResult {
+	case types.OvsdbSchemaFetchErrorNone:
+		evidence.ActiveVersion = active
+	case types.OvsdbSchemaFetchErrorNotSupported:
+		evidence.ActiveError = "active schema API is unsupported"
+	default:
+		evidence.ActiveError = "active schema version could not be collected"
+	}
+
+	report, reportErr := client.GetAllExpectedOvsdbSchemaVersions(ctx, local, spec)
+	if reportErr != nil {
+		return evidence, []types.InspectionCollectionError{{
+			FactGroup: "database",
+			Message: fmt.Sprintf(
+				"failed to get expected %s schema versions: %v",
+				spec.FriendlyName,
+				reportErr,
+			),
+		}}
+	}
+
+	var collectionErrors []types.InspectionCollectionError
+	for _, result := range report {
+		index, found := memberByAddress[result.Host]
+		if !found {
+			collectionErrors = append(collectionErrors, types.InspectionCollectionError{
+				FactGroup: "database",
+				Message:   fmt.Sprintf("schema response from unknown address %q", result.Host),
+			})
+			continue
+		}
+
+		memberEvidence := types.InspectionSchemaMemberEvidence{
+			Node: members[index].Name,
+		}
+		switch result.Error {
+		case types.OvsdbSchemaFetchErrorNone:
+			memberEvidence.Version = result.SchemaVersion
+		case types.OvsdbSchemaFetchErrorNotSupported:
+			memberEvidence.Unsupported = true
+		default:
+			memberEvidence.Error = "schema version could not be collected"
+		}
+		evidence.Members[index] = memberEvidence
+	}
+
+	slices.SortFunc(evidence.Members, func(a, b types.InspectionSchemaMemberEvidence) int {
+		return cmp.Compare(a.Node, b.Node)
+	})
+
+	return evidence, collectionErrors
+}
+
+func getMemberNodeSnapshots(ctx context.Context, members []memberClient) ([]types.InspectionNodeSnapshot, []types.InspectionCollectionError) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var snapshots []types.InspectionNodeSnapshot
+	var errors []types.InspectionCollectionError
+
+	appendError := func(err types.InspectionCollectionError) {
+		mu.Lock()
+		defer mu.Unlock()
+		errors = append(errors, err)
+	}
+
+	appendSnapshot := func(snapshot types.InspectionNodeSnapshot) {
+		mu.Lock()
+		defer mu.Unlock()
+		snapshots = append(snapshots, snapshot)
+	}
+
+	sem := make(chan struct{}, 4)
+
+	for _, m := range members {
+		wg.Add(1)
+		go func(m memberClient) {
+			defer wg.Done()
+			if err := ctx.Err(); err != nil {
+				appendError(types.InspectionCollectionError{
+					Node:      m.member.Name,
+					FactGroup: "member",
+					Message:   fmt.Sprintf("failed to get member node snapshot: %v", err),
+				})
+				return
+			}
+
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				mu.Lock()
+				errors = append(errors, types.InspectionCollectionError{
+					Node:      m.member.Name,
+					FactGroup: "member",
+					Message:   fmt.Sprintf("failed to get member node snapshot: %v", ctx.Err()),
+				})
+				mu.Unlock()
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+
+			snapshot, err := client.GetNodeSnapshot(ctx, m.client)
+			if err != nil {
+				appendError(types.InspectionCollectionError{
+					Node:      m.member.Name,
+					FactGroup: "member",
+					Message:   fmt.Sprintf("failed to get member node snapshot: %v", err),
+				})
+				return
+			}
+			snapshot.NodeName = m.member.Name
+			appendSnapshot(snapshot)
+		}(m)
+	}
+
+	wg.Wait()
+
+	slices.SortFunc(
+		snapshots,
+		func(a, b types.InspectionNodeSnapshot) int {
+			return cmp.Compare(a.NodeName, b.NodeName)
+		},
+	)
+	slices.SortFunc(
+		errors,
+		func(a, b types.InspectionCollectionError) int {
+			if result := cmp.Compare(a.Node, b.Node); result != 0 {
+				return result
+			}
+			return cmp.Compare(a.FactGroup, b.FactGroup)
+		},
+	)
+
+	return snapshots, errors
+}

--- a/microovn/inspect/collect_test.go
+++ b/microovn/inspect/collect_test.go
@@ -1,0 +1,217 @@
+package inspect
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"os"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/canonical/microcluster/v3/microcluster"
+	microTypes "github.com/canonical/microcluster/v3/microcluster/types"
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+type inspectionClient struct {
+	query func(context.Context, any) error
+}
+
+func (client inspectionClient) URL() *url.URL {
+	return nil
+}
+
+func (client inspectionClient) HTTP() *http.Client {
+	return nil
+}
+
+func (client inspectionClient) Query(ctx context.Context, _ string, _ microTypes.EndpointPrefix, _ *url.URL, _ any, out any) error {
+	return client.query(ctx, out)
+}
+
+func (inspectionClient) QueryRaw(context.Context, string, microTypes.EndpointPrefix, *url.URL, any) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (inspectionClient) Websocket(context.Context, microTypes.EndpointPrefix, *url.URL) (*websocket.Conn, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (inspectionClient) SetClusterNotification() {}
+
+func (client inspectionClient) UseTarget(string) microTypes.Client {
+	return client
+}
+
+func TestResolveExecutionContext(t *testing.T) {
+	statusAddress, err := microTypes.ParseAddrPort("10.0.0.1:8443")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		status        *microTypes.Server
+		members       []microTypes.DqliteMember
+		wantNode      string
+		wantRole      types.InspectionMemberRole
+		authoritative bool
+		wantError     bool
+	}{
+		{
+			name:          "matches voter by name",
+			status:        &microTypes.Server{Name: "node1", Address: statusAddress},
+			members:       []microTypes.DqliteMember{{Name: "node1", Address: "10.0.0.1:9000", Role: "voter"}},
+			wantNode:      "node1",
+			wantRole:      "voter",
+			authoritative: true,
+		},
+		{
+			name:     "falls back to normalized host address",
+			status:   &microTypes.Server{Name: "renamed", Address: statusAddress},
+			members:  []microTypes.DqliteMember{{Name: "node1", Address: "10.0.0.1:9000", Role: "stand-by"}},
+			wantNode: "node1",
+			wantRole: "standby",
+		},
+		{
+			name:      "rejects ambiguous name",
+			status:    &microTypes.Server{Name: "node1", Address: statusAddress},
+			members:   []microTypes.DqliteMember{{Name: "node1", Role: "voter"}, {Name: "node1", Role: "stand-by"}},
+			wantError: true,
+		},
+		{
+			name:      "rejects unsupported role",
+			status:    &microTypes.Server{Name: "node1", Address: statusAddress},
+			members:   []microTypes.DqliteMember{{Name: "node1", Role: "pending"}},
+			wantError: true,
+		},
+		{
+			name:      "rejects missing member",
+			status:    &microTypes.Server{Name: "node1", Address: statusAddress},
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			execution, err := resolveExecutionContext(test.status, test.members)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("resolveExecutionContext returned %#v, want error", execution)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if execution.LocalNode != test.wantNode || execution.MemberRole != test.wantRole || execution.Authoritative != test.authoritative {
+				t.Fatalf("execution context = %#v", execution)
+			}
+		})
+	}
+}
+
+func TestDqliteMembersError(t *testing.T) {
+	t.Run("missing cluster state is uninitialized", func(t *testing.T) {
+		err := dqliteMembersError(&os.PathError{Op: "open", Path: "cluster.yaml", Err: os.ErrNotExist})
+		if err.Error() != "MicroOVN is not initialized" {
+			t.Fatalf("error = %q", err)
+		}
+	})
+
+	t.Run("other errors preserve cause", func(t *testing.T) {
+		cause := errors.New("read failed")
+		err := dqliteMembersError(cause)
+		if !errors.Is(err, cause) {
+			t.Fatalf("error %q does not preserve cause", err)
+		}
+	})
+}
+
+func TestGetMemberNodeSnapshotsPreservesPartialResults(t *testing.T) {
+	members := []memberClient{
+		{
+			member: microTypes.ClusterMember{ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: "node2"}},
+			client: inspectionClient{query: func(context.Context, any) error { return errors.New("peer unavailable") }},
+		},
+		{
+			member: microTypes.ClusterMember{ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: "node1"}},
+			client: inspectionClient{query: func(_ context.Context, out any) error {
+				*out.(*types.InspectionNodeSnapshot) = types.InspectionNodeSnapshot{NodeName: "wrong-name"}
+				return nil
+			}},
+		},
+	}
+
+	snapshots, collectionErrors := getMemberNodeSnapshots(context.Background(), members)
+	if len(snapshots) != 1 || snapshots[0].NodeName != "node1" {
+		t.Fatalf("snapshots = %#v", snapshots)
+	}
+	if len(collectionErrors) != 1 || collectionErrors[0].Node != "node2" {
+		t.Fatalf("collection errors = %#v", collectionErrors)
+	}
+}
+
+func TestGetMemberNodeSnapshotsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var queryCalled atomic.Bool
+	members := []memberClient{{
+		member: microTypes.ClusterMember{ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: "node1"}},
+		client: inspectionClient{query: func(context.Context, any) error {
+			queryCalled.Store(true)
+			return nil
+		}},
+	}}
+
+	snapshots, collectionErrors := getMemberNodeSnapshots(ctx, members)
+	if len(snapshots) != 0 || len(collectionErrors) != 1 {
+		t.Fatalf("snapshots = %#v, errors = %#v", snapshots, collectionErrors)
+	}
+	if collectionErrors[0].Message == "" {
+		t.Fatal("cancellation error is empty")
+	}
+	if queryCalled.Load() {
+		t.Fatal("query called after cancellation")
+	}
+}
+
+func TestOrchestrateUsesInjectedCollectionAndChecks(t *testing.T) {
+	input := Input{
+		ExecutionContext: types.InspectionExecutionContext{Authoritative: true},
+		Schemas:          make(map[string]types.InspectionSchemaEvidence),
+	}
+	checks := []Check{
+		fixedCheck{results: []types.InspectionResult{{ID: "first", Status: types.InspectionStatusPass}}},
+		fixedCheck{results: []types.InspectionResult{{ID: "second", Status: types.InspectionStatusWarning}}},
+	}
+	collectCalls := 0
+
+	report, err := Orchestrate(context.Background(), Dependencies{
+		Checks: checks,
+		CollectInput: func(context.Context, *microcluster.MicroCluster, microTypes.Client) (Input, error) {
+			collectCalls++
+			return input, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if collectCalls != 1 {
+		t.Fatalf("collect calls = %d, want 1", collectCalls)
+	}
+	var resultIDs []string
+	for _, result := range report.Results {
+		resultIDs = append(resultIDs, result.ID)
+	}
+	if !reflect.DeepEqual(resultIDs, []string{"first", "second"}) {
+		t.Fatalf("result order = %#v", resultIDs)
+	}
+	if report.Summary.Status != types.InspectionStatusWarning {
+		t.Fatalf("summary = %#v", report.Summary)
+	}
+}

--- a/microovn/inspect/database.go
+++ b/microovn/inspect/database.go
@@ -1,0 +1,246 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+type DatabaseCheck struct{}
+
+func (DatabaseCheck) Name() string {
+	return "database"
+}
+
+func (DatabaseCheck) Run(_ context.Context, input Input) []types.InspectionResult {
+	if !input.ExecutionContext.Authoritative {
+		return []types.InspectionResult{nonAuthoritativeDatabaseResult(input)}
+	}
+
+	members := getSortedMemberNames(input)
+	var results []types.InspectionResult
+	for _, database := range []string{"nb", "sb"} {
+		results = append(results, databaseSchemaResults(database, input.Schemas[database], members)...)
+	}
+	results = append(results, databaseCommunicationResult(input.Communication))
+	if collectionError := databaseCollectionError(input); collectionError != "" {
+		for index := range results {
+			if results[index].Status == types.InspectionStatusUnknown {
+				if results[index].CollectionError == "" {
+					results[index].CollectionError = collectionError
+				} else {
+					results[index].CollectionError += "; " + collectionError
+				}
+				break
+			}
+		}
+	}
+	return results
+}
+
+func databaseSchemaResults(database string, evidence types.InspectionSchemaEvidence, members []string) []types.InspectionResult {
+	byNode := make(map[string]types.InspectionSchemaMemberEvidence, len(evidence.Members))
+	for _, member := range evidence.Members {
+		byNode[member.Node] = member
+	}
+
+	var mismatches []types.InspectionDetail
+	var unavailable []types.InspectionDetail
+	var collectionErrors []string
+	if evidence.ActiveVersion == "" || evidence.ActiveError != "" {
+		summary := "Active schema version is unavailable"
+		if evidence.ActiveError != "" {
+			summary = evidence.ActiveError
+			collectionErrors = append(collectionErrors, evidence.ActiveError)
+		}
+		unavailable = append(unavailable, types.InspectionDetail{
+			ID:      "active-schema",
+			Status:  types.InspectionStatusUnknown,
+			Summary: summary,
+		})
+	}
+
+	if len(members) == 0 {
+		unavailable = append(unavailable, types.InspectionDetail{
+			ID:      "schema-members",
+			Status:  types.InspectionStatusUnknown,
+			Summary: "Expected cluster members are unavailable",
+		})
+	}
+
+	for _, node := range members {
+		member, found := byNode[node]
+		switch {
+		case !found:
+			unavailable = append(unavailable, schemaCoverageDetail(node, "Schema response is missing"))
+		case member.Unsupported:
+			unavailable = append(unavailable, schemaCoverageDetail(node, "Schema API is unsupported"))
+		case member.Error != "":
+			unavailable = append(unavailable, schemaCoverageDetail(node, member.Error))
+			collectionErrors = append(collectionErrors, fmt.Sprintf("%s: %s", node, member.Error))
+		case member.Version == "":
+			unavailable = append(unavailable, schemaCoverageDetail(node, "Schema version is unavailable"))
+		case evidence.ActiveVersion != "" && member.Version != evidence.ActiveVersion:
+			mismatches = append(mismatches, types.InspectionDetail{
+				Node:    node,
+				ID:      "schema-version",
+				Status:  types.InspectionStatusFail,
+				Summary: "Expected schema version does not match the active version",
+				Data: map[string]string{
+					"active_version":   evidence.ActiveVersion,
+					"expected_version": member.Version,
+				},
+			})
+		}
+	}
+
+	var results []types.InspectionResult
+	if len(mismatches) > 0 {
+		results = append(results, types.InspectionResult{
+			ID:          "database-schema-mismatch-" + database,
+			Category:    "database",
+			Status:      types.InspectionStatusFail,
+			Summary:     strings.ToUpper(database) + " schema versions do not match",
+			Details:     mismatches,
+			Remediation: "Upgrade or reconcile members whose schema version differs from the active database schema.",
+		})
+	}
+	if len(unavailable) > 0 {
+		results = append(results, types.InspectionResult{
+			ID:              "database-schema-coverage-" + database,
+			Category:        "database",
+			Status:          types.InspectionStatusUnknown,
+			Summary:         strings.ToUpper(database) + " schema evidence is incomplete",
+			Details:         unavailable,
+			Remediation:     "Restore schema collection or upgrade members with unsupported schema APIs.",
+			CollectionError: strings.Join(collectionErrors, "; "),
+		})
+	}
+	if len(results) > 0 {
+		return results
+	}
+
+	return []types.InspectionResult{{
+		ID:       "database-schema-" + database,
+		Category: "database",
+		Status:   types.InspectionStatusPass,
+		Summary:  strings.ToUpper(database) + " schema versions match",
+	}}
+}
+
+func schemaCoverageDetail(node string, summary string) types.InspectionDetail {
+	return types.InspectionDetail{
+		Node:    node,
+		ID:      "schema-version",
+		Status:  types.InspectionStatusUnknown,
+		Summary: summary,
+	}
+}
+
+func databaseCommunicationResult(evidence types.InspectionCommunicationEvidence) types.InspectionResult {
+	summary := summarizeCommunication(evidence)
+	result := types.InspectionResult{
+		ID:              "database-communication",
+		Category:        "database",
+		Status:          summary.Status,
+		Summary:         summary.Message,
+		CollectionError: evidence.CollectionError,
+		Details: []types.InspectionDetail{{
+			ID:      "database-communication",
+			Status:  summary.Status,
+			Summary: summary.Message,
+			Data:    communicationData(evidence),
+		}},
+	}
+
+	switch summary.Status {
+	case types.InspectionStatusPass:
+		result.Summary = "Database communication is healthy"
+		result.Details[0].Summary = result.Summary
+	case types.InspectionStatusWarning:
+		result.Remediation = "Investigate Southbound database processing and convergence."
+	case types.InspectionStatusFail:
+		result.Remediation = "Restore connectivity to the unreachable OVN database."
+	case types.InspectionStatusUnknown:
+		result.Remediation = "Restore database communication evidence collection."
+	}
+
+	return result
+}
+
+func communicationData(evidence types.InspectionCommunicationEvidence) map[string]string {
+	data := make(map[string]string)
+	if evidence.NBCfg != nil {
+		data["nb_cfg"] = fmt.Sprintf("%d", *evidence.NBCfg)
+	}
+	if evidence.SBCfg != nil {
+		data["sb_cfg"] = fmt.Sprintf("%d", *evidence.SBCfg)
+	}
+	if evidence.NBReachable != nil {
+		data["nb_reachable"] = fmt.Sprintf("%t", *evidence.NBReachable)
+	}
+	if evidence.SBReachable != nil {
+		data["sb_reachable"] = fmt.Sprintf("%t", *evidence.SBReachable)
+	}
+	if evidence.Converged != nil {
+		data["converged"] = fmt.Sprintf("%t", *evidence.Converged)
+	}
+	return data
+}
+
+func nonAuthoritativeDatabaseResult(input Input) types.InspectionResult {
+	result := types.InspectionResult{
+		ID:          "database",
+		Category:    "database",
+		Status:      types.InspectionStatusUnknown,
+		Summary:     "Cluster database health cannot be determined from a non-voting member",
+		Remediation: "Run the inspection on a voting member.",
+	}
+
+	for _, database := range []string{"nb", "sb"} {
+		evidence := input.Schemas[database]
+		if evidence.ActiveVersion == "" {
+			continue
+		}
+		result.Details = append(result.Details, types.InspectionDetail{
+			ID:      "local-schema-" + database,
+			Status:  types.InspectionStatusUnknown,
+			Summary: "Local " + strings.ToUpper(database) + " active schema was collected",
+			Data:    map[string]string{"active_version": evidence.ActiveVersion},
+		})
+	}
+
+	if data := communicationData(input.Communication); len(data) > 0 {
+		result.Details = append(result.Details, types.InspectionDetail{
+			ID:      "local-communication",
+			Status:  types.InspectionStatusUnknown,
+			Summary: "Local database communication evidence was collected",
+			Data:    data,
+		})
+	}
+
+	var collectionErrors []string
+	if input.Communication.CollectionError != "" {
+		collectionErrors = append(collectionErrors, input.Communication.CollectionError)
+	}
+	if collectionError := databaseCollectionError(input); collectionError != "" {
+		collectionErrors = append(collectionErrors, collectionError)
+	}
+	slices.Sort(collectionErrors)
+	result.CollectionError = strings.Join(collectionErrors, "; ")
+	return result
+}
+
+func databaseCollectionError(input Input) string {
+	var errors []string
+	for _, collectionError := range input.CollectionErrors {
+		if collectionError.FactGroup == "database" {
+			errors = append(errors, collectionError.Message)
+		}
+	}
+	slices.Sort(errors)
+	return strings.Join(errors, "; ")
+}

--- a/microovn/inspect/database_test.go
+++ b/microovn/inspect/database_test.go
@@ -1,0 +1,241 @@
+package inspect
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	microTypes "github.com/canonical/microcluster/v3/microcluster/types"
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func TestDatabaseCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        Input
+		wantIDs      []string
+		wantStatuses []types.InspectionStatus
+	}{
+		{
+			name:         "healthy",
+			input:        healthyDatabaseInput(),
+			wantIDs:      []string{"database-schema-nb", "database-schema-sb", "database-communication"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass, types.InspectionStatusPass, types.InspectionStatusPass},
+		},
+		{
+			name: "mismatch and incomplete coverage coexist",
+			input: func() Input {
+				input := healthyDatabaseInput()
+				input.Schemas["nb"] = types.InspectionSchemaEvidence{
+					Database: "nb", ActiveVersion: "2.0",
+					Members: []types.InspectionSchemaMemberEvidence{
+						{Node: "node1", Version: "1.0"},
+						{Node: "node2", Error: "member unreachable"},
+					},
+				}
+				return input
+			}(),
+			wantIDs: []string{
+				"database-schema-mismatch-nb",
+				"database-schema-coverage-nb",
+				"database-schema-sb",
+				"database-communication",
+			},
+			wantStatuses: []types.InspectionStatus{
+				types.InspectionStatusFail,
+				types.InspectionStatusUnknown,
+				types.InspectionStatusPass,
+				types.InspectionStatusPass,
+			},
+		},
+		{
+			name: "unsupported API is unknown",
+			input: func() Input {
+				input := healthyDatabaseInput()
+				input.Schemas["nb"].Members[0] = types.InspectionSchemaMemberEvidence{Node: "node1", Unsupported: true}
+				return input
+			}(),
+			wantIDs:      []string{"database-schema-coverage-nb", "database-schema-sb", "database-communication"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown, types.InspectionStatusPass, types.InspectionStatusPass},
+		},
+		{
+			name: "missing schema evidence is unknown",
+			input: func() Input {
+				input := healthyDatabaseInput()
+				delete(input.Schemas, "nb")
+				return input
+			}(),
+			wantIDs:      []string{"database-schema-coverage-nb", "database-schema-sb", "database-communication"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown, types.InspectionStatusPass, types.InspectionStatusPass},
+		},
+		{
+			name: "communication lag warns",
+			input: func() Input {
+				input := healthyDatabaseInput()
+				input.Communication.Converged = boolPointer(false)
+				return input
+			}(),
+			wantIDs:      []string{"database-schema-nb", "database-schema-sb", "database-communication"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass, types.InspectionStatusPass, types.InspectionStatusWarning},
+		},
+		{
+			name: "unreachable database fails",
+			input: func() Input {
+				input := healthyDatabaseInput()
+				input.Communication.NBReachable = boolPointer(false)
+				input.Communication.SBReachable = nil
+				input.Communication.Converged = nil
+				return input
+			}(),
+			wantIDs:      []string{"database-schema-nb", "database-schema-sb", "database-communication"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass, types.InspectionStatusPass, types.InspectionStatusFail},
+		},
+		{
+			name: "incomplete communication is unknown",
+			input: func() Input {
+				input := healthyDatabaseInput()
+				input.Communication.Converged = nil
+				input.Communication.CollectionError = "probe canceled"
+				return input
+			}(),
+			wantIDs:      []string{"database-schema-nb", "database-schema-sb", "database-communication"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass, types.InspectionStatusPass, types.InspectionStatusUnknown},
+		},
+		{
+			name: "missing member list is unknown",
+			input: func() Input {
+				input := healthyDatabaseInput()
+				input.Members = nil
+				return input
+			}(),
+			wantIDs:      []string{"database-schema-coverage-nb", "database-schema-coverage-sb", "database-communication"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown, types.InspectionStatusUnknown, types.InspectionStatusPass},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := (DatabaseCheck{}).Run(context.Background(), test.input)
+			if len(results) != len(test.wantIDs) {
+				t.Fatalf("result count = %d, want %d: %#v", len(results), len(test.wantIDs), results)
+			}
+			for index, result := range results {
+				if result.ID != test.wantIDs[index] || result.Status != test.wantStatuses[index] {
+					t.Errorf("result %d = (%q, %q), want (%q, %q)", index, result.ID, result.Status, test.wantIDs[index], test.wantStatuses[index])
+				}
+				if result.Category != "database" {
+					t.Errorf("result %d category = %q, want database", index, result.Category)
+				}
+			}
+		})
+	}
+}
+
+func TestDatabaseCheckNonVoter(t *testing.T) {
+	input := Input{
+		ExecutionContext: types.InspectionExecutionContext{LocalNode: "node1"},
+		Schemas: map[string]types.InspectionSchemaEvidence{
+			"nb": {Database: "nb", ActiveVersion: "1.0"},
+		},
+		Communication: types.InspectionCommunicationEvidence{
+			NBReachable: boolPointer(true),
+			NBCfg:       int64Pointer(42),
+		},
+	}
+
+	result := (DatabaseCheck{}).Run(context.Background(), input)[0]
+	if result.Status != types.InspectionStatusUnknown || len(result.Details) != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Details[0].Data["active_version"] != "1.0" {
+		t.Fatalf("schema detail = %#v", result.Details[0])
+	}
+	if result.Details[1].Data["nb_cfg"] != "42" {
+		t.Fatalf("communication detail = %#v", result.Details[1])
+	}
+}
+
+func TestDatabaseCheckDeterministicDetails(t *testing.T) {
+	input := healthyDatabaseInput()
+	input.Members[0], input.Members[1] = input.Members[1], input.Members[0]
+	input.Schemas["nb"] = types.InspectionSchemaEvidence{
+		Database: "nb", ActiveVersion: "2.0",
+		Members: []types.InspectionSchemaMemberEvidence{
+			{Node: "node2", Version: "1.0"},
+			{Node: "node1", Version: "1.0"},
+		},
+	}
+
+	result := (DatabaseCheck{}).Run(context.Background(), input)[0]
+	var got []string
+	for _, detail := range result.Details {
+		got = append(got, detail.Node+":"+detail.ID)
+	}
+	want := []string{"node1:schema-version", "node2:schema-version"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("detail order = %#v, want %#v", got, want)
+	}
+}
+
+func TestDatabaseCheckResultContract(t *testing.T) {
+	if name := (DatabaseCheck{}).Name(); name != "database" {
+		t.Fatalf("name = %q, want database", name)
+	}
+
+	input := healthyDatabaseInput()
+	input.Schemas["nb"].Members[0] = types.InspectionSchemaMemberEvidence{Node: "node1", Error: "member unreachable"}
+	result := (DatabaseCheck{}).Run(context.Background(), input)[0]
+	if result.CollectionError != "node1: member unreachable" {
+		t.Fatalf("collection error = %q", result.CollectionError)
+	}
+	if result.Remediation == "" {
+		t.Fatal("unknown result has no remediation")
+	}
+
+	input = healthyDatabaseInput()
+	input.Communication.Converged = nil
+	input.Communication.CollectionError = "probe canceled"
+	results := (DatabaseCheck{}).Run(context.Background(), input)
+	if results[2].CollectionError != "probe canceled" || results[2].Remediation == "" {
+		t.Fatalf("communication result = %#v", results[2])
+	}
+
+	input = healthyDatabaseInput()
+	delete(input.Schemas, "nb")
+	input.CollectionErrors = []types.InspectionCollectionError{{FactGroup: "database", Message: "schema request failed"}}
+	result = (DatabaseCheck{}).Run(context.Background(), input)[0]
+	if result.CollectionError != "schema request failed" {
+		t.Fatalf("top-level collection error = %q", result.CollectionError)
+	}
+}
+
+func healthyDatabaseInput() Input {
+	members := []microTypes.ClusterMember{
+		{ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: "node1"}},
+		{ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: "node2"}},
+	}
+	memberEvidence := []types.InspectionSchemaMemberEvidence{
+		{Node: "node1", Version: "1.0"},
+		{Node: "node2", Version: "1.0"},
+	}
+
+	return Input{
+		ExecutionContext: types.InspectionExecutionContext{Authoritative: true},
+		Members:          members,
+		Schemas: map[string]types.InspectionSchemaEvidence{
+			"nb": {Database: "nb", ActiveVersion: "1.0", Members: append([]types.InspectionSchemaMemberEvidence(nil), memberEvidence...)},
+			"sb": {Database: "sb", ActiveVersion: "1.0", Members: append([]types.InspectionSchemaMemberEvidence(nil), memberEvidence...)},
+		},
+		Communication: types.InspectionCommunicationEvidence{
+			NBCfg:       int64Pointer(12),
+			SBCfg:       int64Pointer(12),
+			NBReachable: boolPointer(true),
+			SBReachable: boolPointer(true),
+			Converged:   boolPointer(true),
+		},
+	}
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}

--- a/microovn/inspect/environment.go
+++ b/microovn/inspect/environment.go
@@ -1,0 +1,292 @@
+package inspect
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+type EnvironmentCheck struct{}
+
+var memberSpecificEnvironment = map[string]struct{}{
+	"OVN_INITIAL_NB": {},
+	"OVN_INITIAL_SB": {},
+	"OVN_LOCAL_IP":   {},
+}
+
+func (EnvironmentCheck) Name() string {
+	return "environment"
+}
+
+func (EnvironmentCheck) Run(_ context.Context, input Input) []types.InspectionResult {
+	if !input.ExecutionContext.Authoritative {
+		return []types.InspectionResult{nonAuthoritativeEnvironmentResult(input)}
+	}
+
+	var complete []environmentSnapshot
+	var unavailable []types.InspectionDetail
+	var collectionErrors []string
+	memberErrors := forEachMemberSnapshot(input, "environment", func(memberName string, snapshot types.InspectionNodeSnapshot) {
+		complete = append(complete, environmentSnapshot{
+			node:        memberName,
+			environment: canonicalEnvironment(snapshot.Environment),
+		})
+	})
+	for _, memberError := range memberErrors {
+		summary := "Environment snapshot is unavailable"
+		if memberError.snapshotFound {
+			summary = "Environment collection failed"
+		}
+		unavailable = append(unavailable, types.InspectionDetail{
+			Node:    memberError.node,
+			ID:      "environment-unavailable",
+			Status:  types.InspectionStatusUnknown,
+			Summary: summary,
+		})
+		if memberError.err != "" {
+			collectionErrors = append(collectionErrors, fmt.Sprintf("%s: %s", memberError.node, memberError.err))
+		}
+	}
+
+	if len(input.Members) == 0 {
+		unavailable = append(unavailable, types.InspectionDetail{
+			ID:      "environment-unavailable",
+			Status:  types.InspectionStatusUnknown,
+			Summary: "Expected cluster members are unavailable",
+		})
+	}
+
+	groups := groupEnvironments(complete)
+	var results []types.InspectionResult
+	if len(groups) > 1 {
+		results = append(results, environmentDriftResult(groups))
+	}
+
+	if len(unavailable) > 0 {
+		results = append(results, types.InspectionResult{
+			ID:              "environment-coverage",
+			Category:        "environment",
+			Status:          types.InspectionStatusUnknown,
+			Summary:         "Environment evidence is incomplete",
+			Details:         unavailable,
+			Remediation:     "Restore environment snapshot collection on unavailable members.",
+			CollectionError: strings.Join(collectionErrors, "; "),
+		})
+	}
+
+	if len(results) > 0 {
+		return results
+	}
+
+	return []types.InspectionResult{{
+		ID:       "environment",
+		Category: "environment",
+		Status:   types.InspectionStatusPass,
+		Summary:  "Member environments are consistent",
+		Details:  environmentGroupDetails(groups),
+	}}
+}
+
+func nonAuthoritativeEnvironmentResult(input Input) types.InspectionResult {
+	result := types.InspectionResult{
+		ID:          "environment",
+		Category:    "environment",
+		Status:      types.InspectionStatusUnknown,
+		Summary:     "Environment convergence cannot be determined from a non-voting member",
+		Remediation: "Run the inspection on a voting member.",
+	}
+	if snapshot, found := input.Snapshots[input.ExecutionContext.LocalNode]; found {
+		if collectionError := environmentCollectionError(snapshot); collectionError != "" {
+			result.CollectionError = collectionError
+		} else {
+			result.Details = []types.InspectionDetail{{
+				Node:    snapshot.NodeName,
+				ID:      "local-fingerprint",
+				Status:  types.InspectionStatusUnknown,
+				Summary: "Local environment fingerprint was collected",
+				Data:    environmentData(canonicalEnvironment(snapshot.Environment)),
+			}}
+		}
+	} else {
+		result.CollectionError = snapshotCollectionError(input, input.ExecutionContext.LocalNode)
+	}
+
+	return result
+}
+
+type environmentSnapshot struct {
+	node        string
+	environment []types.InspectionEnvironment
+}
+
+type environmentGroup struct {
+	nodes       []string
+	environment []types.InspectionEnvironment
+}
+
+type diffResult struct {
+	added          []types.InspectionEnvironment
+	removed        []types.InspectionEnvironment
+	hashMismatches []hashMismatch
+}
+
+type hashMismatch struct {
+	name    string
+	hashInA string
+	hashInB string
+}
+
+func environmentCollectionError(snapshot types.InspectionNodeSnapshot) string {
+	index := slices.IndexFunc(snapshot.Errors, func(collectionError types.InspectionCollectionError) bool {
+		return collectionError.FactGroup == "environment"
+	})
+	if index == -1 {
+		return ""
+	}
+
+	return snapshot.Errors[index].Message
+}
+
+func canonicalEnvironment(environment []types.InspectionEnvironment) []types.InspectionEnvironment {
+	canonical := make([]types.InspectionEnvironment, 0, len(environment))
+	for _, entry := range environment {
+		if _, memberSpecific := memberSpecificEnvironment[entry.Name]; memberSpecific {
+			continue
+		}
+		canonical = append(canonical, entry)
+	}
+	slices.SortFunc(canonical, func(a, b types.InspectionEnvironment) int {
+		if result := cmp.Compare(a.Name, b.Name); result != 0 {
+			return result
+		}
+		return cmp.Compare(a.Hash, b.Hash)
+	})
+	return canonical
+}
+
+func environmentFingerprint(environment []types.InspectionEnvironment) string {
+	var fingerprint strings.Builder
+	for _, entry := range environment {
+		fmt.Fprintf(&fingerprint, "%d:%s%d:%s", len(entry.Name), entry.Name, len(entry.Hash), entry.Hash)
+	}
+	return fingerprint.String()
+}
+
+func groupEnvironments(snapshots []environmentSnapshot) []environmentGroup {
+	groups := make([]environmentGroup, 0)
+	groupByFingerprint := make(map[string]int)
+	for _, snapshot := range snapshots {
+		fingerprint := environmentFingerprint(snapshot.environment)
+		index, found := groupByFingerprint[fingerprint]
+		if !found {
+			index = len(groups)
+			groupByFingerprint[fingerprint] = index
+			groups = append(groups, environmentGroup{environment: snapshot.environment})
+		}
+		groups[index].nodes = append(groups[index].nodes, snapshot.node)
+	}
+
+	return groups
+}
+
+func environmentData(environment []types.InspectionEnvironment) map[string]string {
+	data := make(map[string]string, len(environment))
+	for _, entry := range environment {
+		data[entry.Name] = entry.Hash
+	}
+	return data
+}
+
+func environmentGroupDetails(groups []environmentGroup) []types.InspectionDetail {
+	details := make([]types.InspectionDetail, 0, len(groups))
+	for index, group := range groups {
+		details = append(details, types.InspectionDetail{
+			Node:    group.nodes[0],
+			ID:      fmt.Sprintf("fingerprint-%d", index+1),
+			Status:  types.InspectionStatusPass,
+			Summary: fmt.Sprintf("Environment fingerprint shared by %s", strings.Join(group.nodes, ", ")),
+			Data:    environmentData(group.environment),
+		})
+	}
+	return details
+}
+
+func environmentDriftResult(groups []environmentGroup) types.InspectionResult {
+	details := environmentGroupDetails(groups[:1])
+	details[0].Status = types.InspectionStatusWarning
+	details[0].Summary = fmt.Sprintf("Baseline environment fingerprint shared by %s", strings.Join(groups[0].nodes, ", "))
+
+	for index, group := range groups[1:] {
+		data := make(map[string]string)
+		diff := diffEnvironments(groups[0].environment, group.environment)
+		for _, entry := range diff.added {
+			data["added."+entry.Name] = entry.Hash
+		}
+		for _, entry := range diff.removed {
+			data["removed."+entry.Name] = entry.Hash
+		}
+		for _, mismatch := range diff.hashMismatches {
+			data["changed."+mismatch.name+".baseline"] = mismatch.hashInA
+			data["changed."+mismatch.name+".observed"] = mismatch.hashInB
+		}
+		details = append(details, types.InspectionDetail{
+			Node:    group.nodes[0],
+			ID:      fmt.Sprintf("fingerprint-%d", index+2),
+			Status:  types.InspectionStatusWarning,
+			Summary: fmt.Sprintf("Environment fingerprint differs on %s", strings.Join(group.nodes, ", ")),
+			Data:    data,
+		})
+	}
+
+	return types.InspectionResult{
+		ID:          "environment-drift",
+		Category:    "environment",
+		Status:      types.InspectionStatusWarning,
+		Summary:     fmt.Sprintf("Member environments differ across %d fingerprints", len(groups)),
+		Details:     details,
+		Remediation: "Compare the generated environment configuration on members with different fingerprints.",
+	}
+}
+
+func diffEnvironments(a, b []types.InspectionEnvironment) diffResult {
+	var diff diffResult
+	i, j := 0, 0
+
+	for i < len(a) && j < len(b) {
+		l, r := a[i], b[j]
+
+		switch {
+		case l.Name == r.Name:
+			if l.Hash != r.Hash {
+				diff.hashMismatches = append(diff.hashMismatches, hashMismatch{
+					name:    l.Name,
+					hashInA: l.Hash,
+					hashInB: r.Hash,
+				})
+			}
+			i++
+			j++
+		case l.Name < r.Name:
+			diff.removed = append(diff.removed, l)
+			i++
+		case l.Name > r.Name:
+			diff.added = append(diff.added, r)
+			j++
+		}
+
+	}
+
+	for ; i < len(a); i++ {
+		diff.removed = append(diff.removed, a[i])
+	}
+
+	for ; j < len(b); j++ {
+		diff.added = append(diff.added, b[j])
+	}
+
+	return diff
+}

--- a/microovn/inspect/environment_test.go
+++ b/microovn/inspect/environment_test.go
@@ -1,0 +1,251 @@
+package inspect
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	microTypes "github.com/canonical/microcluster/v3/microcluster/types"
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func TestEnvironmentCheck(t *testing.T) {
+	environmentA := []types.InspectionEnvironment{{Name: "B", Hash: "hash-b"}, {Name: "A", Hash: "hash-a"}}
+	environmentB := []types.InspectionEnvironment{{Name: "A", Hash: "hash-other"}, {Name: "C", Hash: "hash-c"}}
+
+	tests := []struct {
+		name         string
+		input        Input
+		wantIDs      []string
+		wantStatuses []types.InspectionStatus
+	}{
+		{
+			name: "non-voter includes local fingerprint",
+			input: Input{
+				ExecutionContext: types.InspectionExecutionContext{LocalNode: "node1"},
+				Snapshots: map[string]types.InspectionNodeSnapshot{
+					"node1": {NodeName: "node1", Environment: environmentA},
+				},
+			},
+			wantIDs:      []string{"environment"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+		{
+			name:         "single member passes",
+			input:        environmentInput([]string{"node1"}, map[string][]types.InspectionEnvironment{"node1": environmentA}),
+			wantIDs:      []string{"environment"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass},
+		},
+		{
+			name: "equal environments pass",
+			input: environmentInput([]string{"node2", "node1"}, map[string][]types.InspectionEnvironment{
+				"node1": environmentA,
+				"node2": {{Name: "A", Hash: "hash-a"}, {Name: "B", Hash: "hash-b"}},
+			}),
+			wantIDs:      []string{"environment"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass},
+		},
+		{
+			name: "member-specific environment differences pass",
+			input: environmentInput([]string{"node1", "node2"}, map[string][]types.InspectionEnvironment{
+				"node1": {
+					{Name: "OVN_INITIAL_NB", Hash: "node2"},
+					{Name: "OVN_INITIAL_SB", Hash: "node2"},
+					{Name: "OVN_LOCAL_IP", Hash: "node1"},
+					{Name: "OVN_NB_CONNECT", Hash: "shared"},
+				},
+				"node2": {
+					{Name: "OVN_INITIAL_NB", Hash: "node1"},
+					{Name: "OVN_INITIAL_SB", Hash: "node1"},
+					{Name: "OVN_LOCAL_IP", Hash: "node2"},
+					{Name: "OVN_NB_CONNECT", Hash: "shared"},
+				},
+			}),
+			wantIDs:      []string{"environment"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass},
+		},
+		{
+			name: "drift warns",
+			input: environmentInput([]string{"node1", "node2"}, map[string][]types.InspectionEnvironment{
+				"node1": environmentA,
+				"node2": environmentB,
+			}),
+			wantIDs:      []string{"environment-drift"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusWarning},
+		},
+		{
+			name:         "missing snapshot is unknown",
+			input:        environmentInput([]string{"node1", "node2"}, map[string][]types.InspectionEnvironment{"node1": environmentA}),
+			wantIDs:      []string{"environment-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+		{
+			name: "fact error is unknown",
+			input: func() Input {
+				input := environmentInput([]string{"node1"}, map[string][]types.InspectionEnvironment{"node1": environmentA})
+				snapshot := input.Snapshots["node1"]
+				snapshot.Errors = []types.InspectionCollectionError{{FactGroup: "environment", Message: "read failed"}}
+				input.Snapshots["node1"] = snapshot
+				return input
+			}(),
+			wantIDs:      []string{"environment-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+		{
+			name: "drift and missing coverage coexist",
+			input: environmentInput([]string{"node3", "node1", "node2"}, map[string][]types.InspectionEnvironment{
+				"node1": environmentA,
+				"node2": environmentB,
+			}),
+			wantIDs:      []string{"environment-drift", "environment-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusWarning, types.InspectionStatusUnknown},
+		},
+		{
+			name:         "missing member evidence is unknown",
+			input:        environmentInput(nil, nil),
+			wantIDs:      []string{"environment-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := (EnvironmentCheck{}).Run(context.Background(), test.input)
+			if len(results) != len(test.wantIDs) {
+				t.Fatalf("result count = %d, want %d: %#v", len(results), len(test.wantIDs), results)
+			}
+			for index, result := range results {
+				if result.ID != test.wantIDs[index] || result.Status != test.wantStatuses[index] {
+					t.Errorf("result %d = (%q, %q), want (%q, %q)", index, result.ID, result.Status, test.wantIDs[index], test.wantStatuses[index])
+				}
+				if result.Category != "environment" {
+					t.Errorf("result %d category = %q, want environment", index, result.Category)
+				}
+			}
+		})
+	}
+}
+
+func TestEnvironmentCheckDeterministicGroupsAndSafeDiff(t *testing.T) {
+	input := environmentInput([]string{"node3", "node1", "node2"}, map[string][]types.InspectionEnvironment{
+		"node1": {{Name: "A", Hash: "hash-a"}, {Name: "B", Hash: "hash-b"}},
+		"node2": {{Name: "B", Hash: "hash-b"}, {Name: "A", Hash: "hash-a"}},
+		"node3": {{Name: "A", Hash: "hash-other"}, {Name: "C", Hash: "hash-c"}},
+	})
+
+	results := (EnvironmentCheck{}).Run(context.Background(), input)
+	if len(results) != 1 || len(results[0].Details) != 2 {
+		t.Fatalf("results = %#v", results)
+	}
+	if results[0].Details[0].Summary != "Baseline environment fingerprint shared by node1, node2" {
+		t.Fatalf("baseline detail = %#v", results[0].Details[0])
+	}
+	data := results[0].Details[1].Data
+	if data["changed.A.baseline"] != "hash-a" || data["changed.A.observed"] != "hash-other" ||
+		data["removed.B"] != "hash-b" || data["added.C"] != "hash-c" {
+		t.Fatalf("diff data = %#v", data)
+	}
+}
+
+func TestEnvironmentCheckResultEvidence(t *testing.T) {
+	t.Run("non-voter includes hash-only local evidence", func(t *testing.T) {
+		input := Input{
+			ExecutionContext: types.InspectionExecutionContext{LocalNode: "node1"},
+			Snapshots: map[string]types.InspectionNodeSnapshot{
+				"node1": {
+					NodeName: "node1",
+					Environment: []types.InspectionEnvironment{{
+						Name: "OVN_NB_DB", Hash: "safe-hash",
+					}},
+				},
+			},
+		}
+
+		result := (EnvironmentCheck{}).Run(context.Background(), input)[0]
+		if len(result.Details) != 1 || result.Details[0].Data["OVN_NB_DB"] != "safe-hash" {
+			t.Fatalf("details = %#v", result.Details)
+		}
+		data, err := json.Marshal(result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), "raw-environment-value") {
+			t.Fatalf("result exposed a raw environment value: %s", data)
+		}
+	})
+
+	t.Run("missing snapshot preserves collection cause", func(t *testing.T) {
+		input := environmentInput([]string{"node1", "node2"}, map[string][]types.InspectionEnvironment{
+			"node1": {{Name: "A", Hash: "hash-a"}},
+		})
+		input.CollectionErrors = []types.InspectionCollectionError{
+			{Node: "node2", FactGroup: "member", Message: "context canceled"},
+		}
+
+		result := (EnvironmentCheck{}).Run(context.Background(), input)[0]
+		if result.CollectionError != "node2: context canceled" {
+			t.Fatalf("collection error = %q", result.CollectionError)
+		}
+		if len(result.Details) != 1 || result.Details[0].Node != "node2" ||
+			result.Details[0].Status != types.InspectionStatusUnknown {
+			t.Fatalf("details = %#v", result.Details)
+		}
+	})
+
+	t.Run("fact error is preserved", func(t *testing.T) {
+		input := environmentInput([]string{"node1"}, map[string][]types.InspectionEnvironment{"node1": nil})
+		snapshot := input.Snapshots["node1"]
+		snapshot.Errors = []types.InspectionCollectionError{{FactGroup: "environment", Message: "read failed"}}
+		input.Snapshots["node1"] = snapshot
+
+		result := (EnvironmentCheck{}).Run(context.Background(), input)[0]
+		if result.CollectionError != "node1: read failed" {
+			t.Fatalf("collection error = %q", result.CollectionError)
+		}
+	})
+
+	t.Run("pass has healthy summary and no remediation", func(t *testing.T) {
+		result := (EnvironmentCheck{}).Run(context.Background(), environmentInput(
+			[]string{"node1"},
+			map[string][]types.InspectionEnvironment{"node1": {{Name: "A", Hash: "hash-a"}}},
+		))[0]
+		if result.Summary != "Member environments are consistent" || result.Remediation != "" {
+			t.Fatalf("result = %#v", result)
+		}
+	})
+}
+
+func TestEnvironmentCheckNonVoterSnapshotError(t *testing.T) {
+	input := Input{
+		ExecutionContext: types.InspectionExecutionContext{LocalNode: "node1"},
+		CollectionErrors: []types.InspectionCollectionError{{
+			Node: "node1", FactGroup: "snapshot", Message: "snapshot unavailable",
+		}},
+	}
+
+	result := (EnvironmentCheck{}).Run(context.Background(), input)[0]
+	if result.CollectionError != "snapshot unavailable" {
+		t.Fatalf("collection error = %q", result.CollectionError)
+	}
+}
+
+func environmentInput(memberNames []string, environments map[string][]types.InspectionEnvironment) Input {
+	members := make([]microTypes.ClusterMember, 0, len(memberNames))
+	for _, memberName := range memberNames {
+		members = append(members, microTypes.ClusterMember{
+			ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: memberName},
+		})
+	}
+
+	snapshots := make(map[string]types.InspectionNodeSnapshot, len(environments))
+	for node, environment := range environments {
+		snapshots[node] = types.InspectionNodeSnapshot{NodeName: node, Environment: environment}
+	}
+
+	return Input{
+		ExecutionContext: types.InspectionExecutionContext{LocalNode: "node1", Authoritative: true},
+		Members:          members,
+		Snapshots:        snapshots,
+	}
+}

--- a/microovn/inspect/facts/convergence.go
+++ b/microovn/inspect/facts/convergence.go
@@ -1,0 +1,62 @@
+package facts
+
+import (
+	"context"
+	"time"
+)
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func pollSBUntilConverged(
+	ctx context.Context,
+	readSB dbCfgReader,
+	nbCfg int64,
+	pollInterval time.Duration,
+	deadline time.Duration,
+) (value *int64, converged *bool, err error) {
+	var sbCfg int64
+	pollCtx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
+	for {
+		var next int64
+		next, err = readSB(pollCtx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return value, nil, ctx.Err()
+			}
+			if pollCtx.Err() == context.DeadlineExceeded {
+				if value == nil {
+					return nil, nil, pollCtx.Err()
+				}
+				return value, boolPtr(false), nil
+			}
+			return value, nil, err
+		}
+		sbCfg = next
+		value = &sbCfg
+
+		if sbCfg >= nbCfg {
+			return value, boolPtr(true), nil
+		}
+
+		interval := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			interval.Stop()
+			return value, nil, ctx.Err()
+
+		case <-pollCtx.Done():
+			interval.Stop()
+			if ctx.Err() != nil {
+				return value, nil, ctx.Err()
+			}
+			return value, boolPtr(false), nil
+
+		case <-interval.C:
+			// Check again
+		}
+	}
+}

--- a/microovn/inspect/facts/convergence_test.go
+++ b/microovn/inspect/facts/convergence_test.go
@@ -1,0 +1,228 @@
+package facts
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProbeDatabaseCommunicationConvergence(t *testing.T) {
+	tests := []struct {
+		name          string
+		sbValues      []int64
+		deadline      time.Duration
+		wantConverged bool
+	}{
+		{name: "immediate", sbValues: []int64{10}, deadline: time.Second, wantConverged: true},
+		{name: "delayed", sbValues: []int64{8, 9, 10}, deadline: time.Second, wantConverged: true},
+		{name: "deadline", sbValues: []int64{9}, deadline: 10 * time.Millisecond, wantConverged: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			index := 0
+			readSB := func(context.Context) (int64, error) {
+				if index < len(test.sbValues)-1 {
+					value := test.sbValues[index]
+					index++
+					return value, nil
+				}
+				return test.sbValues[len(test.sbValues)-1], nil
+			}
+
+			evidence := probeDatabaseCommunication(
+				context.Background(),
+				func(context.Context) (int64, error) { return 10, nil },
+				readSB,
+				time.Millisecond,
+				test.deadline,
+			)
+
+			assertBoolPointer(t, "NBReachable", evidence.NBReachable, true)
+			assertBoolPointer(t, "SBReachable", evidence.SBReachable, true)
+			assertBoolPointer(t, "Converged", evidence.Converged, test.wantConverged)
+			if evidence.NBCfg == nil || *evidence.NBCfg != 10 {
+				t.Fatalf("NBCfg = %v, want 10", evidence.NBCfg)
+			}
+			if evidence.SBCfg == nil {
+				t.Fatal("SBCfg is nil, want an observed value")
+			}
+		})
+	}
+}
+
+func TestProbeDatabaseCommunicationFailures(t *testing.T) {
+	t.Run("northbound unreachable", func(t *testing.T) {
+		evidence := probeDatabaseCommunication(
+			context.Background(),
+			func(context.Context) (int64, error) { return 0, errors.New("unreachable") },
+			func(context.Context) (int64, error) { return 0, nil },
+			time.Millisecond,
+			time.Second,
+		)
+
+		assertBoolPointer(t, "NBReachable", evidence.NBReachable, false)
+		if evidence.SBReachable != nil {
+			t.Fatalf("SBReachable = %v, want unknown", *evidence.SBReachable)
+		}
+	})
+
+	t.Run("southbound unreachable on first read", func(t *testing.T) {
+		evidence := probeDatabaseCommunication(
+			context.Background(),
+			func(context.Context) (int64, error) { return 10, nil },
+			func(context.Context) (int64, error) { return 0, errors.New("unreachable") },
+			time.Millisecond,
+			time.Second,
+		)
+
+		assertBoolPointer(t, "NBReachable", evidence.NBReachable, true)
+		assertBoolPointer(t, "SBReachable", evidence.SBReachable, false)
+		if evidence.SBCfg != nil {
+			t.Fatalf("SBCfg = %v, want no observation", *evidence.SBCfg)
+		}
+		if evidence.Converged != nil {
+			t.Fatalf("Converged = %v, want unknown", *evidence.Converged)
+		}
+	})
+
+	t.Run("southbound preserves prior observation", func(t *testing.T) {
+		calls := 0
+		readSB := func(context.Context) (int64, error) {
+			calls++
+			if calls == 1 {
+				return 5, nil
+			}
+			return 0, errors.New("unreachable")
+		}
+
+		evidence := probeDatabaseCommunication(
+			context.Background(),
+			func(context.Context) (int64, error) { return 10, nil },
+			readSB,
+			time.Millisecond,
+			time.Second,
+		)
+
+		assertBoolPointer(t, "SBReachable", evidence.SBReachable, true)
+		if evidence.SBCfg == nil || *evidence.SBCfg != 5 {
+			t.Fatalf("SBCfg = %v, want preserved value 5", evidence.SBCfg)
+		}
+		if evidence.Converged != nil {
+			t.Fatalf("Converged = %v, want unknown", *evidence.Converged)
+		}
+	})
+}
+
+func TestProbeDatabaseCommunicationMalformedOutput(t *testing.T) {
+	t.Run("northbound", func(t *testing.T) {
+		evidence := probeDatabaseCommunication(
+			context.Background(),
+			func(context.Context) (int64, error) { return 0, dbCfgParseError{database: "NB"} },
+			func(context.Context) (int64, error) { return 0, nil },
+			time.Millisecond,
+			time.Second,
+		)
+
+		assertBoolPointer(t, "NBReachable", evidence.NBReachable, true)
+		if evidence.Converged != nil {
+			t.Fatalf("Converged = %v, want unknown", *evidence.Converged)
+		}
+		if !strings.Contains(evidence.CollectionError, "invalid NB nb_cfg value") {
+			t.Fatalf("CollectionError = %q", evidence.CollectionError)
+		}
+	})
+
+	t.Run("southbound first read", func(t *testing.T) {
+		evidence := probeDatabaseCommunication(
+			context.Background(),
+			func(context.Context) (int64, error) { return 10, nil },
+			func(context.Context) (int64, error) { return 0, dbCfgParseError{database: "SB"} },
+			time.Millisecond,
+			time.Second,
+		)
+
+		assertBoolPointer(t, "SBReachable", evidence.SBReachable, true)
+		if evidence.SBCfg != nil || evidence.Converged != nil {
+			t.Fatalf("evidence = %#v, want no SB value and unknown convergence", evidence)
+		}
+	})
+
+	t.Run("southbound preserves prior observation", func(t *testing.T) {
+		calls := 0
+		evidence := probeDatabaseCommunication(
+			context.Background(),
+			func(context.Context) (int64, error) { return 10, nil },
+			func(context.Context) (int64, error) {
+				calls++
+				if calls == 1 {
+					return 5, nil
+				}
+				return 0, dbCfgParseError{database: "SB"}
+			},
+			time.Millisecond,
+			time.Second,
+		)
+
+		assertBoolPointer(t, "SBReachable", evidence.SBReachable, true)
+		if evidence.SBCfg == nil || *evidence.SBCfg != 5 {
+			t.Fatalf("SBCfg = %v, want preserved value 5", evidence.SBCfg)
+		}
+		if evidence.Converged != nil {
+			t.Fatalf("Converged = %v, want unknown", *evidence.Converged)
+		}
+	})
+}
+
+func TestProbeDatabaseCommunicationCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	evidence := probeDatabaseCommunication(
+		ctx,
+		func(ctx context.Context) (int64, error) { return 0, ctx.Err() },
+		func(context.Context) (int64, error) { return 0, nil },
+		time.Millisecond,
+		time.Second,
+	)
+
+	if evidence.NBReachable != nil {
+		t.Fatalf("NBReachable = %v, want unknown", *evidence.NBReachable)
+	}
+	if !strings.Contains(evidence.CollectionError, context.Canceled.Error()) {
+		t.Fatalf("CollectionError = %q, want cancellation cause", evidence.CollectionError)
+	}
+}
+
+func TestProbeDatabaseCommunicationFirstSBReadDeadline(t *testing.T) {
+	evidence := probeDatabaseCommunication(
+		context.Background(),
+		func(context.Context) (int64, error) { return 10, nil },
+		func(ctx context.Context) (int64, error) {
+			<-ctx.Done()
+			return 0, ctx.Err()
+		},
+		time.Millisecond,
+		time.Millisecond,
+	)
+
+	assertBoolPointer(t, "NBReachable", evidence.NBReachable, true)
+	if evidence.SBReachable != nil || evidence.SBCfg != nil || evidence.Converged != nil {
+		t.Fatalf("evidence = %#v, want unknown SB state", evidence)
+	}
+	if !strings.Contains(evidence.CollectionError, context.DeadlineExceeded.Error()) {
+		t.Fatalf("CollectionError = %q, want deadline cause", evidence.CollectionError)
+	}
+}
+
+func assertBoolPointer(t *testing.T, name string, got *bool, want bool) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s is nil, want %t", name, want)
+	}
+	if *got != want {
+		t.Fatalf("%s = %t, want %t", name, *got, want)
+	}
+}

--- a/microovn/inspect/facts/database.go
+++ b/microovn/inspect/facts/database.go
@@ -1,0 +1,225 @@
+package facts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/canonical/microcluster/v3/state"
+	"github.com/canonical/microovn/microovn/api/types"
+	"github.com/canonical/microovn/microovn/ovn/cmd"
+	ovnOvsdb "github.com/canonical/microovn/microovn/ovn/ovsdb"
+)
+
+const (
+	probePollInterval = 500 * time.Millisecond
+	probeDeadline     = 5 * time.Second
+)
+
+func CollectDatabaseProbe(
+	ctx context.Context,
+	s state.State,
+	scope types.InspectionScope,
+) (types.InspectionDatabaseProbe, error) {
+	var readNB, readSB dbCfgReader
+	switch scope {
+	case types.InspectionScopeCluster:
+		readNB, readSB = dbCfgReadersCluster(s)
+	case types.InspectionScopeLocal:
+		readNB, readSB = dbCfgReadersLocal(s)
+	default:
+		return types.InspectionDatabaseProbe{}, fmt.Errorf("invalid scope: %s", scope)
+	}
+
+	var schemas <-chan []types.InspectionSchemaEvidence
+	if scope == types.InspectionScopeLocal {
+		result := make(chan []types.InspectionSchemaEvidence, 1)
+		schemas = result
+		go func() {
+			result <- collectSchemas(ctx, s)
+		}()
+	}
+
+	probe := types.InspectionDatabaseProbe{
+		Scope: scope,
+		Communication: probeDatabaseCommunication(
+			ctx,
+			readNB,
+			readSB,
+			probePollInterval,
+			probeDeadline,
+		),
+	}
+
+	if schemas != nil {
+		probe.Schemas = <-schemas
+	}
+
+	return probe, nil
+}
+
+type dbCfgParseError struct {
+	database string
+}
+
+func (e dbCfgParseError) Error() string {
+	return fmt.Sprintf("invalid %s nb_cfg value", e.database)
+}
+
+type dbCfgReader func(context.Context) (int64, error)
+
+func dbCfgReadersCluster(s state.State) (dbCfgReader, dbCfgReader) {
+	return dbCfgReaders(s, cmd.NBCtlCluster, cmd.SBCtlCluster)
+}
+
+func dbCfgReadersLocal(s state.State) (dbCfgReader, dbCfgReader) {
+	return dbCfgReaders(s, cmd.NBCtl, cmd.SBCtl)
+}
+
+func probeDatabaseCommunication(
+	ctx context.Context,
+	readNB dbCfgReader,
+	readSB dbCfgReader,
+	pollInterval time.Duration,
+	deadline time.Duration,
+) types.InspectionCommunicationEvidence {
+	var evidence types.InspectionCommunicationEvidence
+
+	nbCfg, err := readNB(ctx)
+	if err != nil {
+		var nbReachable *bool
+		var parseError dbCfgParseError
+		if errors.As(err, &parseError) {
+			nbReachable = boolPtr(true)
+		} else if ctx.Err() == nil {
+			nbReachable = boolPtr(false)
+		}
+		collectionError := fmt.Sprintf("failed to read NB configuration: %v", err)
+		if ctx.Err() != nil {
+			collectionError = fmt.Sprintf("failed to read NB configuration: %v", ctx.Err())
+		}
+		return types.InspectionCommunicationEvidence{
+			NBReachable:     nbReachable,
+			CollectionError: collectionError,
+		}
+	}
+
+	evidence.NBCfg = &nbCfg
+	evidence.NBReachable = boolPtr(true)
+
+	sbCfg, converged, err := pollSBUntilConverged(ctx, readSB, nbCfg, pollInterval, deadline)
+	if err != nil {
+		var sbReachable *bool
+		var parseError dbCfgParseError
+		if sbCfg != nil || errors.As(err, &parseError) {
+			sbReachable = boolPtr(true)
+		} else if ctx.Err() == nil && !errors.Is(err, context.DeadlineExceeded) {
+			sbReachable = boolPtr(false)
+		}
+		collectionError := fmt.Sprintf("failed to read SB configuration: %v", err)
+		if ctx.Err() != nil {
+			collectionError = fmt.Sprintf("failed to read SB configuration: %v", ctx.Err())
+		}
+		return types.InspectionCommunicationEvidence{
+			NBCfg:           evidence.NBCfg,
+			SBCfg:           sbCfg,
+			NBReachable:     evidence.NBReachable,
+			SBReachable:     sbReachable,
+			Converged:       converged,
+			CollectionError: collectionError,
+		}
+	}
+
+	evidence.SBCfg = sbCfg
+	evidence.SBReachable = boolPtr(true)
+	evidence.Converged = converged
+	return evidence
+}
+
+func collectSchemas(ctx context.Context, s state.State) []types.InspectionSchemaEvidence {
+	evidence := make([]types.InspectionSchemaEvidence, 0, 2)
+
+	for _, dbType := range []cmd.OvsdbType{
+		cmd.OvsdbTypeNBLocal,
+		cmd.OvsdbTypeSBLocal,
+	} {
+		dbSpec, err := cmd.NewOvsdbSpec(dbType)
+		if err != nil {
+			continue
+		}
+
+		schema := types.InspectionSchemaEvidence{
+			Database: dbSpec.ShortName,
+			Members: []types.InspectionSchemaMemberEvidence{
+				{Node: s.Name()},
+			},
+		}
+
+		active, err := cmd.OvsdbClient(
+			ctx, s, dbSpec,
+			1, 1,
+			"get-schema-version",
+			dbSpec.SocketURL,
+		)
+		if err != nil {
+			schema.ActiveError = "active schema version could not be collected"
+		} else {
+			schema.ActiveVersion = strings.TrimSpace(active)
+		}
+
+		expected, err := ovnOvsdb.ExpectedOvsdbSchemaVersion(ctx, s, dbSpec)
+		if err != nil {
+			schema.Members[0].Error = "expected schema version could not be collected"
+		} else {
+			schema.Members[0].Version = expected
+		}
+
+		evidence = append(evidence, schema)
+	}
+
+	return evidence
+}
+
+func parseDBCfg(database string, output string) (int64, error) {
+	value, err := strconv.ParseInt(strings.TrimSpace(output), 10, 64)
+	if err != nil {
+		return 0, dbCfgParseError{database: database}
+	}
+
+	return value, nil
+}
+
+func dbCfgReaders(
+	s state.State,
+	nbCtl func(context.Context, state.State, int, ...string) (string, error),
+	sbCtl func(context.Context, state.State, int, ...string) (string, error),
+) (dbCfgReader, dbCfgReader) {
+	var nbCfgArgs = []string{
+		"--timeout", "1",
+		"--format=csv", "--no-headings", "--data=bare",
+		"get", "NB_Global", ".", "nb_cfg",
+	}
+
+	var sbCfgArgs = []string{
+		"--timeout", "1",
+		"--format=csv", "--no-headings", "--data=bare",
+		"get", "SB_Global", ".", "nb_cfg",
+	}
+
+	return func(ctx context.Context) (int64, error) {
+			output, err := nbCtl(ctx, s, 1, nbCfgArgs...)
+			if err != nil {
+				return 0, err
+			}
+			return parseDBCfg("NB", output)
+		}, func(ctx context.Context) (int64, error) {
+			output, err := sbCtl(ctx, s, 1, sbCfgArgs...)
+			if err != nil {
+				return 0, err
+			}
+			return parseDBCfg("SB", output)
+		}
+}

--- a/microovn/inspect/facts/database_test.go
+++ b/microovn/inspect/facts/database_test.go
@@ -1,0 +1,30 @@
+package facts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseDBCfg(t *testing.T) {
+	for _, database := range []string{"NB", "SB"} {
+		t.Run(database+" valid", func(t *testing.T) {
+			value, err := parseDBCfg(database, " 42\n")
+			if err != nil {
+				t.Fatalf("parseDBCfg returned an error: %v", err)
+			}
+			if value != 42 {
+				t.Fatalf("parseDBCfg returned %d, want 42", value)
+			}
+		})
+
+		t.Run(database+" malformed", func(t *testing.T) {
+			_, err := parseDBCfg(database, "not-a-number")
+			if err == nil {
+				t.Fatal("parseDBCfg accepted malformed output")
+			}
+			if !strings.Contains(err.Error(), database) {
+				t.Fatalf("parseDBCfg error %q does not identify %s", err, database)
+			}
+		})
+	}
+}

--- a/microovn/inspect/facts/network.go
+++ b/microovn/inspect/facts/network.go
@@ -1,0 +1,321 @@
+package facts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/canonical/microcluster/v3/state"
+	"github.com/canonical/microovn/microovn/api/types"
+	"github.com/canonical/microovn/microovn/ovn/cmd"
+)
+
+func CollectNetworkProbe(
+	ctx context.Context,
+	s state.State,
+) types.InspectionNetworkProbe {
+	probe := types.InspectionNetworkProbe{
+		Scope: types.InspectionScopeCluster,
+	}
+
+	dhcp, collectionErrors := collectDHCP(ctx, s)
+	if len(collectionErrors) > 0 {
+		probe.CollectionErrors = append(probe.CollectionErrors, collectionErrors...)
+	} else {
+		probe.DHCPOptions = dhcp
+	}
+
+	return probe
+}
+
+type dhcpOptionsResponse struct {
+	Data []dhcp `json:"data"`
+}
+
+type dhcp struct {
+	UUID        string
+	CIDR        string
+	Options     dhcpOptions
+	ExternalIDs map[string]string
+}
+
+type dhcpOptions struct {
+	ClasslessStaticRoutes []string
+	DNSServers            []string
+	DomainName            string
+	LeaseTime             string
+	MTU                   string
+	Router                string
+	ServerID              string
+	ServerMAC             string
+}
+
+type logicSwitchPortResponse struct {
+	Data []logicSwitchPort `json:"data"`
+}
+
+type logicSwitchPort struct {
+	Name            string
+	DHCPOptionsUUID string
+}
+
+func parseSet(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	raw = strings.Trim(raw, "{}")
+	parts := strings.Split(raw, ",")
+	res := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			res = append(res, part)
+		}
+	}
+	return res
+}
+
+func parseClasslessStaticRoutes(raw string) ([]string, error) {
+	values := parseSet(raw)
+	if len(values)%2 != 0 {
+		return nil, fmt.Errorf("invalid classless static routes, expected destination/gateway pairs, got %d values", len(values))
+	}
+
+	routes := make([]string, 0, len(values)/2)
+	for i := 0; i < len(values); i += 2 {
+		routes = append(routes, values[i]+","+values[i+1])
+	}
+
+	return routes, nil
+}
+
+func parseMap(raw json.RawMessage) (map[string]string, error) {
+	var tuple []json.RawMessage
+
+	if err := json.Unmarshal(raw, &tuple); err != nil {
+		return nil, err
+	}
+	if len(tuple) != 2 {
+		return nil, fmt.Errorf("failed to parse map tuple, expected 2 fields, got %d", len(tuple))
+	}
+
+	var typeStr string
+	if err := json.Unmarshal(tuple[0], &typeStr); err != nil {
+		return nil, fmt.Errorf("failed to parse map type: %w", err)
+	}
+	if typeStr != "map" {
+		return nil, fmt.Errorf("invalid map type, expected 'map', got %q", typeStr)
+	}
+
+	var pairs [][]string
+	if err := json.Unmarshal(tuple[1], &pairs); err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("failed to parse map row, expected 2 fields, got %d", len(pair))
+		}
+		result[pair[0]] = pair[1]
+	}
+
+	return result, nil
+}
+
+func (s *dhcp) UnmarshalJSON(b []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if len(raw) != 4 {
+		return fmt.Errorf("invalid subnet row, expected 4 fields, got %d", len(raw))
+	}
+
+	var uuidTuple []string
+	if err := json.Unmarshal(raw[0], &uuidTuple); err != nil {
+		return fmt.Errorf("failed to parse subnet UUID: %w", err)
+	}
+	if len(uuidTuple) != 2 || uuidTuple[0] != "uuid" {
+		return fmt.Errorf("invalid subnet UUID tuple, expected [uuid, value]")
+	}
+	s.UUID = uuidTuple[1]
+
+	var cidr string
+	if err := json.Unmarshal(raw[1], &cidr); err != nil {
+		return fmt.Errorf("failed to parse subnet CIDR: %w", err)
+
+	}
+	s.CIDR = cidr
+
+	options, err := parseMap(raw[2])
+	if err != nil {
+		return fmt.Errorf("failed to parse options map: %w", err)
+	}
+	classlessStaticRoutes, err := parseClasslessStaticRoutes(options["classless_static_route"])
+	if err != nil {
+		return err
+	}
+	s.Options = dhcpOptions{
+		ClasslessStaticRoutes: classlessStaticRoutes,
+		DNSServers:            parseSet(options["dns_server"]),
+		DomainName:            strings.Trim(options["domain_name"], `"`),
+		LeaseTime:             options["lease_time"],
+		MTU:                   options["mtu"],
+		Router:                options["router"],
+		ServerID:              options["server_id"],
+		ServerMAC:             options["server_mac"],
+	}
+
+	externalIDs, err := parseMap(raw[3])
+	if err != nil {
+		return fmt.Errorf("failed to parse external_ids map: %w", err)
+	}
+	s.ExternalIDs = externalIDs
+
+	return nil
+}
+
+func (s *logicSwitchPort) UnmarshalJSON(b []byte) error {
+	var tuple []json.RawMessage
+	if err := json.Unmarshal(b, &tuple); err != nil {
+		return err
+	}
+	if len(tuple) != 2 {
+		return fmt.Errorf("invalid logic switch port row, expected 2 fields, got %d", len(tuple))
+	}
+
+	var name string
+	if err := json.Unmarshal(tuple[0], &name); err != nil {
+		return fmt.Errorf("failed to parse logic switch port name: %w", err)
+	}
+	s.Name = name
+
+	var dhcpOptions []json.RawMessage
+	if err := json.Unmarshal(tuple[1], &dhcpOptions); err != nil {
+		return fmt.Errorf("failed to parse logic switch port DHCP options: %w", err)
+	}
+	if len(dhcpOptions) != 2 {
+		return fmt.Errorf("invalid logic switch port DHCP options, expected 2 fields, got %d", len(dhcpOptions))
+	}
+
+	var optionType string
+	if err := json.Unmarshal(dhcpOptions[0], &optionType); err != nil {
+		return fmt.Errorf(
+			"failed to parse logical switch port DHCP options type: %w",
+			err,
+		)
+	}
+
+	switch optionType {
+	case "set":
+		var values []json.RawMessage
+		if err := json.Unmarshal(dhcpOptions[1], &values); err != nil {
+			return fmt.Errorf("failed to parse logical switch port DHCP options set: %w", err)
+		}
+		if len(values) != 0 {
+			return fmt.Errorf("invalid logical switch port DHCP options set, expected empty set, got %d values", len(values))
+		}
+		s.DHCPOptionsUUID = ""
+	case "uuid":
+		if err := json.Unmarshal(dhcpOptions[1], &s.DHCPOptionsUUID); err != nil {
+			return fmt.Errorf(
+				"failed to parse logical switch port DHCP options UUID: %w",
+				err,
+			)
+		}
+	default:
+		return fmt.Errorf("invalid logic switch port DHCP options, expected 'set' or 'uuid', got %s", dhcpOptions[0])
+	}
+
+	return nil
+}
+
+func buildDHCPOptionEvidence(dhcpOptions []dhcp, ports []logicSwitchPort) []types.InspectionDHCPOptionEvidence {
+	portsByDHCPUUID := make(map[string][]string)
+	for _, port := range ports {
+		if port.DHCPOptionsUUID != "" {
+			portsByDHCPUUID[port.DHCPOptionsUUID] = append(portsByDHCPUUID[port.DHCPOptionsUUID], port.Name)
+		}
+	}
+
+	evidence := make([]types.InspectionDHCPOptionEvidence, len(dhcpOptions))
+	for i, option := range dhcpOptions {
+		evidence[i] = types.InspectionDHCPOptionEvidence{
+			UUID:                 option.UUID,
+			CIDR:                 option.CIDR,
+			ExternalIDs:          option.ExternalIDs,
+			Ports:                portsByDHCPUUID[option.UUID],
+			ClasslessStaticRoute: option.Options.ClasslessStaticRoutes,
+		}
+		slices.Sort(evidence[i].Ports)
+	}
+	slices.SortFunc(evidence, func(a, b types.InspectionDHCPOptionEvidence) int {
+		return strings.Compare(a.UUID, b.UUID)
+	})
+
+	return evidence
+}
+
+func collectDHCP(ctx context.Context, s state.State) ([]types.InspectionDHCPOptionEvidence, []types.InspectionCollectionError) {
+	var evidence []types.InspectionDHCPOptionEvidence
+	var errors []types.InspectionCollectionError
+
+	var dhcp dhcpOptionsResponse
+	rawDHCP, err := probeDHCPOptions(ctx, s)
+	if err != nil {
+		errors = append(errors, types.InspectionCollectionError{
+			FactGroup: "network",
+			Message:   err.Error(),
+		})
+	} else {
+		if err := json.Unmarshal([]byte(rawDHCP), &dhcp); err != nil {
+			errors = append(errors, types.InspectionCollectionError{
+				FactGroup: "network",
+				Message:   fmt.Sprintf("failed to parse DHCP options: %v", err),
+			})
+		}
+	}
+
+	var lsp logicSwitchPortResponse
+	rawLSP, err := probeLogicalSwitchPorts(ctx, s)
+	if err != nil {
+		errors = append(errors, types.InspectionCollectionError{
+			FactGroup: "network",
+			Message:   err.Error(),
+		})
+	} else {
+		if err := json.Unmarshal([]byte(rawLSP), &lsp); err != nil {
+			errors = append(errors, types.InspectionCollectionError{
+				FactGroup: "network",
+				Message:   fmt.Sprintf("failed to parse logical switch ports: %v", err),
+			})
+		}
+	}
+
+	evidence = buildDHCPOptionEvidence(dhcp.Data, lsp.Data)
+
+	return evidence, errors
+}
+
+func probeDHCPOptions(ctx context.Context, s state.State) (string, error) {
+	var args = []string{
+		"--timeout", "1",
+		"--format=json", "--columns=_uuid,cidr,options,external_ids",
+		"list", "dhcp_options",
+	}
+	return cmd.NBCtlCluster(ctx, s, 1, args...)
+}
+
+func probeLogicalSwitchPorts(ctx context.Context, s state.State) (string, error) {
+	var args = []string{
+		"--timeout", "1",
+		"--format=json", "--columns=name,dhcpv4_options",
+		"list", "logical_switch_port",
+	}
+
+	return cmd.NBCtlCluster(ctx, s, 1, args...)
+}

--- a/microovn/inspect/facts/network_test.go
+++ b/microovn/inspect/facts/network_test.go
@@ -1,0 +1,61 @@
+package facts
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestBuildDHCPOptionEvidence(t *testing.T) {
+	dhcpJSON := `{"data":[[["uuid","uuid-b"],"10.0.1.0/24",["map",[]],["map",[]]],[["uuid","uuid-a"],"10.0.0.0/24",["map",[["classless_static_route","{169.254.169.254/32,10.0.0.2, 0.0.0.0/0,10.0.0.1}"]]],["map",[["subnet_id","subnet-a"]]]]]}`
+	portsJSON := `{"data":[["port-b",["uuid","uuid-a"]],["unused",["set",[]]],["port-a",["uuid","uuid-a"]]]}`
+
+	var dhcpOptions dhcpOptionsResponse
+	if err := json.Unmarshal([]byte(dhcpJSON), &dhcpOptions); err != nil {
+		t.Fatalf("failed to decode DHCP options: %v", err)
+	}
+	var ports logicSwitchPortResponse
+	if err := json.Unmarshal([]byte(portsJSON), &ports); err != nil {
+		t.Fatalf("failed to decode logical switch ports: %v", err)
+	}
+
+	evidence := buildDHCPOptionEvidence(dhcpOptions.Data, ports.Data)
+	if len(evidence) != 2 || evidence[0].UUID != "uuid-a" || evidence[1].UUID != "uuid-b" {
+		t.Fatalf("evidence is not sorted by UUID: %+v", evidence)
+	}
+	if !slices.Equal(evidence[0].Ports, []string{"port-a", "port-b"}) {
+		t.Fatalf("ports = %v, want [port-a port-b]", evidence[0].Ports)
+	}
+	wantRoutes := []string{"169.254.169.254/32,10.0.0.2", "0.0.0.0/0,10.0.0.1"}
+	if !slices.Equal(evidence[0].ClasslessStaticRoute, wantRoutes) {
+		t.Fatalf("classless static routes = %v, want %v", evidence[0].ClasslessStaticRoute, wantRoutes)
+	}
+}
+
+func TestDHCPRejectsMalformedTaggedValues(t *testing.T) {
+	tests := map[string]string{
+		"UUID": `[["set",[]],"10.0.0.0/24",["map",[]],["map",[]]]`,
+		"map":  `[["uuid","uuid-a"],"10.0.0.0/24",["set",[]],["map",[]]]`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var option dhcp
+			if err := json.Unmarshal([]byte(input), &option); err == nil {
+				t.Fatalf("accepted malformed %s tagged value", name)
+			}
+		})
+	}
+}
+
+func TestLogicalSwitchPortRejectsNonEmptyOptionalSet(t *testing.T) {
+	var port logicSwitchPort
+	err := json.Unmarshal([]byte(`["port-a",["set",[["uuid","uuid-a"]]]]`), &port)
+	if err == nil {
+		t.Fatal("accepted a non-empty DHCP options set")
+	}
+	if !strings.Contains(err.Error(), "expected empty set") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/microovn/inspect/facts/snapshot.go
+++ b/microovn/inspect/facts/snapshot.go
@@ -1,0 +1,183 @@
+package facts
+
+import (
+	"bufio"
+	"cmp"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func CollectNodeSnapshot(
+	ctx context.Context,
+	name string,
+	address string,
+	serviceStates func(context.Context) (io.Reader, error),
+	environment func() (io.Reader, error),
+) types.InspectionNodeSnapshot {
+	snapshot := types.InspectionNodeSnapshot{NodeName: name, Address: address}
+
+	rawServices, err := serviceStates(ctx)
+	if err != nil {
+		snapshot.Errors = append(snapshot.Errors, types.InspectionCollectionError{
+			FactGroup: "daemons",
+			Message:   err.Error(),
+		})
+	} else {
+		daemons, err := parseServiceStates(rawServices)
+		if err != nil {
+			snapshot.Errors = append(snapshot.Errors, types.InspectionCollectionError{
+				FactGroup: "daemons",
+				Message:   err.Error(),
+			})
+		} else {
+			snapshot.Daemons = daemons
+		}
+	}
+
+	rawEnvironment, err := environment()
+	if err != nil {
+		snapshot.Errors = append(snapshot.Errors, types.InspectionCollectionError{
+			FactGroup: "environment",
+			Message:   err.Error(),
+		})
+	} else {
+		env, err := parseEnvironment(rawEnvironment)
+		if err != nil {
+			snapshot.Errors = append(snapshot.Errors, types.InspectionCollectionError{
+				FactGroup: "environment",
+				Message:   err.Error(),
+			})
+		} else {
+			snapshot.Environment = env
+		}
+	}
+
+	return snapshot
+}
+
+func parseEnvironment(reader io.Reader) ([]types.InspectionEnvironment, error) {
+	scanner := bufio.NewScanner(reader)
+	seen := map[string]struct{}{}
+	var entries []types.InspectionEnvironment
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if name == "" || value == "" {
+			continue
+		}
+
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+
+		value, err := strconv.Unquote(value)
+		if err != nil {
+			continue
+		}
+		hash := sha256.Sum256([]byte(value))
+
+		entries = append(entries, types.InspectionEnvironment{
+			Name: name,
+			Hash: hex.EncodeToString(hash[:]),
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read environment: %w", err)
+	}
+
+	slices.SortFunc(entries, func(a, b types.InspectionEnvironment) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return entries, nil
+}
+
+func parseServiceStates(reader io.Reader) ([]types.InspectionDaemonState, error) {
+	scanner := bufio.NewScanner(reader)
+
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("invalid 'snapctl services' output")
+	}
+
+	if header := strings.Join(strings.Fields(scanner.Text()), " "); header != "Service Startup Current Notes" {
+		return nil, fmt.Errorf("invalid header")
+	}
+
+	var entries []types.InspectionDaemonState
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		service, err := parseServiceState(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse service state: %w", err)
+		}
+		// Filter timer-activated service
+		if service.Name == "microovn.refresh-expiring-certs" {
+			continue
+		}
+		entries = append(entries, service)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read service states: %w", err)
+	}
+
+	slices.SortFunc(entries, func(a, b types.InspectionDaemonState) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return entries, nil
+}
+
+func parseServiceState(output string) (types.InspectionDaemonState, error) {
+	fields := strings.Fields(output)
+	if len(fields) < 3 {
+		return types.InspectionDaemonState{}, fmt.Errorf("invalid service state")
+	}
+
+	service := types.InspectionDaemonState{Name: fields[0]}
+	switch fields[1] {
+	case "enabled":
+		service.Enabled = true
+	case "disabled":
+		service.Enabled = false
+	default:
+		return service, fmt.Errorf("invalid startup state: %s", fields[1])
+	}
+
+	switch fields[2] {
+	case "active":
+		service.Active = true
+	case "inactive":
+		service.Active = false
+	default:
+		return service, fmt.Errorf("invalid current state: %s", fields[2])
+	}
+
+	return service, nil
+}

--- a/microovn/inspect/facts/snapshot_test.go
+++ b/microovn/inspect/facts/snapshot_test.go
@@ -1,0 +1,171 @@
+package facts
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func TestParseServiceStates(t *testing.T) {
+	input := strings.NewReader("Service Startup Current Notes\n" +
+		"microovn.switch disabled inactive -\n" +
+		"microovn.refresh-expiring-certs enabled inactive timer-activated\n" +
+		"microovn.daemon enabled active -\n")
+
+	got, err := parseServiceStates(input)
+	if err != nil {
+		t.Fatalf("parseServiceStates returned an error: %v", err)
+	}
+	want := []types.InspectionDaemonState{
+		{Name: "microovn.daemon", Active: true, Enabled: true},
+		{Name: "microovn.switch", Active: false, Enabled: false},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseServiceStates returned %#v, want %#v", got, want)
+	}
+
+	for _, test := range []struct {
+		name        string
+		row         string
+		wantEnabled bool
+		wantActive  bool
+	}{
+		{name: "enabled active", row: "service enabled active -", wantEnabled: true, wantActive: true},
+		{name: "enabled inactive", row: "service enabled inactive -", wantEnabled: true, wantActive: false},
+		{name: "disabled active", row: "service disabled active -", wantEnabled: false, wantActive: true},
+		{name: "disabled inactive", row: "service disabled inactive -", wantEnabled: false, wantActive: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			state, err := parseServiceState(test.row)
+			if err != nil {
+				t.Fatalf("parseServiceState(%q) returned an error: %v", test.row, err)
+			}
+			if state.Enabled != test.wantEnabled || state.Active != test.wantActive {
+				t.Fatalf("parseServiceState(%q) returned enabled=%t active=%t", test.row, state.Enabled, state.Active)
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		row  string
+	}{
+		{name: "missing state", row: "microovn.daemon enabled"},
+		{name: "unknown startup", row: "microovn.daemon automatic active -"},
+		{name: "unknown current", row: "microovn.daemon enabled activating -"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseServiceState(test.row)
+			if err == nil {
+				t.Fatalf("parseServiceState(%q) succeeded", test.row)
+			}
+		})
+	}
+}
+
+func TestParseEnvironment(t *testing.T) {
+	const alphaValue = "alpha-secret"
+	const zuluValue = "zulu-secret"
+	input := strings.NewReader("# generated environment\n" +
+		"\n" +
+		"ZULU=\"" + zuluValue + "\"\n" +
+		"malformed\n" +
+		"ALPHA=\"" + alphaValue + "\"\n" +
+		"ALPHA=\"duplicate\"\n" +
+		"UNQUOTED=value\n")
+
+	got, err := parseEnvironment(input)
+	if err != nil {
+		t.Fatalf("parseEnvironment returned an error: %v", err)
+	}
+	alphaHash := sha256.Sum256([]byte(alphaValue))
+	zuluHash := sha256.Sum256([]byte(zuluValue))
+	want := []types.InspectionEnvironment{
+		{Name: "ALPHA", Hash: hex.EncodeToString(alphaHash[:])},
+		{Name: "ZULU", Hash: hex.EncodeToString(zuluHash[:])},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseEnvironment returned %#v, want %#v", got, want)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("failed to marshal environment evidence: %v", err)
+	}
+	for _, rawValue := range []string{alphaValue, zuluValue, "duplicate", "value"} {
+		if strings.Contains(string(encoded), rawValue) {
+			t.Fatalf("serialized environment contains raw value %q", rawValue)
+		}
+	}
+}
+
+func TestCollectNodeSnapshotPreservesPartialResults(t *testing.T) {
+	validServices := func(context.Context) (io.Reader, error) {
+		return strings.NewReader("Service Startup Current Notes\n" +
+			"microovn.daemon enabled active -\n"), nil
+	}
+	validEnvironment := func() (io.Reader, error) {
+		return strings.NewReader("OVN_TEST=\"value\"\n"), nil
+	}
+
+	tests := []struct {
+		name             string
+		services         func(context.Context) (io.Reader, error)
+		environment      func() (io.Reader, error)
+		wantDaemons      int
+		wantEnvironments int
+		wantErrorGroup   string
+	}{
+		{
+			name: "service collection fails",
+			services: func(context.Context) (io.Reader, error) {
+				return nil, errors.New("services unavailable")
+			},
+			environment:      validEnvironment,
+			wantEnvironments: 1,
+			wantErrorGroup:   "daemons",
+		},
+		{
+			name:     "environment collection fails",
+			services: validServices,
+			environment: func() (io.Reader, error) {
+				return nil, errors.New("environment unavailable")
+			},
+			wantDaemons:    1,
+			wantErrorGroup: "environment",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := CollectNodeSnapshot(
+				context.Background(),
+				"node1",
+				"10.0.0.1",
+				test.services,
+				test.environment,
+			)
+
+			if snapshot.NodeName != "node1" || snapshot.Address != "10.0.0.1" {
+				t.Fatalf("snapshot identity = %q/%q", snapshot.NodeName, snapshot.Address)
+			}
+			if len(snapshot.Daemons) != test.wantDaemons {
+				t.Errorf("daemon count = %d, want %d", len(snapshot.Daemons), test.wantDaemons)
+			}
+			if len(snapshot.Environment) != test.wantEnvironments {
+				t.Errorf("environment count = %d, want %d", len(snapshot.Environment), test.wantEnvironments)
+			}
+			if len(snapshot.Errors) != 1 || snapshot.Errors[0].FactGroup != test.wantErrorGroup {
+				t.Fatalf("snapshot errors = %#v, want one %q error", snapshot.Errors, test.wantErrorGroup)
+			}
+		})
+	}
+}

--- a/microovn/inspect/inspect.go
+++ b/microovn/inspect/inspect.go
@@ -1,0 +1,242 @@
+package inspect
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/canonical/microcluster/v3/microcluster"
+	microTypes "github.com/canonical/microcluster/v3/microcluster/types"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+const collectionTimeout = 30 * time.Second
+
+type Input struct {
+	ExecutionContext      types.InspectionExecutionContext
+	Services              types.Services
+	Members               []microTypes.ClusterMember
+	Snapshots             map[string]types.InspectionNodeSnapshot
+	Schemas               map[string]types.InspectionSchemaEvidence
+	Communication         types.InspectionCommunicationEvidence
+	Network               types.InspectionNetworkProbe
+	CollectionErrors      []types.InspectionCollectionError
+	DesiredStateAvailable bool
+}
+
+type Check interface {
+	Name() string
+	Run(context.Context, Input) []types.InspectionResult
+}
+
+func DefaultChecks() []Check {
+	return []Check{
+		TopologyCheck{},
+		ServiceRuntimeCheck{},
+		DatabaseCheck{},
+		EnvironmentCheck{},
+		NetworkCheck{},
+	}
+}
+
+type CollectInputFunc func(context.Context, *microcluster.MicroCluster, microTypes.Client) (Input, error)
+
+type Dependencies struct {
+	Cluster      *microcluster.MicroCluster
+	Client       microTypes.Client
+	Checks       []Check
+	CollectInput CollectInputFunc
+}
+
+type memberClient struct {
+	member microTypes.ClusterMember
+	client microTypes.Client
+}
+
+func Orchestrate(ctx context.Context, deps Dependencies) (types.InspectionReport, error) {
+	ctx, cancel := context.WithTimeout(ctx, collectionTimeout)
+	defer cancel()
+
+	collect := deps.CollectInput
+	if collect == nil {
+		collect = collectInput
+	}
+
+	checks := deps.Checks
+	if checks == nil {
+		checks = DefaultChecks()
+	}
+
+	input, err := collect(ctx, deps.Cluster, deps.Client)
+	if err != nil {
+		return types.InspectionReport{}, err
+	}
+	return buildReport(ctx, time.Now().UTC(), input, checks), nil
+}
+
+func summarizeSchema(evidence types.InspectionSchemaEvidence) types.InspectionDatabaseStatus {
+	summary := types.InspectionDatabaseStatus{
+		ActiveSchemaVersion: evidence.ActiveVersion,
+		ExpectedMembers:     len(evidence.Members),
+	}
+
+	mismatch := false
+	incomplete := evidence.Database == "" ||
+		evidence.ActiveVersion == "" ||
+		evidence.ActiveError != ""
+
+	for _, member := range evidence.Members {
+		if member.Version != "" || member.Unsupported {
+			summary.RespondingMembers++
+		}
+
+		if member.Version != "" {
+			if evidence.ActiveVersion != "" &&
+				member.Version != evidence.ActiveVersion {
+				mismatch = true
+			}
+		}
+
+		if member.Version == "" || member.Unsupported || member.Error != "" {
+			incomplete = true
+		}
+	}
+
+	switch {
+	case mismatch:
+		summary.Status = types.InspectionStatusFail
+		summary.Message = "schema versions do not match"
+	case incomplete:
+		summary.Status = types.InspectionStatusUnknown
+		summary.Message = "schema evidence is incomplete"
+	default:
+		summary.Status = types.InspectionStatusPass
+	}
+
+	return summary
+}
+
+func summarizeCommunication(
+	evidence types.InspectionCommunicationEvidence,
+) types.InspectionCommunicationSummary {
+	summary := types.InspectionCommunicationSummary{
+		NBCfg: evidence.NBCfg,
+		SBCfg: evidence.SBCfg,
+	}
+
+	switch {
+	case evidence.NBReachable != nil && !*evidence.NBReachable:
+		summary.Status = types.InspectionStatusFail
+		summary.Message = "Northbound database is unreachable"
+
+	case evidence.SBReachable != nil && !*evidence.SBReachable:
+		summary.Status = types.InspectionStatusFail
+		summary.Message = "Southbound database is unreachable"
+
+	case evidence.NBReachable == nil ||
+		evidence.SBReachable == nil ||
+		evidence.Converged == nil:
+		summary.Status = types.InspectionStatusUnknown
+		summary.Message = evidence.CollectionError
+		if summary.Message == "" {
+			summary.Message = "database communication could not be determined"
+		}
+
+	case !*evidence.Converged:
+		summary.Status = types.InspectionStatusWarning
+		summary.Message = "Southbound database has not converged"
+
+	default:
+		summary.Status = types.InspectionStatusPass
+	}
+
+	return summary
+}
+
+func summarize(results []types.InspectionResult) types.InspectionSummary {
+	var summary types.InspectionSummary
+
+	for _, result := range results {
+		switch result.Status {
+		case types.InspectionStatusPass:
+			summary.Counts.Pass++
+		case types.InspectionStatusWarning:
+			summary.Counts.Warning++
+		case types.InspectionStatusFail:
+			summary.Counts.Fail++
+		case types.InspectionStatusUnknown:
+			summary.Counts.Unknown++
+		}
+	}
+
+	switch {
+	case summary.Counts.Fail > 0:
+		summary.Status = types.InspectionStatusFail
+	case summary.Counts.Unknown > 0:
+		summary.Status = types.InspectionStatusUnknown
+	case summary.Counts.Warning > 0:
+		summary.Status = types.InspectionStatusWarning
+	default:
+		summary.Status = types.InspectionStatusPass
+	}
+
+	return summary
+}
+
+func buildReport(ctx context.Context, now time.Time, input Input, checks []Check) types.InspectionReport {
+	var results []types.InspectionResult
+
+	if !input.ExecutionContext.Authoritative {
+		results = append(results, types.InspectionResult{
+			ID:       "execution-authority",
+			Category: "cluster",
+			Status:   types.InspectionStatusWarning,
+			Summary: fmt.Sprintf(
+				"Inspection on %s is not authoritative",
+				input.ExecutionContext.MemberRole,
+			),
+		})
+	}
+
+	for _, check := range checks {
+		results = append(results, check.Run(ctx, input)...)
+	}
+
+	for index := range results {
+		slices.SortFunc(
+			results[index].Details,
+			func(a, b types.InspectionDetail) int {
+				if result := cmp.Compare(a.Node, b.Node); result != 0 {
+					return result
+				}
+				return cmp.Compare(a.ID, b.ID)
+			},
+		)
+	}
+
+	databaseSummary := types.InspectionDatabaseSummary{
+		Northbound:    summarizeSchema(input.Schemas["nb"]),
+		Southbound:    summarizeSchema(input.Schemas["sb"]),
+		Communication: summarizeCommunication(input.Communication),
+	}
+	if !input.ExecutionContext.Authoritative {
+		databaseSummary.Northbound.Status = types.InspectionStatusUnknown
+		databaseSummary.Northbound.Message = "cluster schema health is unavailable from a non-voting member"
+		databaseSummary.Southbound.Status = types.InspectionStatusUnknown
+		databaseSummary.Southbound.Message = "cluster schema health is unavailable from a non-voting member"
+		databaseSummary.Communication.Status = types.InspectionStatusUnknown
+		databaseSummary.Communication.Message = "cluster database communication is unavailable from a non-voting member"
+	}
+
+	return types.InspectionReport{
+		SchemaVersion:    types.InspectionSchemaVersion,
+		Timestamp:        now.UTC(),
+		ExecutionContext: input.ExecutionContext,
+		Summary:          summarize(results),
+		DatabaseSummary:  databaseSummary,
+		Results:          results,
+	}
+}

--- a/microovn/inspect/inspect_test.go
+++ b/microovn/inspect/inspect_test.go
@@ -1,0 +1,170 @@
+package inspect
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+type fixedCheck struct {
+	results []types.InspectionResult
+}
+
+func (fixedCheck) Name() string {
+	return "fixed"
+}
+
+func (check fixedCheck) Run(context.Context, Input) []types.InspectionResult {
+	return check.results
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func TestSummarize(t *testing.T) {
+	results := []types.InspectionResult{
+		{Status: types.InspectionStatusPass},
+		{Status: types.InspectionStatusWarning},
+		{Status: types.InspectionStatusUnknown},
+		{Status: types.InspectionStatusFail},
+	}
+
+	summary := summarize(results)
+	if summary.Status != types.InspectionStatusFail {
+		t.Fatalf("summary status = %q, want %q", summary.Status, types.InspectionStatusFail)
+	}
+	if summary.Counts != (types.InspectionCounts{Pass: 1, Warning: 1, Fail: 1, Unknown: 1}) {
+		t.Fatalf("summary counts = %#v", summary.Counts)
+	}
+}
+
+func TestSummarizeSchema(t *testing.T) {
+	tests := []struct {
+		name       string
+		evidence   types.InspectionSchemaEvidence
+		wantStatus types.InspectionStatus
+		responding int
+	}{
+		{
+			name: "matching",
+			evidence: types.InspectionSchemaEvidence{
+				Database: "nb", ActiveVersion: "1.0",
+				Members: []types.InspectionSchemaMemberEvidence{{Node: "node1", Version: "1.0"}},
+			},
+			wantStatus: types.InspectionStatusPass,
+			responding: 1,
+		},
+		{
+			name: "mismatch",
+			evidence: types.InspectionSchemaEvidence{
+				Database: "nb", ActiveVersion: "1.0",
+				Members: []types.InspectionSchemaMemberEvidence{{Node: "node1", Version: "2.0"}},
+			},
+			wantStatus: types.InspectionStatusFail,
+			responding: 1,
+		},
+		{
+			name: "unsupported response",
+			evidence: types.InspectionSchemaEvidence{
+				Database: "nb", ActiveVersion: "1.0",
+				Members: []types.InspectionSchemaMemberEvidence{{Node: "node1", Unsupported: true}},
+			},
+			wantStatus: types.InspectionStatusUnknown,
+			responding: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			summary := summarizeSchema(test.evidence)
+			if summary.Status != test.wantStatus {
+				t.Fatalf("status = %q, want %q", summary.Status, test.wantStatus)
+			}
+			if summary.RespondingMembers != test.responding {
+				t.Fatalf("responding members = %d, want %d", summary.RespondingMembers, test.responding)
+			}
+		})
+	}
+}
+
+func TestSummarizeCommunication(t *testing.T) {
+	tests := []struct {
+		name       string
+		evidence   types.InspectionCommunicationEvidence
+		wantStatus types.InspectionStatus
+	}{
+		{
+			name: "converged",
+			evidence: types.InspectionCommunicationEvidence{
+				NBReachable: boolPointer(true), SBReachable: boolPointer(true), Converged: boolPointer(true),
+			},
+			wantStatus: types.InspectionStatusPass,
+		},
+		{
+			name: "not converged",
+			evidence: types.InspectionCommunicationEvidence{
+				NBReachable: boolPointer(true), SBReachable: boolPointer(true), Converged: boolPointer(false),
+			},
+			wantStatus: types.InspectionStatusWarning,
+		},
+		{
+			name: "unreachable",
+			evidence: types.InspectionCommunicationEvidence{
+				NBReachable: boolPointer(false),
+			},
+			wantStatus: types.InspectionStatusFail,
+		},
+		{name: "unknown", wantStatus: types.InspectionStatusUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := summarizeCommunication(test.evidence).Status; got != test.wantStatus {
+				t.Fatalf("status = %q, want %q", got, test.wantStatus)
+			}
+		})
+	}
+}
+
+func TestBuildReportNonAuthoritative(t *testing.T) {
+	timestamp := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.FixedZone("test", 3600))
+	input := Input{ExecutionContext: types.InspectionExecutionContext{
+		LocalNode: "node1", MemberRole: types.InspectionMemberRoleStandby, Scope: types.InspectionScopeLocal,
+	}}
+	check := fixedCheck{results: []types.InspectionResult{{
+		ID: "check", Status: types.InspectionStatusUnknown,
+		Details: []types.InspectionDetail{
+			{Node: "node2", ID: "b"},
+			{Node: "node1", ID: "b"},
+			{Node: "node1", ID: "a"},
+		},
+	}}}
+
+	report := buildReport(context.Background(), timestamp, input, []Check{check})
+	if len(report.Results) != 2 || report.Results[0].ID != "execution-authority" || report.Results[1].ID != "check" {
+		t.Fatalf("result order = %#v", report.Results)
+	}
+	details := report.Results[1].Details
+	if details[0].Node != "node1" || details[0].ID != "a" || details[1].Node != "node1" || details[1].ID != "b" || details[2].Node != "node2" {
+		t.Fatalf("detail order = %#v", details)
+	}
+	if report.Timestamp.Location() != time.UTC {
+		t.Fatalf("timestamp location = %v, want UTC", report.Timestamp.Location())
+	}
+	if report.Summary.Status != types.InspectionStatusUnknown || report.Summary.Counts.Warning != 1 {
+		t.Fatalf("summary = %#v", report.Summary)
+	}
+	if report.DatabaseSummary.Northbound.Status != types.InspectionStatusUnknown ||
+		report.DatabaseSummary.Southbound.Status != types.InspectionStatusUnknown ||
+		report.DatabaseSummary.Communication.Status != types.InspectionStatusUnknown {
+		t.Fatalf("database summary = %#v", report.DatabaseSummary)
+	}
+	if report.DatabaseSummary.Northbound.Message != "cluster schema health is unavailable from a non-voting member" ||
+		report.DatabaseSummary.Southbound.Message != "cluster schema health is unavailable from a non-voting member" ||
+		report.DatabaseSummary.Communication.Message != "cluster database communication is unavailable from a non-voting member" {
+		t.Fatalf("database summary messages = %#v", report.DatabaseSummary)
+	}
+}

--- a/microovn/inspect/network.go
+++ b/microovn/inspect/network.go
@@ -1,0 +1,129 @@
+package inspect
+
+import (
+	"context"
+	"net/netip"
+	"strings"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+const metadataIPv4CIDR = "169.254.169.254/32"
+
+type NetworkCheck struct{}
+
+func (NetworkCheck) Name() string {
+	return "network"
+}
+
+func (NetworkCheck) Run(_ context.Context, input Input) []types.InspectionResult {
+	if !input.ExecutionContext.Authoritative {
+		return []types.InspectionResult{nonAuthoritativeNetworkResult()}
+	}
+
+	var collectionError strings.Builder
+	for _, collectionErr := range input.CollectionErrors {
+		if collectionErr.FactGroup != "network" {
+			continue
+		}
+		if collectionError.Len() > 0 {
+			collectionError.WriteString("; ")
+		}
+		collectionError.WriteString(collectionErr.Message)
+	}
+	for _, collectionErr := range input.Network.CollectionErrors {
+		if collectionError.Len() > 0 {
+			collectionError.WriteString("; ")
+		}
+		collectionError.WriteString(collectionErr.Message)
+	}
+	if collectionError.Len() > 0 {
+		return []types.InspectionResult{{
+			ID:              "network",
+			Category:        "network",
+			Status:          types.InspectionStatusUnknown,
+			Summary:         "Network state is unavailable",
+			CollectionError: collectionError.String(),
+		}}
+	}
+
+	details, applicableOptions := networkDetails(input.Network)
+	if len(details) > 0 {
+		return []types.InspectionResult{{
+			ID:          "dhcp-metadata-route",
+			Category:    "network",
+			Status:      types.InspectionStatusFail,
+			Summary:     "DHCP options are missing a valid metadata route",
+			Details:     details,
+			Remediation: "Restore the metadata route in the affected DHCP options.",
+		}}
+	}
+
+	summary := "DHCP metadata routes are configured"
+	if applicableOptions == 0 {
+		summary = "No applicable DHCPv4 options were found"
+	}
+
+	return []types.InspectionResult{{
+		ID:       "network",
+		Category: "network",
+		Status:   types.InspectionStatusPass,
+		Summary:  summary,
+	}}
+}
+
+func networkDetails(network types.InspectionNetworkProbe) ([]types.InspectionDetail, int) {
+	var details []types.InspectionDetail
+	applicableOptions := 0
+
+	for _, option := range network.DHCPOptions {
+		prefix, err := netip.ParsePrefix(option.CIDR)
+		if len(option.Ports) == 0 || err != nil || !prefix.Addr().Is4() {
+			continue
+		}
+		applicableOptions++
+
+		if hasMetadataRoute(option.ClasslessStaticRoute) {
+			continue
+		}
+
+		details = append(details, types.InspectionDetail{
+			ID:      "dhcp-metadata-route",
+			Status:  types.InspectionStatusFail,
+			Summary: "DHCP options are missing a valid metadata route",
+			Data: map[string]string{
+				"uuid":  option.UUID,
+				"cidr":  option.CIDR,
+				"ports": strings.Join(option.Ports, ","),
+			},
+		})
+	}
+
+	return details, applicableOptions
+}
+
+func hasMetadataRoute(routes []string) bool {
+	for _, route := range routes {
+		destination, nextHop, found := strings.Cut(route, ",")
+		if !found || strings.TrimSpace(destination) != metadataIPv4CIDR {
+			continue
+		}
+
+		address, err := netip.ParseAddr(strings.TrimSpace(nextHop))
+		if err == nil && address.Is4() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func nonAuthoritativeNetworkResult() types.InspectionResult {
+	return types.InspectionResult{
+		ID:          "network",
+		Category:    "network",
+		Status:      types.InspectionStatusUnknown,
+		Summary:     "Network state cannot be determined from a non-voting member",
+		Remediation: "Run the inspection on a voting member.",
+	}
+}

--- a/microovn/inspect/network_test.go
+++ b/microovn/inspect/network_test.go
@@ -1,0 +1,161 @@
+package inspect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func TestNetworkCheck(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               Input
+		wantID              string
+		wantStatus          types.InspectionStatus
+		wantSummary         string
+		wantDetails         int
+		wantCollectionError string
+	}{
+		{
+			name:       "non-authoritative",
+			input:      Input{},
+			wantID:     "network",
+			wantStatus: types.InspectionStatusUnknown,
+		},
+		{
+			name: "collection errors",
+			input: networkInput(nil, []types.InspectionCollectionError{
+				{Message: "DHCP options unavailable"},
+				{Message: "logical switch ports unavailable"},
+			}),
+			wantID:              "network",
+			wantStatus:          types.InspectionStatusUnknown,
+			wantCollectionError: "DHCP options unavailable; logical switch ports unavailable",
+		},
+		{
+			name: "network endpoint error",
+			input: Input{
+				ExecutionContext: types.InspectionExecutionContext{Authoritative: true},
+				CollectionErrors: []types.InspectionCollectionError{
+					{FactGroup: "database", Message: "database unavailable"},
+					{FactGroup: "network", Message: "failed to get network probe"},
+				},
+			},
+			wantID:              "network",
+			wantStatus:          types.InspectionStatusUnknown,
+			wantCollectionError: "failed to get network probe",
+		},
+		{
+			name:        "no applicable options",
+			input:       networkInput(nil, nil),
+			wantID:      "network",
+			wantStatus:  types.InspectionStatusPass,
+			wantSummary: "No applicable DHCPv4 options were found",
+		},
+		{
+			name: "valid metadata route",
+			input: networkInput([]types.InspectionDHCPOptionEvidence{{
+				UUID:                 "dhcp-a",
+				CIDR:                 "10.0.0.0/24",
+				Ports:                []string{"port-a"},
+				ClasslessStaticRoute: []string{"0.0.0.0/0,10.0.0.1", "169.254.169.254/32,10.0.0.2"},
+			}}, nil),
+			wantID:      "network",
+			wantStatus:  types.InspectionStatusPass,
+			wantSummary: "DHCP metadata routes are configured",
+		},
+		{
+			name: "unreferenced and IPv6 options are ignored",
+			input: networkInput([]types.InspectionDHCPOptionEvidence{
+				{UUID: "dhcp-a", CIDR: "10.0.0.0/24"},
+				{UUID: "dhcp-b", CIDR: "fd42::/64", Ports: []string{"port-b"}},
+			}, nil),
+			wantID:      "network",
+			wantStatus:  types.InspectionStatusPass,
+			wantSummary: "No applicable DHCPv4 options were found",
+		},
+		{
+			name: "missing metadata route",
+			input: networkInput([]types.InspectionDHCPOptionEvidence{{
+				UUID:                 "dhcp-a",
+				CIDR:                 "10.0.0.0/24",
+				Ports:                []string{"port-a", "port-b"},
+				ClasslessStaticRoute: []string{"0.0.0.0/0,10.0.0.1"},
+			}}, nil),
+			wantID:      "dhcp-metadata-route",
+			wantStatus:  types.InspectionStatusFail,
+			wantDetails: 1,
+		},
+		{
+			name: "invalid metadata next hop",
+			input: networkInput([]types.InspectionDHCPOptionEvidence{{
+				UUID:                 "dhcp-a",
+				CIDR:                 "10.0.0.0/24",
+				Ports:                []string{"port-a"},
+				ClasslessStaticRoute: []string{"169.254.169.254/32,not-an-address"},
+			}}, nil),
+			wantID:      "dhcp-metadata-route",
+			wantStatus:  types.InspectionStatusFail,
+			wantDetails: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := (NetworkCheck{}).Run(context.Background(), test.input)
+			if len(results) != 1 {
+				t.Fatalf("result count = %d, want 1: %#v", len(results), results)
+			}
+
+			result := results[0]
+			if result.ID != test.wantID || result.Status != test.wantStatus {
+				t.Errorf("result = (%q, %q), want (%q, %q)", result.ID, result.Status, test.wantID, test.wantStatus)
+			}
+			if test.wantSummary != "" && result.Summary != test.wantSummary {
+				t.Errorf("summary = %q, want %q", result.Summary, test.wantSummary)
+			}
+			if len(result.Details) != test.wantDetails {
+				t.Errorf("detail count = %d, want %d", len(result.Details), test.wantDetails)
+			}
+			if result.CollectionError != test.wantCollectionError {
+				t.Errorf("collection error = %q, want %q", result.CollectionError, test.wantCollectionError)
+			}
+		})
+	}
+}
+
+func TestNetworkCheckResultContract(t *testing.T) {
+	if name := (NetworkCheck{}).Name(); name != "network" {
+		t.Fatalf("name = %q, want network", name)
+	}
+
+	input := networkInput([]types.InspectionDHCPOptionEvidence{{
+		UUID:  "dhcp-a",
+		CIDR:  "10.0.0.0/24",
+		Ports: []string{"port-a", "port-b"},
+	}}, nil)
+	result := (NetworkCheck{}).Run(context.Background(), input)[0]
+	if result.Category != "network" {
+		t.Errorf("category = %q, want network", result.Category)
+	}
+	if result.Remediation == "" {
+		t.Error("failure has no remediation")
+	}
+	if len(result.Details) != 1 {
+		t.Fatalf("detail count = %d, want 1", len(result.Details))
+	}
+	if result.Details[0].Data["uuid"] != "dhcp-a" || result.Details[0].Data["ports"] != "port-a,port-b" {
+		t.Errorf("detail data = %#v", result.Details[0].Data)
+	}
+}
+
+func networkInput(options []types.InspectionDHCPOptionEvidence, collectionErrors []types.InspectionCollectionError) Input {
+	return Input{
+		ExecutionContext: types.InspectionExecutionContext{Authoritative: true},
+		Network: types.InspectionNetworkProbe{
+			DHCPOptions:      options,
+			CollectionErrors: collectionErrors,
+		},
+	}
+}

--- a/microovn/inspect/render.go
+++ b/microovn/inspect/render.go
@@ -1,0 +1,156 @@
+package inspect
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func RenderJSON(w io.Writer, report types.InspectionReport) error {
+	return json.NewEncoder(w).Encode(report)
+}
+
+func RenderText(w io.Writer, report types.InspectionReport, verbose bool) error {
+	buf := bufio.NewWriter(w)
+
+	_, err := fmt.Fprintf(buf, "Execution: node=%s role=%s scope=%s authoritative=%t\n",
+		report.ExecutionContext.LocalNode,
+		report.ExecutionContext.MemberRole,
+		report.ExecutionContext.Scope,
+		report.ExecutionContext.Authoritative)
+	if err != nil {
+		return err
+	}
+
+	if err := renderDatabaseSummary(buf, report.DatabaseSummary); err != nil {
+		return err
+	}
+
+	for _, result := range report.Results {
+		if !verbose && result.Status == types.InspectionStatusPass {
+			continue
+		}
+
+		if _, err := fmt.Fprintf(buf, "[%s] %s/%s: %s\n", result.Status, result.Category, result.ID, result.Summary); err != nil {
+			return err
+		}
+
+		if !verbose {
+			continue
+		}
+
+		for _, detail := range result.Details {
+			label := detail.ID
+			if detail.Node != "" {
+				label = detail.Node + "/" + detail.ID
+			}
+			if _, err := fmt.Fprintf(buf, "  [%s] %s: %s\n", detail.Status, label, detail.Summary); err != nil {
+				return err
+			}
+
+			keys := make([]string, 0, len(detail.Data))
+			for key := range detail.Data {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				if _, err := fmt.Fprintf(buf, "    %s=%s\n", key, detail.Data[key]); err != nil {
+					return err
+				}
+			}
+		}
+
+		if result.CollectionError != "" {
+			if _, err := fmt.Fprintf(buf, "  Collection error: %s\n", result.CollectionError); err != nil {
+				return err
+			}
+		}
+		if result.Remediation != "" {
+			if _, err := fmt.Fprintf(buf, "  Remediation: %s\n", result.Remediation); err != nil {
+				return err
+			}
+		}
+	}
+
+	_, err = fmt.Fprintf(buf, "Summary: %s (pass=%d warning=%d fail=%d unknown=%d)\n",
+		report.Summary.Status,
+		report.Summary.Counts.Pass,
+		report.Summary.Counts.Warning,
+		report.Summary.Counts.Fail,
+		report.Summary.Counts.Unknown)
+	if err != nil {
+		return err
+	}
+
+	return buf.Flush()
+}
+
+func renderDatabaseSummary(w io.Writer, summary types.InspectionDatabaseSummary) error {
+	if _, err := fmt.Fprintln(w, "Database:"); err != nil {
+		return err
+	}
+
+	if err := renderDatabaseStatus(w, "Northbound", summary.Northbound); err != nil {
+		return err
+	}
+	if err := renderDatabaseStatus(w, "Southbound", summary.Southbound); err != nil {
+		return err
+	}
+
+	communication := summary.Communication
+	if _, err := fmt.Fprintf(w, "  Communication: %s", communication.Status); err != nil {
+		return err
+	}
+	if communication.NBCfg != nil {
+		if _, err := fmt.Fprintf(w, " nb_cfg=%d", *communication.NBCfg); err != nil {
+			return err
+		}
+	}
+	if communication.SBCfg != nil {
+		if _, err := fmt.Fprintf(w, " sb_cfg=%d", *communication.SBCfg); err != nil {
+			return err
+		}
+	}
+	if communication.Message != "" {
+		if _, err := fmt.Fprintf(w, " message=%q", communication.Message); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintln(w)
+	return err
+}
+
+func renderDatabaseStatus(w io.Writer, name string, status types.InspectionDatabaseStatus) error {
+	if _, err := fmt.Fprintf(w, "  %s: %s", name, status.Status); err != nil {
+		return err
+	}
+	if status.ActiveSchemaVersion != "" {
+		if _, err := fmt.Fprintf(w, " active_schema=%s", status.ActiveSchemaVersion); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, " responding=%d/%d", status.RespondingMembers, status.ExpectedMembers); err != nil {
+		return err
+	}
+	if status.Message != "" {
+		if _, err := fmt.Fprintf(w, " message=%q", status.Message); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintln(w)
+	return err
+}
+
+func ExitCode(report types.InspectionReport) int {
+	if report.Summary.Status == types.InspectionStatusPass {
+		return 0
+	}
+
+	return 1
+}

--- a/microovn/inspect/render_test.go
+++ b/microovn/inspect/render_test.go
@@ -1,0 +1,163 @@
+package inspect
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func testReport() types.InspectionReport {
+	nbCfg := int64(8)
+	sbCfg := int64(7)
+
+	return types.InspectionReport{
+		SchemaVersion: 1,
+		ExecutionContext: types.InspectionExecutionContext{
+			LocalNode:     "node1",
+			MemberRole:    "voter",
+			Authoritative: true,
+			Scope:         "cluster",
+		},
+		Summary: types.InspectionSummary{
+			Status: types.InspectionStatusWarning,
+			Counts: types.InspectionCounts{Pass: 1, Warning: 1},
+		},
+		DatabaseSummary: types.InspectionDatabaseSummary{
+			Northbound: types.InspectionDatabaseStatus{
+				Status: types.InspectionStatusPass, ActiveSchemaVersion: "7.3.0",
+				ExpectedMembers: 3, RespondingMembers: 3,
+			},
+			Southbound: types.InspectionDatabaseStatus{
+				Status: types.InspectionStatusWarning, ActiveSchemaVersion: "20.30.0",
+				ExpectedMembers: 3, RespondingMembers: 2, Message: "one peer unavailable",
+			},
+			Communication: types.InspectionCommunicationSummary{
+				Status: types.InspectionStatusWarning, NBCfg: &nbCfg, SBCfg: &sbCfg,
+				Message: "not converged",
+			},
+		},
+		Results: []types.InspectionResult{
+			{ID: "topology", Category: "cluster", Status: types.InspectionStatusPass, Summary: "Topology is healthy"},
+			{
+				ID: "environment", Category: "environment", Status: types.InspectionStatusWarning,
+				Summary: "Environment differs", Remediation: "Compare generated configuration",
+				Details: []types.InspectionDetail{{
+					Node: "node2", ID: "changed", Status: types.InspectionStatusWarning,
+					Summary: "Key differs", Data: map[string]string{"hash": "def", "key": "OVN_KEY"},
+				}},
+			},
+		},
+	}
+}
+
+func TestRenderTextConcise(t *testing.T) {
+	var output bytes.Buffer
+	report := testReport()
+
+	err := RenderText(&output, report, false)
+	if err != nil {
+		t.Fatalf("RenderText returned an error: %v", err)
+	}
+
+	want := "Execution: node=node1 role=voter scope=cluster authoritative=true\n" +
+		"Database:\n" +
+		"  Northbound: PASS active_schema=7.3.0 responding=3/3\n" +
+		"  Southbound: WARNING active_schema=20.30.0 responding=2/3 message=\"one peer unavailable\"\n" +
+		"  Communication: WARNING nb_cfg=8 sb_cfg=7 message=\"not converged\"\n" +
+		"[WARNING] environment/environment: Environment differs\n" +
+		"Summary: WARNING (pass=1 warning=1 fail=0 unknown=0)\n"
+	if output.String() != want {
+		t.Fatalf("unexpected concise output:\n%s\nwant:\n%s", output.String(), want)
+	}
+}
+
+func TestRenderTextVerboseDoesNotMutateReport(t *testing.T) {
+	var output bytes.Buffer
+	report := testReport()
+	before := testReport()
+
+	err := RenderText(&output, report, true)
+	if err != nil {
+		t.Fatalf("RenderText returned an error: %v", err)
+	}
+	if !reflect.DeepEqual(report, before) {
+		t.Fatal("RenderText mutated the report")
+	}
+
+	wantLines := []string{
+		"[PASS] cluster/topology: Topology is healthy",
+		"  [WARNING] node2/changed: Key differs",
+		"    hash=def",
+		"    key=OVN_KEY",
+		"  Remediation: Compare generated configuration",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(output.String(), line+"\n") {
+			t.Fatalf("verbose output does not contain %q:\n%s", line, output.String())
+		}
+	}
+}
+
+func TestRenderTextVerboseDetailWithoutNode(t *testing.T) {
+	var output bytes.Buffer
+	report := testReport()
+	report.Results[1].Details = []types.InspectionDetail{{
+		ID: "database-communication", Status: types.InspectionStatusPass,
+		Summary: "Database communication is healthy",
+	}}
+
+	err := RenderText(&output, report, true)
+	if err != nil {
+		t.Fatalf("RenderText returned an error: %v", err)
+	}
+	if !strings.Contains(output.String(), "  [PASS] database-communication: Database communication is healthy\n") {
+		t.Fatalf("verbose output has an invalid detail label:\n%s", output.String())
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	var output bytes.Buffer
+	report := testReport()
+
+	err := RenderJSON(&output, report)
+	if err != nil {
+		t.Fatalf("RenderJSON returned an error: %v", err)
+	}
+	if strings.Count(output.String(), "\n") != 1 || !strings.HasSuffix(output.String(), "\n") {
+		t.Fatalf("JSON output must have exactly one trailing newline: %q", output.String())
+	}
+
+	var decoded types.InspectionReport
+	err = json.Unmarshal(output.Bytes(), &decoded)
+	if err != nil {
+		t.Fatalf("JSON output is invalid: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, report) {
+		t.Fatalf("decoded report differs from input: %#v", decoded)
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		status types.InspectionStatus
+		want   int
+	}{
+		{status: types.InspectionStatusPass, want: 0},
+		{status: types.InspectionStatusWarning, want: 1},
+		{status: types.InspectionStatusFail, want: 1},
+		{status: types.InspectionStatusUnknown, want: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.status), func(t *testing.T) {
+			report := types.InspectionReport{Summary: types.InspectionSummary{Status: test.status}}
+			if got := ExitCode(report); got != test.want {
+				t.Fatalf("ExitCode returned %d, want %d", got, test.want)
+			}
+		})
+	}
+}

--- a/microovn/inspect/service_runtime.go
+++ b/microovn/inspect/service_runtime.go
@@ -1,0 +1,299 @@
+package inspect
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+type ServiceRuntimeCheck struct{}
+
+func (ServiceRuntimeCheck) Name() string {
+	return "service-runtime"
+}
+
+func (ServiceRuntimeCheck) Run(_ context.Context, input Input) []types.InspectionResult {
+	if !input.ExecutionContext.Authoritative {
+		return []types.InspectionResult{nonAuthoritativeServiceRuntimeResult(input)}
+	}
+
+	if !input.DesiredStateAvailable {
+		return []types.InspectionResult{desiredStateUnavailableServiceRuntimeResult(input)}
+	}
+
+	desired := buildDesiredServiceRuntime(input.Services)
+
+	var complete []serviceRuntimeSnapshot
+	var unavailable []types.InspectionDetail
+	var collectionErrors []string
+	memberErrors := forEachMemberSnapshot(input, "daemons", func(memberName string, snapshot types.InspectionNodeSnapshot) {
+		complete = append(complete, serviceRuntimeSnapshot{
+			node:     memberName,
+			services: canonicalServices(snapshot.Daemons),
+		})
+	})
+	for _, memberError := range memberErrors {
+		summary := "Service runtime snapshot is unavailable"
+		if memberError.snapshotFound {
+			summary = "Service runtime collection failed"
+		}
+		unavailable = append(unavailable, types.InspectionDetail{
+			Node:    memberError.node,
+			ID:      "service-runtime-unavailable",
+			Status:  types.InspectionStatusUnknown,
+			Summary: summary,
+		})
+		if memberError.err != "" {
+			collectionErrors = append(collectionErrors, fmt.Sprintf("%s: %s", memberError.node, memberError.err))
+		}
+	}
+
+	if len(input.Members) == 0 {
+		unavailable = append(unavailable, types.InspectionDetail{
+			ID:      "service-runtime-unavailable",
+			Status:  types.InspectionStatusUnknown,
+			Summary: "Expected cluster members are unavailable",
+		})
+	}
+
+	var failures []types.InspectionDetail
+	var warnings []types.InspectionDetail
+	for _, snapshot := range complete {
+		snapshotFailures, snapshotWarnings := serviceRuntimeDetails(snapshot, desired[snapshot.node])
+		failures = append(failures, snapshotFailures...)
+		warnings = append(warnings, snapshotWarnings...)
+	}
+
+	var results []types.InspectionResult
+	if len(failures) > 0 {
+		results = append(results, types.InspectionResult{
+			ID:          "service-runtime-failure",
+			Category:    "service-runtime",
+			Status:      types.InspectionStatusFail,
+			Summary:     "Required services are not active and enabled",
+			Details:     failures,
+			Remediation: "Ensure that required services are active and enabled on the affected members.",
+		})
+	}
+	if len(warnings) > 0 {
+		results = append(results, types.InspectionResult{
+			ID:          "service-runtime-drift",
+			Category:    "service-runtime",
+			Status:      types.InspectionStatusWarning,
+			Summary:     "Unexpected services are active or enabled",
+			Details:     warnings,
+			Remediation: "Disable unexpected services after confirming they are no longer needed.",
+		})
+	}
+	if len(unavailable) > 0 {
+		results = append(results, types.InspectionResult{
+			ID:              "service-runtime-coverage",
+			Category:        "service-runtime",
+			Status:          types.InspectionStatusUnknown,
+			Summary:         "Service runtime evidence is incomplete",
+			Details:         unavailable,
+			Remediation:     "Restore service runtime snapshot collection on unavailable members.",
+			CollectionError: strings.Join(collectionErrors, "; "),
+		})
+	}
+
+	if len(results) > 0 {
+		return results
+	}
+
+	return []types.InspectionResult{{
+		ID:       "service-runtime",
+		Category: "service-runtime",
+		Status:   types.InspectionStatusPass,
+		Summary:  "Service runtime is consistent across cluster members",
+		Details:  serviceDetails(complete),
+	}}
+}
+
+var roleDaemons = []struct {
+	role    types.SrvName
+	daemons []string
+}{
+	{role: types.SrvBgp, daemons: []string{"microovn.bird"}},
+	{role: types.SrvChassis, daemons: []string{"microovn.chassis"}},
+	{role: types.SrvCentral, daemons: []string{
+		"microovn.ovn-northd",
+		"microovn.ovn-ovsdb-server-nb",
+		"microovn.ovn-ovsdb-server-sb",
+	}},
+	{role: types.SrvSwitch, daemons: []string{"microovn.switch"}},
+}
+
+func nonAuthoritativeServiceRuntimeResult(input Input) types.InspectionResult {
+	result := types.InspectionResult{
+		ID:          "service-runtime",
+		Category:    "service-runtime",
+		Status:      types.InspectionStatusUnknown,
+		Summary:     "Service runtime convergence cannot be determined from a non-voting member",
+		Remediation: "Run the inspection on a voting member.",
+	}
+	if snapshot, found := input.Snapshots[input.ExecutionContext.LocalNode]; found {
+		if collectionError := daemonCollectionError(snapshot); collectionError != "" {
+			result.CollectionError = collectionError
+			return result
+		}
+		result.Details = []types.InspectionDetail{{
+			Node:    snapshot.NodeName,
+			ID:      "local-fingerprint",
+			Status:  types.InspectionStatusUnknown,
+			Summary: "Local service runtime fingerprint was collected",
+			Data:    serviceRuntimeData(snapshot.Daemons),
+		}}
+	} else {
+		result.CollectionError = snapshotCollectionError(input, input.ExecutionContext.LocalNode)
+	}
+
+	return result
+}
+
+func desiredStateUnavailableServiceRuntimeResult(input Input) types.InspectionResult {
+	return types.InspectionResult{
+		ID:              "service-runtime-coverage",
+		Category:        "service-runtime",
+		Status:          types.InspectionStatusUnknown,
+		Summary:         "Desired service state could not be determined",
+		Remediation:     "Restore desired service state collection and run the inspection again.",
+		CollectionError: desiredServiceCollectionError(input),
+	}
+}
+
+type serviceRuntimeSnapshot struct {
+	node     string
+	services []types.InspectionDaemonState
+}
+
+func serviceRuntimeData(daemons []types.InspectionDaemonState) map[string]string {
+	data := make(map[string]string, len(daemons))
+	for _, daemon := range daemons {
+		data[daemon.Name] = fmt.Sprintf("active=%t,enabled=%t", daemon.Active, daemon.Enabled)
+	}
+
+	return data
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func canonicalServices(services []types.InspectionDaemonState) []types.InspectionDaemonState {
+	canonical := slices.Clone(services)
+	slices.SortFunc(canonical, func(a, b types.InspectionDaemonState) int {
+		if result := cmp.Compare(a.Name, b.Name); result != 0 {
+			return result
+		}
+		if result := cmp.Compare(boolToInt(a.Active), boolToInt(b.Active)); result != 0 {
+			return result
+		}
+		return cmp.Compare(boolToInt(a.Enabled), boolToInt(b.Enabled))
+	})
+	return canonical
+}
+
+func daemonCollectionError(snapshot types.InspectionNodeSnapshot) string {
+	var errors []string
+	for _, collectionError := range snapshot.Errors {
+		if collectionError.FactGroup == "daemons" {
+			errors = append(errors, collectionError.Message)
+		}
+	}
+	slices.Sort(errors)
+	return strings.Join(errors, "; ")
+}
+
+func desiredServiceCollectionError(input Input) string {
+	var errors []string
+	for _, collectionError := range input.CollectionErrors {
+		if collectionError.FactGroup == "services" || collectionError.FactGroup == "member" {
+			errors = append(errors, collectionError.Message)
+		}
+	}
+	slices.Sort(errors)
+	return strings.Join(errors, "; ")
+}
+
+func buildDesiredServiceRuntime(services types.Services) map[string]map[types.SrvName]bool {
+	desired := make(map[string]map[types.SrvName]bool)
+
+	for _, service := range services {
+		if desired[service.Location] == nil {
+			desired[service.Location] = make(map[types.SrvName]bool)
+		}
+
+		desired[service.Location][service.Service] = true
+	}
+
+	return desired
+}
+
+func serviceDetails(snapshots []serviceRuntimeSnapshot) []types.InspectionDetail {
+	details := make([]types.InspectionDetail, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		details = append(details, types.InspectionDetail{
+			Node:    snapshot.node,
+			ID:      "service-runtime",
+			Status:  types.InspectionStatusPass,
+			Summary: "Service runtime evidence was collected",
+			Data:    serviceRuntimeData(snapshot.services),
+		})
+	}
+	return details
+}
+
+func serviceRuntimeDetails(snapshot serviceRuntimeSnapshot, desired map[types.SrvName]bool) ([]types.InspectionDetail, []types.InspectionDetail) {
+	observed := make(map[string]types.InspectionDaemonState, len(snapshot.services))
+	for _, daemon := range snapshot.services {
+		observed[daemon.Name] = daemon
+	}
+
+	var failures []types.InspectionDetail
+	var warnings []types.InspectionDetail
+	for _, entry := range roleDaemons {
+		for _, daemonName := range entry.daemons {
+			daemon, found := observed[daemonName]
+			if desired[entry.role] {
+				if !found || !daemon.Active || !daemon.Enabled {
+					failures = append(failures, types.InspectionDetail{
+						Node:    snapshot.node,
+						ID:      daemonName,
+						Status:  types.InspectionStatusFail,
+						Summary: fmt.Sprintf("Required service %q is not active and enabled", daemonName),
+						Data:    daemonStateData(daemon, found),
+					})
+				}
+				continue
+			}
+
+			if found && (daemon.Active || daemon.Enabled) {
+				warnings = append(warnings, types.InspectionDetail{
+					Node:    snapshot.node,
+					ID:      daemonName,
+					Status:  types.InspectionStatusWarning,
+					Summary: fmt.Sprintf("Unexpected service %q is active or enabled", daemonName),
+					Data:    daemonStateData(daemon, true),
+				})
+			}
+		}
+	}
+
+	return failures, warnings
+}
+
+func daemonStateData(daemon types.InspectionDaemonState, observed bool) map[string]string {
+	return map[string]string{
+		"observed": fmt.Sprintf("%t", observed),
+		"active":   fmt.Sprintf("%t", daemon.Active),
+		"enabled":  fmt.Sprintf("%t", daemon.Enabled),
+	}
+}

--- a/microovn/inspect/service_runtime_test.go
+++ b/microovn/inspect/service_runtime_test.go
@@ -1,0 +1,298 @@
+package inspect
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	microTypes "github.com/canonical/microcluster/v3/microcluster/types"
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func TestServiceRuntimeCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        Input
+		wantIDs      []string
+		wantStatuses []types.InspectionStatus
+	}{
+		{
+			name: "healthy desired services pass",
+			input: serviceRuntimeInput(
+				[]string{"node1"},
+				types.Services{
+					{Service: types.SrvSwitch, Location: "node1"},
+					{Service: types.SrvChassis, Location: "node1"},
+					{Service: types.SrvCentral, Location: "node1"},
+					{Service: types.SrvBgp, Location: "node1"},
+				},
+				map[string][]types.InspectionDaemonState{
+					"node1": healthyMappedDaemons(),
+				},
+			),
+			wantIDs:      []string{"service-runtime"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass},
+		},
+		{
+			name: "inactive desired daemon fails",
+			input: serviceRuntimeInput(
+				[]string{"node1"},
+				types.Services{{Service: types.SrvSwitch, Location: "node1"}},
+				map[string][]types.InspectionDaemonState{
+					"node1": {{Name: "microovn.switch", Enabled: true}},
+				},
+			),
+			wantIDs:      []string{"service-runtime-failure"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusFail},
+		},
+		{
+			name: "disabled desired daemon fails",
+			input: serviceRuntimeInput(
+				[]string{"node1"},
+				types.Services{{Service: types.SrvSwitch, Location: "node1"}},
+				map[string][]types.InspectionDaemonState{
+					"node1": {{Name: "microovn.switch", Active: true}},
+				},
+			),
+			wantIDs:      []string{"service-runtime-failure"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusFail},
+		},
+		{
+			name: "missing desired daemon fails",
+			input: serviceRuntimeInput(
+				[]string{"node1"},
+				types.Services{{Service: types.SrvSwitch, Location: "node1"}},
+				map[string][]types.InspectionDaemonState{"node1": nil},
+			),
+			wantIDs:      []string{"service-runtime-failure"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusFail},
+		},
+		{
+			name: "unexpected active daemon warns",
+			input: serviceRuntimeInput(
+				[]string{"node1"},
+				nil,
+				map[string][]types.InspectionDaemonState{
+					"node1": {{Name: "microovn.switch", Active: true}},
+				},
+			),
+			wantIDs:      []string{"service-runtime-drift"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusWarning},
+		},
+		{
+			name: "unexpected enabled daemon warns",
+			input: serviceRuntimeInput(
+				[]string{"node1"},
+				nil,
+				map[string][]types.InspectionDaemonState{
+					"node1": {{Name: "microovn.bird", Enabled: true}},
+				},
+			),
+			wantIDs:      []string{"service-runtime-drift"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusWarning},
+		},
+		{
+			name: "missing desired state is unknown",
+			input: func() Input {
+				input := serviceRuntimeInput(
+					[]string{"node1"}, nil,
+					map[string][]types.InspectionDaemonState{"node1": healthyMappedDaemons()},
+				)
+				input.DesiredStateAvailable = false
+				input.CollectionErrors = []types.InspectionCollectionError{{FactGroup: "services", Message: "services unavailable"}}
+				return input
+			}(),
+			wantIDs:      []string{"service-runtime-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+		{
+			name: "daemon collection error is unknown",
+			input: func() Input {
+				input := serviceRuntimeInput([]string{"node1"}, nil, map[string][]types.InspectionDaemonState{"node1": nil})
+				snapshot := input.Snapshots["node1"]
+				snapshot.Errors = []types.InspectionCollectionError{{FactGroup: "daemons", Message: "snap failed"}}
+				input.Snapshots["node1"] = snapshot
+				return input
+			}(),
+			wantIDs:      []string{"service-runtime-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+		{
+			name: "failure warning and unavailable peer coexist",
+			input: func() Input {
+				input := serviceRuntimeInput(
+					[]string{"node3", "node1", "node2"},
+					types.Services{{Service: types.SrvSwitch, Location: "node1"}},
+					map[string][]types.InspectionDaemonState{
+						"node1": {{Name: "microovn.switch", Enabled: true}},
+						"node2": {{Name: "microovn.bird", Active: true, Enabled: true}},
+					},
+				)
+				input.CollectionErrors = []types.InspectionCollectionError{{Node: "node3", FactGroup: "member", Message: "context deadline exceeded"}}
+				return input
+			}(),
+			wantIDs:      []string{"service-runtime-failure", "service-runtime-drift", "service-runtime-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusFail, types.InspectionStatusWarning, types.InspectionStatusUnknown},
+		},
+		{
+			name: "no member evidence is unknown",
+			input: Input{
+				ExecutionContext:      types.InspectionExecutionContext{Authoritative: true},
+				DesiredStateAvailable: true,
+			},
+			wantIDs:      []string{"service-runtime-coverage"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := (ServiceRuntimeCheck{}).Run(context.Background(), test.input)
+			if len(results) != len(test.wantIDs) {
+				t.Fatalf("result count = %d, want %d: %#v", len(results), len(test.wantIDs), results)
+			}
+			for index, result := range results {
+				if result.ID != test.wantIDs[index] || result.Status != test.wantStatuses[index] {
+					t.Errorf("result %d = (%q, %q), want (%q, %q)", index, result.ID, result.Status, test.wantIDs[index], test.wantStatuses[index])
+				}
+				if result.Category != "service-runtime" {
+					t.Errorf("result %d category = %q, want service-runtime", index, result.Category)
+				}
+			}
+		})
+	}
+}
+
+func TestServiceRuntimeCheckNonVoter(t *testing.T) {
+	input := Input{
+		ExecutionContext: types.InspectionExecutionContext{LocalNode: "node1"},
+		Snapshots: map[string]types.InspectionNodeSnapshot{
+			"node1": {
+				NodeName: "node1",
+				Daemons:  []types.InspectionDaemonState{{Name: "microovn.switch", Active: true, Enabled: true}},
+			},
+		},
+	}
+
+	result := (ServiceRuntimeCheck{}).Run(context.Background(), input)[0]
+	if result.Status != types.InspectionStatusUnknown || len(result.Details) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if got := result.Details[0].Data["microovn.switch"]; got != "active=true,enabled=true" {
+		t.Fatalf("local daemon state = %q", got)
+	}
+}
+
+func TestServiceRuntimeCheckResultContract(t *testing.T) {
+	if name := (ServiceRuntimeCheck{}).Name(); name != "service-runtime" {
+		t.Fatalf("name = %q, want service-runtime", name)
+	}
+
+	t.Run("missing snapshot preserves collection cause", func(t *testing.T) {
+		input := serviceRuntimeInput([]string{"node1"}, nil, nil)
+		input.CollectionErrors = []types.InspectionCollectionError{
+			{Node: "node1", FactGroup: "member", Message: "context deadline exceeded"},
+		}
+
+		result := (ServiceRuntimeCheck{}).Run(context.Background(), input)[0]
+		if result.CollectionError != "node1: context deadline exceeded" {
+			t.Fatalf("collection error = %q", result.CollectionError)
+		}
+		if result.Remediation == "" {
+			t.Fatal("unknown result has no remediation")
+		}
+	})
+
+	t.Run("daemon fact error is preserved", func(t *testing.T) {
+		input := serviceRuntimeInput([]string{"node1"}, nil, map[string][]types.InspectionDaemonState{"node1": nil})
+		snapshot := input.Snapshots["node1"]
+		snapshot.Errors = []types.InspectionCollectionError{{FactGroup: "daemons", Message: "snap failed"}}
+		input.Snapshots["node1"] = snapshot
+
+		result := (ServiceRuntimeCheck{}).Run(context.Background(), input)[0]
+		if result.CollectionError != "node1: snap failed" {
+			t.Fatalf("collection error = %q", result.CollectionError)
+		}
+	})
+
+	t.Run("baseline daemon and stopped undesired daemon pass", func(t *testing.T) {
+		input := serviceRuntimeInput(
+			[]string{"node1"}, nil,
+			map[string][]types.InspectionDaemonState{
+				"node1": {
+					{Name: "microovn.daemon", Active: true, Enabled: true},
+					{Name: "microovn.switch"},
+				},
+			},
+		)
+
+		result := (ServiceRuntimeCheck{}).Run(context.Background(), input)[0]
+		if result.Status != types.InspectionStatusPass || result.Remediation != "" {
+			t.Fatalf("result = %#v", result)
+		}
+	})
+}
+
+func TestServiceRuntimeCheckDeterministicDetails(t *testing.T) {
+	input := serviceRuntimeInput(
+		[]string{"node2", "node1"},
+		types.Services{
+			{Service: types.SrvCentral, Location: "node2"},
+			{Service: types.SrvCentral, Location: "node1"},
+		},
+		map[string][]types.InspectionDaemonState{
+			"node1": {{Name: "microovn.ovn-ovsdb-server-sb"}},
+			"node2": {{Name: "microovn.ovn-northd"}},
+		},
+	)
+
+	result := (ServiceRuntimeCheck{}).Run(context.Background(), input)[0]
+	var got []string
+	for _, detail := range result.Details {
+		got = append(got, detail.Node+":"+detail.ID)
+	}
+	want := []string{
+		"node1:microovn.ovn-northd",
+		"node1:microovn.ovn-ovsdb-server-nb",
+		"node1:microovn.ovn-ovsdb-server-sb",
+		"node2:microovn.ovn-northd",
+		"node2:microovn.ovn-ovsdb-server-nb",
+		"node2:microovn.ovn-ovsdb-server-sb",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("detail order = %#v, want %#v", got, want)
+	}
+}
+
+func serviceRuntimeInput(memberNames []string, services types.Services, daemons map[string][]types.InspectionDaemonState) Input {
+	members := make([]microTypes.ClusterMember, 0, len(memberNames))
+	for _, memberName := range memberNames {
+		members = append(members, microTypes.ClusterMember{
+			ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: memberName},
+		})
+	}
+
+	snapshots := make(map[string]types.InspectionNodeSnapshot, len(daemons))
+	for node, states := range daemons {
+		snapshots[node] = types.InspectionNodeSnapshot{NodeName: node, Daemons: states}
+	}
+
+	return Input{
+		ExecutionContext:      types.InspectionExecutionContext{Authoritative: true},
+		Services:              services,
+		Members:               members,
+		Snapshots:             snapshots,
+		DesiredStateAvailable: true,
+	}
+}
+
+func healthyMappedDaemons() []types.InspectionDaemonState {
+	return []types.InspectionDaemonState{
+		{Name: "microovn.switch", Active: true, Enabled: true},
+		{Name: "microovn.chassis", Active: true, Enabled: true},
+		{Name: "microovn.ovn-northd", Active: true, Enabled: true},
+		{Name: "microovn.ovn-ovsdb-server-nb", Active: true, Enabled: true},
+		{Name: "microovn.ovn-ovsdb-server-sb", Active: true, Enabled: true},
+		{Name: "microovn.bird", Active: true, Enabled: true},
+	}
+}

--- a/microovn/inspect/topology.go
+++ b/microovn/inspect/topology.go
@@ -1,0 +1,103 @@
+package inspect
+
+import (
+	"context"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+type TopologyCheck struct{}
+
+func (TopologyCheck) Name() string {
+	return "topology"
+}
+
+func (TopologyCheck) Run(_ context.Context, input Input) []types.InspectionResult {
+	if !input.ExecutionContext.Authoritative {
+		return []types.InspectionResult{nonAuthoritativeTopologyResult()}
+	}
+	if !input.DesiredStateAvailable {
+		return []types.InspectionResult{desiredStateUnavailableTopologyResult(input)}
+	}
+
+	centralCnt := 0
+	for _, service := range input.Services {
+		if service.Service == types.SrvCentral {
+			centralCnt++
+		}
+	}
+
+	if centralCnt == 0 {
+		return []types.InspectionResult{{
+			ID:       "central-topology",
+			Category: "cluster",
+			Status:   types.InspectionStatusPass,
+			Summary:  "Central topology is not managed by this deployment",
+		}}
+	}
+
+	var results []types.InspectionResult
+	if centralCnt%2 == 0 {
+		results = append(results, types.InspectionResult{
+			ID:          "central-count-even",
+			Category:    "cluster",
+			Status:      types.InspectionStatusWarning,
+			Summary:     "Central topology has an even number of central services",
+			Remediation: "Configure an odd number of central services, with at least three for fault tolerance.",
+		})
+	}
+	if centralCnt < 3 {
+		results = append(results, types.InspectionResult{
+			ID:          "central-count-few",
+			Category:    "cluster",
+			Status:      types.InspectionStatusWarning,
+			Summary:     "Central topology has fewer than three central services",
+			Remediation: "Configure at least three central services to tolerate a node failure.",
+		})
+	}
+	if len(results) == 0 {
+		results = append(results, types.InspectionResult{
+			ID:       "central-topology",
+			Category: "cluster",
+			Status:   types.InspectionStatusPass,
+			Summary:  "Central topology is healthy",
+		})
+	}
+	return results
+}
+
+func nonAuthoritativeTopologyResult() types.InspectionResult {
+	return types.InspectionResult{
+		ID:          "central-topology",
+		Category:    "cluster",
+		Status:      types.InspectionStatusUnknown,
+		Summary:     "Central topology is unavailable from a non-voting member",
+		Remediation: "Run the inspection on a voting member.",
+	}
+}
+
+func desiredStateUnavailableTopologyResult(input Input) types.InspectionResult {
+	result := types.InspectionResult{
+		ID:       "central-topology",
+		Category: "cluster",
+		Status:   types.InspectionStatusUnknown,
+		Summary:  "Central topology could not be determined",
+	}
+
+	for _, collectionErr := range input.CollectionErrors {
+		if collectionErr.FactGroup == "services" {
+			result.CollectionError = collectionErr.Message
+			break
+		}
+	}
+	if result.CollectionError == "" {
+		for _, collectionErr := range input.CollectionErrors {
+			if collectionErr.FactGroup == "member" {
+				result.CollectionError = collectionErr.Message
+				break
+			}
+		}
+	}
+
+	return result
+}

--- a/microovn/inspect/topology_test.go
+++ b/microovn/inspect/topology_test.go
@@ -1,0 +1,127 @@
+package inspect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canonical/microovn/microovn/api/types"
+)
+
+func TestTopologyCheck(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               Input
+		wantIDs             []string
+		wantStatuses        []types.InspectionStatus
+		wantCollectionError string
+	}{
+		{
+			name: "non-authoritative",
+			input: Input{ExecutionContext: types.InspectionExecutionContext{
+				MemberRole: types.InspectionMemberRoleStandby,
+			}},
+			wantIDs:      []string{"central-topology"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusUnknown},
+		},
+		{
+			name: "desired state unavailable prefers services error",
+			input: Input{
+				ExecutionContext:      types.InspectionExecutionContext{Authoritative: true},
+				DesiredStateAvailable: false,
+				CollectionErrors: []types.InspectionCollectionError{
+					{FactGroup: "member", Message: "member error"},
+					{FactGroup: "services", Message: "services error"},
+				},
+			},
+			wantIDs:             []string{"central-topology"},
+			wantStatuses:        []types.InspectionStatus{types.InspectionStatusUnknown},
+			wantCollectionError: "services error",
+		},
+		{
+			name:         "zero central is exempt",
+			input:        topologyInput(0),
+			wantIDs:      []string{"central-topology"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass},
+		},
+		{
+			name:         "one central is too few",
+			input:        topologyInput(1),
+			wantIDs:      []string{"central-count-few"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusWarning},
+		},
+		{
+			name:         "two centrals are even and too few",
+			input:        topologyInput(2),
+			wantIDs:      []string{"central-count-even", "central-count-few"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusWarning, types.InspectionStatusWarning},
+		},
+		{
+			name:         "three centrals are healthy",
+			input:        topologyInput(3),
+			wantIDs:      []string{"central-topology"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusPass},
+		},
+		{
+			name:         "four centrals are even",
+			input:        topologyInput(4),
+			wantIDs:      []string{"central-count-even"},
+			wantStatuses: []types.InspectionStatus{types.InspectionStatusWarning},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := (TopologyCheck{}).Run(context.Background(), test.input)
+			if len(results) != len(test.wantIDs) {
+				t.Fatalf("result count = %d, want %d: %#v", len(results), len(test.wantIDs), results)
+			}
+
+			for index, result := range results {
+				if result.ID != test.wantIDs[index] || result.Status != test.wantStatuses[index] {
+					t.Errorf("result %d = (%q, %q), want (%q, %q)", index, result.ID, result.Status, test.wantIDs[index], test.wantStatuses[index])
+				}
+			}
+			if results[0].CollectionError != test.wantCollectionError {
+				t.Errorf("collection error = %q, want %q", results[0].CollectionError, test.wantCollectionError)
+			}
+		})
+	}
+}
+
+func TestTopologyCheckResultContract(t *testing.T) {
+	if name := (TopologyCheck{}).Name(); name != "topology" {
+		t.Fatalf("name = %q, want topology", name)
+	}
+
+	results := (TopologyCheck{}).Run(context.Background(), topologyInput(2))
+	for _, result := range results {
+		if result.Category != "cluster" {
+			t.Errorf("category = %q, want cluster", result.Category)
+		}
+		if result.Remediation == "" {
+			t.Errorf("result %q has no remediation", result.ID)
+		}
+	}
+
+	input := Input{
+		ExecutionContext: types.InspectionExecutionContext{Authoritative: true},
+		CollectionErrors: []types.InspectionCollectionError{{FactGroup: "member", Message: "member error"}},
+	}
+	results = (TopologyCheck{}).Run(context.Background(), input)
+	if results[0].CollectionError != "member error" {
+		t.Fatalf("collection error = %q, want member error", results[0].CollectionError)
+	}
+}
+
+func topologyInput(centralCount int) Input {
+	services := make(types.Services, centralCount)
+	for index := range services {
+		services[index] = types.Service{Service: types.SrvCentral}
+	}
+
+	return Input{
+		ExecutionContext:      types.InspectionExecutionContext{Authoritative: true},
+		Services:              services,
+		DesiredStateAvailable: true,
+	}
+}

--- a/microovn/ovn/cluster/cluster.go
+++ b/microovn/ovn/cluster/cluster.go
@@ -27,6 +27,7 @@ func UpdateOvnListenConfig(ctx context.Context, s state.State) error {
 	_, err = ovnCmd.NBCtl(
 		ctx,
 		s,
+		ovnCmd.DefaultDBConnectWait,
 		"--no-leader-only",
 		fmt.Sprintf("--db=%s", nbDB.SocketURL),
 		"set-connection",
@@ -39,6 +40,7 @@ func UpdateOvnListenConfig(ctx context.Context, s state.State) error {
 	_, err = ovnCmd.SBCtl(
 		ctx,
 		s,
+		ovnCmd.DefaultDBConnectWait,
 		"--no-leader-only",
 		fmt.Sprintf("--db=%s", sbDB.SocketURL),
 		"set-connection",

--- a/microovn/ovn/cmd/commands.go
+++ b/microovn/ovn/cmd/commands.go
@@ -19,6 +19,7 @@ import (
 
 // DefaultDBConnectWait - Default time to wait for connection to ovsdb.
 const DefaultDBConnectWait = 30
+const DefaultDBStateWait = 10
 
 // OvsdbConnected       - String representing the connected state.
 const OvsdbConnected = "connected"
@@ -118,7 +119,7 @@ func WaitForDBState(ctx context.Context, _ state.State, db *OvsdbSpec, dbState s
 //
 // Argument `db` is usually either `OVN_Northbound` or `OVN_Southbound`
 // Argument 'port' is usually '6641' for the Northbound database and `6642` for the Southbound database
-func WaitForClusterDBState(ctx context.Context, s state.State, db string, dbState string, port int) error {
+func WaitForClusterDBState(ctx context.Context, s state.State, db string, dbState string, port int, connectTimeout int) error {
 	var err error
 	nbIPs, err := environment.CentralIps(ctx, s)
 	if err != nil {
@@ -133,7 +134,8 @@ func WaitForClusterDBState(ctx context.Context, s state.State, db string, dbStat
 		_, err = shared.RunCommandContext(
 			ctx,
 			filepath.Join(paths.Wrappers(), "ovsdb-client"),
-			"-t", "10",
+			"-t",
+			strconv.Itoa(connectTimeout),
 			"wait",
 			socketURL,
 			db,
@@ -204,10 +206,10 @@ func ovnDBCtl(ctx context.Context, s state.State, dbType OvsdbType, timeout int,
 // is a list of arguments that are passed directly to the shell command.
 // Before the command is executed, this function ensures that underlying
 // database is in connected state. If the database does not reach "connected"
-// state before timeout (defined in DefaultDBConnectWait), an error is returned
+// state before timeout (defined in connectTimeout), an error is returned
 // and command is not executed.
-func NBCtl(ctx context.Context, s state.State, args ...string) (string, error) {
-	return ovnDBCtl(ctx, s, OvsdbTypeNBLocal, DefaultDBConnectWait, args...)
+func NBCtl(ctx context.Context, s state.State, connectTimeout int, args ...string) (string, error) {
+	return ovnDBCtl(ctx, s, OvsdbTypeNBLocal, connectTimeout, args...)
 }
 
 // NBCtlCluster is a convenience function for execution of ovn-nbctl command
@@ -217,13 +219,13 @@ func NBCtl(ctx context.Context, s state.State, args ...string) (string, error) {
 // is a list of arguments that are passed directly to the shell command.
 //
 // Warning: This function will fail if local MicroOVN node is not bootstrapped.
-func NBCtlCluster(ctx context.Context, s state.State, args ...string) (string, error) {
+func NBCtlCluster(ctx context.Context, s state.State, connectTimeout int, args ...string) (string, error) {
 	if !slices.Contains(args, "--timeout") && !slices.Contains(args, "-t") {
 		args = append([]string{"--timeout", "30"}, args...)
 	}
 
 	var err error
-	err = WaitForClusterDBState(ctx, s, "OVN_Northbound", OvsdbConnected, 6641)
+	err = WaitForClusterDBState(ctx, s, "OVN_Northbound", OvsdbConnected, 6641, connectTimeout)
 	if err != nil {
 		return "", errors.New("failed to connect to OVN Northbound database cluster")
 	}
@@ -239,6 +241,35 @@ func NBCtlCluster(ctx context.Context, s state.State, args ...string) (string, e
 	return "", err
 }
 
+// SBCtlCluster is a convenience function for execution of ovn-sbctl command
+// against OVN SB cluster endpoints. The command is re-tried up to 3 times.
+// If command arguments do not specify timeout (-t or
+// --timeout), a default of 30s will be added automatically. Parameter "args"
+// is a list of arguments that are passed directly to the shell command.
+//
+// Warning: This function will fail if local MicroOVN node is not bootstrapped.
+func SBCtlCluster(ctx context.Context, s state.State, connectTimeout int, args ...string) (string, error) {
+	if !slices.Contains(args, "--timeout") && !slices.Contains(args, "-t") {
+		args = append([]string{"--timeout", "30"}, args...)
+	}
+
+	var err error
+	err = WaitForClusterDBState(ctx, s, "OVN_Southbound", OvsdbConnected, 6642, connectTimeout)
+	if err != nil {
+		return "", errors.New("failed to connect to OVN Southbound database cluster")
+	}
+
+	// try command 3 times if it is failing
+	for attempts := 0; attempts < 3; attempts++ {
+		var output string
+		output, err = shared.RunCommandContext(ctx, filepath.Join(paths.Wrappers(), "ovn-sbctl"), args...)
+		if err == nil {
+			return output, nil
+		}
+	}
+	return "", err
+}
+
 // SBCtl is a convenience function for execution of ovn-sbctl command against
 // OVN NB local unix socket. The command is re-tried up to 3 times.
 // If command arguments do not specify timeout (-t or
@@ -246,10 +277,10 @@ func NBCtlCluster(ctx context.Context, s state.State, args ...string) (string, e
 // a list of arguments that are passed directly to the shell command. Before the
 // command is executed, this function ensures that underlying database is in
 // connected state. If the database does not reach "connected" state before
-// timeout (defined in DefaultDBConnectWait), an error is returned and command
+// timeout (defined in connectTimeout), an error is returned and command
 // is not executed.
-func SBCtl(ctx context.Context, s state.State, args ...string) (string, error) {
-	return ovnDBCtl(ctx, s, OvsdbTypeSBLocal, DefaultDBConnectWait, args...)
+func SBCtl(ctx context.Context, s state.State, connectTimeout int, args ...string) (string, error) {
+	return ovnDBCtl(ctx, s, OvsdbTypeSBLocal, connectTimeout, args...)
 }
 
 // VSCtl is a convenience function for execution of ovs-vsctl command which is

--- a/microovn/ovn/environment/environment.go
+++ b/microovn/ovn/environment/environment.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"os"
@@ -229,6 +230,22 @@ func GenerateEnvironment(ctx context.Context, s state.State) error {
 	}
 
 	return nil
+}
+
+// ReadEnvironment reads the OVN environment file and returns an io.Reader for its contents.
+func ReadEnvironment() (io.Reader, error) {
+	file, err := os.Open(paths.OvnEnvFile())
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.NewReader(string(data)), nil
 }
 
 // CreatePaths creates the required directories for OVN.

--- a/microovn/snap/snap.go
+++ b/microovn/snap/snap.go
@@ -4,6 +4,8 @@ package snap
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/canonical/lxd/shared"
 )
@@ -77,4 +79,18 @@ func Reload(ctx context.Context, service string) error {
 	}
 
 	return nil
+}
+
+// Services - returns the raw list of snap services and their states as reported by "snapctl services" command.
+func Services(ctx context.Context) (io.Reader, error) {
+	args := []string{
+		"services",
+	}
+
+	output, err := shared.RunCommandContext(ctx, "snapctl", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.NewReader(output), nil
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -1,0 +1,1 @@
+test_helper/bats/inspect.bats

--- a/tests/test_helper/bats/inspect.bats
+++ b/tests/test_helper/bats/inspect.bats
@@ -1,0 +1,243 @@
+# This is a bash shell fragment -*- bash -*-
+
+load "${ABS_TOP_TEST_DIRNAME}test_helper/setup_teardown/$(basename "${BATS_TEST_FILENAME//.bats/.bash}")"
+
+setup() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-support/load.bash
+    load ${ABS_TOP_TEST_DIRNAME}../.bats/bats-assert/load.bash
+
+    assert [ -n "$TEST_CONTAINERS" ]
+
+    read -r INSPECT_LEADER _ _ INSPECT_NON_VOTER <<< "$TEST_CONTAINERS"
+    INSPECT_ENV_CONTAINER=""
+    INSPECT_UNEXPECTED_SERVICE_CONTAINER=""
+    INSPECT_STOPPED_CONTAINER=""
+    INSPECT_STOPPED_SERVICE_CONTAINER=""
+    INSPECT_NETWORK_SWITCH=""
+    INSPECT_NETWORK_DHCP_UUID=""
+}
+
+teardown() {
+    if [ -n "$INSPECT_ENV_CONTAINER" ]; then
+        lxc_exec "$INSPECT_ENV_CONTAINER" \
+            "sed -i '/^MICROOVN_INSPECT_TEST=/d' /var/snap/microovn/common/data/env/ovn.env" || true
+    fi
+
+    if [ -n "$INSPECT_STOPPED_SERVICE_CONTAINER" ]; then
+        lxc_exec "$INSPECT_STOPPED_SERVICE_CONTAINER" \
+            "snap start microovn.switch" || true
+    fi
+
+    if [ -n "$INSPECT_UNEXPECTED_SERVICE_CONTAINER" ]; then
+        lxc_exec "$INSPECT_UNEXPECTED_SERVICE_CONTAINER" \
+            "microovn enable switch" || true
+    fi
+
+    if [ -n "$INSPECT_STOPPED_CONTAINER" ]; then
+        lxc start "$INSPECT_STOPPED_CONTAINER" || true
+        wait_containers_ready "$INSPECT_STOPPED_CONTAINER" || true
+    fi
+
+    if [ -n "$INSPECT_NETWORK_SWITCH" ]; then
+        lxc_exec "$INSPECT_LEADER" \
+            "microovn.ovn-nbctl --if-exists ls-del '$INSPECT_NETWORK_SWITCH'" || true
+    fi
+
+    if [ -n "$INSPECT_NETWORK_DHCP_UUID" ]; then
+        lxc_exec "$INSPECT_LEADER" \
+            "microovn.ovn-nbctl --if-exists destroy DHCP_Options '$INSPECT_NETWORK_DHCP_UUID'" || true
+    fi
+
+    print_diagnostics_on_failure $TEST_CONTAINERS
+}
+
+@test "Inspect reports a healthy deployment without changing status" {
+    local status_before
+    local status_after
+    status_before=$(lxc_exec "$INSPECT_LEADER" "microovn status")
+
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect"
+    assert_success
+    assert_output -p "Execution: node=$INSPECT_LEADER role=voter scope=cluster authoritative=true"
+    assert_output -p "Database:"
+    assert_output -p "Summary: PASS"
+
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect --verbose"
+    assert_success
+    assert_output -p "[PASS]"
+
+    status_after=$(lxc_exec "$INSPECT_LEADER" "microovn status")
+    assert_equal "$status_after" "$status_before"
+}
+
+@test "Inspect produces a complete versioned JSON report" {
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn inspect --format=json | jq -e '
+            .schema_version == 1 and
+            .execution_context.authoritative == true and
+            .execution_context.scope == \"cluster\" and
+            .summary.status == \"PASS\" and
+            .summary.counts.warning == 0 and
+            .summary.counts.fail == 0 and
+            .summary.counts.unknown == 0 and
+            (.database_summary | has(\"northbound\") and has(\"southbound\") and has(\"communication\")) and
+            (.results | length > 0)
+        '"
+    assert_success
+}
+
+@test "Inspect rejects incompatible output flags with exit code 2" {
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect --verbose --format=json"
+    assert_equal "$status" 2
+    assert_output -p "--verbose and --format=json cannot be used together"
+}
+
+@test "Inspect reports a stopped configured service" {
+    INSPECT_STOPPED_SERVICE_CONTAINER="$INSPECT_NON_VOTER"
+    run lxc_exec "$INSPECT_STOPPED_SERVICE_CONTAINER" "snap stop microovn.switch"
+    assert_success
+
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect --format=json"
+    assert_equal "$status" 1
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn inspect --format=json | jq -e '
+            .summary.status == \"FAIL\" and
+            .summary.counts.fail > 0 and
+            any(.results[]; .status == \"FAIL\") and
+            (tostring | contains(\"$INSPECT_STOPPED_SERVICE_CONTAINER\")) and
+            (tostring | contains(\"microovn.switch\"))
+        '"
+    assert_success
+}
+
+@test "Inspect warns about an unexpected active service" {
+    INSPECT_UNEXPECTED_SERVICE_CONTAINER="$INSPECT_LEADER"
+    run lxc_exec "$INSPECT_UNEXPECTED_SERVICE_CONTAINER" "microovn disable switch"
+    assert_success
+    run lxc_exec "$INSPECT_UNEXPECTED_SERVICE_CONTAINER" "snap start microovn.switch"
+    assert_success
+
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect --format=json"
+    assert_equal "$status" 1
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn inspect --format=json | jq -e '
+            .summary.counts.warning > 0 and
+            any(.results[]; .id == \"service-runtime-drift\" and .status == \"WARNING\") and
+            (tostring | contains(\"$INSPECT_UNEXPECTED_SERVICE_CONTAINER\")) and
+            (tostring | contains(\"microovn.switch\"))
+        '"
+    assert_success
+}
+
+@test "Inspect reports environment drift without exposing values" {
+    local marker="inspect-value-must-not-be-reported"
+    INSPECT_ENV_CONTAINER="$INSPECT_NON_VOTER"
+    lxc_exec "$INSPECT_ENV_CONTAINER" \
+        "printf '%s\n' 'MICROOVN_INSPECT_TEST=\"$marker\"' >> /var/snap/microovn/common/data/env/ovn.env"
+
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect --format=json"
+    assert_equal "$status" 1
+    refute_output -p "$marker"
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn inspect --format=json | jq -e '
+            .summary.counts.warning > 0 and
+            any(.results[]; .category == \"environment\" and .status == \"WARNING\") and
+            (tostring | contains(\"MICROOVN_INSPECT_TEST\")) and
+            (tostring | contains(\"$marker\") | not)
+        '"
+    assert_success
+}
+
+@test "Inspect reports and recovers from a missing DHCP metadata route" {
+    INSPECT_NETWORK_SWITCH="inspect-metadata-route"
+    local port="inspect-metadata-port"
+    local cidr="10.250.0.0/24"
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn.ovn-nbctl ls-add '$INSPECT_NETWORK_SWITCH'"
+    assert_success
+
+    INSPECT_NETWORK_DHCP_UUID=$(lxc_exec "$INSPECT_LEADER" \
+        "microovn.ovn-nbctl create DHCP_Options cidr='$cidr'")
+    assert [ -n "$INSPECT_NETWORK_DHCP_UUID" ]
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn.ovn-nbctl lsp-add '$INSPECT_NETWORK_SWITCH' '$port'"
+    assert_success
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn.ovn-nbctl set Logical_Switch_Port '$port' dhcpv4_options='$INSPECT_NETWORK_DHCP_UUID'"
+    assert_success
+
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect --format=json"
+    assert_equal "$status" 1
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn inspect --format=json | jq -e '
+            .summary.status == \"FAIL\" and
+            any(.results[];
+                .id == \"dhcp-metadata-route\" and
+                .status == \"FAIL\" and
+                any(.details[];
+                    .data.uuid == \"$INSPECT_NETWORK_DHCP_UUID\" and
+                    .data.cidr == \"$cidr\" and
+                    .data.ports == \"$port\"
+                )
+            )
+        '"
+    assert_success
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn.ovn-nbctl set DHCP_Options '$INSPECT_NETWORK_DHCP_UUID' options:classless_static_route='{169.254.169.254/32,10.250.0.2}'"
+    assert_success
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn inspect --format=json | jq -e '
+            .summary.status == \"PASS\" and
+            any(.results[];
+                .id == \"network\" and
+                .status == \"PASS\" and
+                .summary == \"DHCP metadata routes are configured\"
+            )
+        '"
+    assert_success
+}
+
+@test "Inspect preserves partial results when a peer is unavailable" {
+    INSPECT_STOPPED_CONTAINER="$INSPECT_NON_VOTER"
+    run lxc stop --force "$INSPECT_STOPPED_CONTAINER"
+    assert_success
+
+    run lxc_exec "$INSPECT_LEADER" "microovn inspect --format=json"
+    assert_equal "$status" 1
+
+    run lxc_exec "$INSPECT_LEADER" \
+        "microovn inspect --format=json | jq -e '
+            .summary.status == \"UNKNOWN\" and
+            .summary.counts.pass > 0 and
+            .summary.counts.unknown > 0 and
+            any(.results[]; .status == \"UNKNOWN\") and
+            (tostring | contains(\"$INSPECT_STOPPED_CONTAINER\"))
+        '"
+    assert_success
+}
+
+@test "Inspect degrades to local evidence on a non-voting member" {
+    run lxc_exec "$INSPECT_NON_VOTER" "microovn inspect --format=json"
+    assert_equal "$status" 1
+
+    run lxc_exec "$INSPECT_NON_VOTER" \
+        "microovn inspect --format=json | jq -e '
+            .execution_context.authoritative == false and
+            .execution_context.scope == \"local\" and
+            (.execution_context.member_role == \"standby\" or .execution_context.member_role == \"spare\") and
+            .summary.status != \"PASS\" and
+            .summary.counts.unknown > 0
+        '"
+    assert_success
+}

--- a/tests/test_helper/setup_teardown/inspect.bash
+++ b/tests/test_helper/setup_teardown/inspect.bash
@@ -1,0 +1,18 @@
+setup_file() {
+    load test_helper/common.bash
+    load test_helper/lxd.bash
+    load test_helper/microovn.bash
+
+    TEST_CONTAINERS=$(container_names "$BATS_TEST_FILENAME" 4)
+    export TEST_CONTAINERS
+    launch_containers $TEST_CONTAINERS
+    wait_containers_ready $TEST_CONTAINERS
+    install_microovn "$MICROOVN_SNAP_PATH" $TEST_CONTAINERS
+    bootstrap_cluster $TEST_CONTAINERS
+}
+
+teardown_file() {
+    print_diagnostics_on_failure $TEST_CONTAINERS
+    collect_coverage $TEST_CONTAINERS
+    delete_containers $TEST_CONTAINERS
+}


### PR DESCRIPTION
# Overview

* Adds `microovn inspect`, a read-only command for inspecting the health of a MicroOVN deployment.
* Collects cluster topology, service runtime state, OVN database communication and convergence, and environment consistency.
* Supports human-readable and JSON output, including partial results when members or data sources are unavailable.
* Produces authoritative cluster-wide results on voting members. Standby and spare members provide local observations and mark checks requiring cluster authority as `UNKNOWN`.
* Reports `PASS`, `WARNING`, `FAIL`, and `UNKNOWN` results without exposing raw environment values.

## QA

The command was validated with:

* Go unit and race tests
* Functional `inspect.bats` suite

## Demo

### Single node cluster

<img width="2406" height="1147" alt="image" src="https://github.com/user-attachments/assets/137431e8-d424-4f63-b9fa-e1cad2c149c9" />

### Triple node cluster

<img width="2406" height="1629" alt="image" src="https://github.com/user-attachments/assets/833a9aa6-1ade-425b-bb12-7f5e81583d03" />
